### PR TITLE
add mpich to Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,23 +54,23 @@ WORKDIR /src
 ENV BLAS -L${MKLROOT}/lib/intel64 -lmkl_rt -fopenmp -lpthread -limf -lsvml -ldl
 ENV CPPFLAGS -I${MKLROOT}/include
 
-# RUN wget -nv https://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz \
-#     && tar xvzf mpich-3.3.tar.gz \
-#     && cd mpich-3.3 \
-#     && ./configure \
-#     && make -j4 \
-#     && make install \
-#     && make clean \
-#     && cd .. && rm -Rf mpich-3.3
-# # defaults to installing in /usr/local
+RUN wget -nv https://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz \
+    && tar xvzf mpich-3.3.tar.gz \
+    && cd mpich-3.3 \
+    && ./configure \
+    && make -j4 \
+    && make install \
+    && make clean \
+    && cd .. && rm -Rf mpich-3.3
+# defaults to installing in /usr/local
 
-# # mpi4py / mpicc can't handle -ax=knl
-# ENV CFLAGS -O3 -g -fPIC -std=gnu99 -pthread
-# RUN git clone https://github.com/mpi4py/mpi4py.git \
-#          && (cd mpi4py \
-#          && python setup.py build \
-#          && python setup.py install) \
-#          && rm -Rf mpi4py
+# mpi4py / mpicc can't handle -ax=knl
+ENV CFLAGS -O3 -g -fPIC -std=gnu99 -pthread
+RUN git clone https://github.com/mpi4py/mpi4py.git \
+         && (cd mpi4py \
+         && python setup.py build \
+         && python setup.py install) \
+         && rm -Rf mpi4py
 
 # Pip installs -- built from source
 RUN pip --no-cache-dir install fitsio
@@ -87,7 +87,8 @@ RUN echo 'PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh
 
 RUN rm /root/.profile
 
-RUN DEBIAN_FRONTEND=noninteractive \
+RUN apt -y update && apt install -y apt-utils \
+ && DEBIAN_FRONTEND=noninteractive \
     apt install -y --no-install-recommends \
     make \
     git \
@@ -105,6 +106,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     libgsl-dev \
     libcfitsio-dev \
     libcfitsio-bin \
+    imagemagick \
     # python3 \
     # python3-dev \
     # python3-pip \
@@ -117,7 +119,6 @@ COPY --from=builder /usr/local /usr/local
 COPY --from=builder /opt/conda /opt/conda
 
 RUN conda update --no-deps certifi
-# Pip installs
 RUN for x in \
     setuptools \
     wheel \
@@ -219,8 +220,3 @@ RUN echo "export PS1='[container] \\u@\\h:\\w$ '" >> $HOME/.bashrc \
   # Make astropy cache files readable!?!!
   && chmod -R a+rwX $HOME/.astropy
   
-# Curses upon you, astropy
-RUN wget -O /opt/conda/lib/python3.7/site-packages/astropy/utils/iers/data/Leap_Second.dat \
-    https://raw.githubusercontent.com/astropy/astropy/master/astropy/utils/iers/data/Leap_Second.dat \
-    && rm $HOME/.wget-hsts
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -140,9 +140,7 @@ RUN for x in \
     emcee \
     configobj \
     sqlalchemy \
-    corner \
-    ppxf \
-    # fnnls \
+    fnnls \
     ; do pip3 install $x; done \
     && rm -Rf /root/.cache/pip
 
@@ -179,13 +177,13 @@ RUN for package in \
     desisim \
     specsim \
     redrock; do \
-      git clone https://github.com/desihub/$package; \
-      # cd $package; \
-      # python setup.py develop;
+      git clone https://github.com/desihub/$package \
+      && cd $package \
+      && python setup.py install; \
     done
 
-ENV PATH /src/desiutil/bin:/src/desimodel/bin:/src/desitarget/bin:/src/desispec/bin:/src/desisim/bin:/src/redrock/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV PYTHONPATH /src/desiutil/py:/src/desimodel/py:/src/desitarget/py:/src/desispec/py:/src/desisim/py:/src/redrock/py
+# ENV PATH /src/desiutil/bin:/src/desimodel/bin:/src/desitarget/bin:/src/desispec/bin:/src/desisim/bin:/src/redrock/bin:$PATH
+# ENV PYTHONPATH /src/desiutil/py:/src/desimodel/py:/src/desitarget/py:/src/desispec/py:/src/desisim/py:/src/redrock/py
 
 # RUN git clone https://github.com/desihub/redrock-templates
 # ENV RR_TEMPLATE_DIR /src/redrock-templates
@@ -196,7 +194,8 @@ ENV PYTHONPATH /src/desiutil/py:/src/desimodel/py:/src/desitarget/py:/src/desisp
 
 ENV DESIMODEL /src/desimodel
 
-RUN cd $DESIMODEL \
+RUN mkdir $DESIMODEL \
+    && cd $DESIMODEL \
     && svn export https://desi.lbl.gov/svn/code/desimodel/trunk/data
 
 RUN mkdir /homedir && chmod 777 /homedir

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,34 +1,122 @@
-FROM ubuntu:20.04
+FROM registry.services.nersc.gov/nersc/intel_cxx_fort_mpi_mkl_devel as builder
 
-RUN apt -y update && apt install -y apt-utils && echo 1
+RUN apt -y update && apt install -y apt-utils && echo 3
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt install -y --no-install-recommends \
     make \
-    gcc \
-    gfortran \
     git \
-    subversion \
     file \
+    patch \
+    # pkg-config \
+    wget \
+    subversion \
     emacs \
     less \
-    patch \
-    pkg-config \
-    wget \
+    # gcc \
+    zlib1g-dev \
+    # gfortran \
+    libbz2-dev \
+    libgsl-dev \
     libcfitsio-dev \
     libcfitsio-bin \
-    libbz2-dev \
-    python3 \
-    python3-dev \
-    python3-pip \
-    python3-pil \
-    python3-tk \
+    # python3 \
+    # python3-dev \
+    # python3-pip \
+    # python3-pil \
+    # python3-tk \
     # # Remove APT files
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Python related stuff
-RUN echo "../site-packages" > /usr/local/lib/python3.8/dist-packages/site-packages.pth
+RUN echo 'PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh
 
+RUN wget -nv https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && \
+    bash miniconda.sh -b -p /opt/conda && \
+    conda config --add channels intel && \
+    conda config --set always_yes yes && \
+    conda update conda && \
+    conda install python=3.8 pip numpy scipy && \
+    conda clean -a -y
+
+ENV CC icc
+ENV CXX icpc
+ENV LDSHARED icc -shared
+ENV CFLAGS -O3 -g -fPIC -std=gnu99 -pthread -x=haswell -ax=knl
+ENV ARCH_FLAGS ""
+
+ENV PYTHON python3
+ENV PYTHON_CONFIG python3-config
+ENV PYTHON_SCRIPT "/usr/bin/env python3"
+
+RUN mkdir -p /src
+WORKDIR /src
+
+ENV BLAS -L${MKLROOT}/lib/intel64 -lmkl_rt -fopenmp -lpthread -limf -lsvml -ldl
+ENV CPPFLAGS -I${MKLROOT}/include
+
+# RUN wget -nv https://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz \
+#     && tar xvzf mpich-3.3.tar.gz \
+#     && cd mpich-3.3 \
+#     && ./configure \
+#     && make -j4 \
+#     && make install \
+#     && make clean \
+#     && cd .. && rm -Rf mpich-3.3
+# # defaults to installing in /usr/local
+
+# # mpi4py / mpicc can't handle -ax=knl
+# ENV CFLAGS -O3 -g -fPIC -std=gnu99 -pthread
+# RUN git clone https://github.com/mpi4py/mpi4py.git \
+#          && (cd mpi4py \
+#          && python setup.py build \
+#          && python setup.py install) \
+#          && rm -Rf mpi4py
+
+# Pip installs -- built from source
+RUN pip --no-cache-dir install fitsio
+
+RUN /sbin/ldconfig
+
+######## Stage 2 ########
+FROM registry.services.nersc.gov/nersc/intel_cxx_fort_mpi_mkl_runtime
+
+ENV PYTHON python3
+ENV PYTHON_CONFIG python3-config
+ENV PYTHON_SCRIPT "/usr/bin/env python3"
+RUN echo 'PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh
+
+RUN rm /root/.profile
+
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt install -y --no-install-recommends \
+    make \
+    git \
+    file \
+    pkg-config \
+    wget \
+    # gcc \
+    zlib1g-dev \
+    # gfortran \
+    subversion \
+    emacs \
+    less \
+    patch \
+    libbz2-dev \
+    libgsl-dev \
+    libcfitsio-dev \
+    libcfitsio-bin \
+    # python3 \
+    # python3-dev \
+    # python3-pip \
+    # python3-pil \
+    # python3-tk \
+    # # Remove APT files
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /opt/conda /opt/conda
+
+RUN conda update --no-deps certifi
 # Pip installs
 RUN for x in \
     setuptools \
@@ -37,7 +125,6 @@ RUN for x in \
     scipy \
     matplotlib \
     astropy \
-    fitsio \
     numba \
     pyyaml \
     requests \
@@ -54,15 +141,14 @@ RUN for x in \
     sqlalchemy \
     corner \
     ppxf \
-    fnnls \
+    # fnnls \
     ; do pip3 install $x; done \
     && rm -Rf /root/.cache/pip
 
-# python = python3
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
-RUN mkdir -p /src
 WORKDIR /src
+
+# python = python3
+RUN ln -s $(which python3) /usr/bin/python
 
 # # install FSPS
 # RUN git clone https://github.com/cconroy20/fsps
@@ -78,6 +164,10 @@ WORKDIR /src
 
 RUN git clone https://github.com/dkirkby/speclite.git
 RUN cd speclite \
+    && python setup.py install
+
+RUN git clone https://github.com/mikeiovine/fast-nnls
+RUN cd fast-nnls \
     && python setup.py install
 
 RUN for package in \
@@ -113,13 +203,24 @@ ENV HOME /homedir
 
 # set prompt and default shell
 SHELL ["/bin/bash", "-c"]
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["/bin/bash"]
 
 RUN echo "export PS1='[container] \\u@\\h:\\w$ '" >> $HOME/.bashrc \
   # Create config files in $HOME
   && python -c "import astropy" \
-  && chmod -R a+rwX $HOME/.astropy \
   && python -c "import matplotlib.font_manager as fm; f = fm.FontManager()" \
-  && ipython -c "print('hello')"
+  && ipython -c "print('hello')" \
+  # Download astropy site locations and USNO sky model
+  && python -c "from astropy.coordinates import EarthLocation; EarthLocation._get_site_registry(force_download=True)" \
+  && python -c "from astropy.coordinates import EarthLocation, SkyCoord, AltAz; from astropy.time import Time; print(EarthLocation.of_site('ctio')); print(SkyCoord(180.,-45.,unit='deg').transform_to(AltAz(obstime=Time(56806.0, format='mjd'), location=EarthLocation.of_site('ctio'))))" \
+  # Download astropy IERS leap-second list
+  && python -c "from astropy.time import Time; Time.now()" \
+  # Make astropy cache files readable!?!!
+  && chmod -R a+rwX $HOME/.astropy
   
-ENTRYPOINT ["/bin/bash", "-c"]
-CMD ["/bin/bash"]
+# Curses upon you, astropy
+RUN wget -O /opt/conda/lib/python3.7/site-packages/astropy/utils/iers/data/Leap_Second.dat \
+    https://raw.githubusercontent.com/astropy/astropy/master/astropy/utils/iers/data/Leap_Second.dat \
+    && rm $HOME/.wget-hsts
+

--- a/docker/README
+++ b/docker/README
@@ -2,7 +2,7 @@ Build a Docker container for fastspecfit.
 =========================================
 
 ```
-docker build . -t desihub/fastspecfit
+./build.sh 
 docker push desihub/fastspecfit:latest
 
 docker tag desihub/fastspecfit:latest desihub/fastspecfit:v0.0.1

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# Tunnel to NERSC's license server
+ssh -fN intel-license
+
+if [ "$(uname)" = "Darwin" ]; then
+    # Mac OSX
+    LOCAL_IP=$(ipconfig getifaddr $(route get nersc.gov | grep 'interface:' | awk '{print $NF}'))
+else
+    # Linux
+    LOCAL_IP=$(ip route ls | tail -n 1 | awk '{print $NF}')
+fi
+
+docker build  --add-host intel.licenses.nersc.gov:${LOCAL_IP} -t desihub/fastspecfit:latest .
+


### PR DESCRIPTION
Adds `mpich` (and other goodies) with the NERSC intel compilers so we can use MPI. 

Steals liberally from a Dockerfile originally written by @dstndstn for the imaging surveys.