### PR TITLE
development and another major refactor to get MPI going

### DIFF
--- a/bin/fastspecfit-desi
+++ b/bin/fastspecfit-desi
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-"""fastspecfit for DESI - serial / multiprocessing entry point.
+"""fastspecfit for DESI.
+
+Use --mpi for the MPI version.
 
 """
 import os

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -1,0 +1,504 @@
+#!/usr/bin/env python
+"""
+MPI wrapper for fastspecfit
+
+To process all tiles in the SV1 exposure list do--
+  mpi-fastspecfit
+
+To process one specific tile and night:
+  mpi-fastspecfit --tile 80605 --night 20201215
+
+"""
+import pdb # for debuggin
+
+import sys, os, glob, time, subprocess, re
+import argparse
+import numpy as np
+from redrock.utils import nersc_login_node
+from fastspecfit.external import desi
+
+from desiutil.log import get_logger
+log = get_logger()
+
+def weighted_partition(weights, n):
+    '''
+    Partition `weights` into `n` groups with approximately same sum(weights)
+
+    Args:
+        weights: array-like weights
+        n: number of groups
+
+    Returns (groups, groupweights):
+        * groups: list of lists of indices of weights for each group
+        * groupweights: sum of weights assigned to each group
+
+    Notes:
+        similar to `redrock.utils.distribute_work`, which was written
+            independently; these have not yet been compared.
+        within each group, the weights are sorted largest to smallest
+    '''
+    sumweights = np.zeros(n, dtype=float)
+    groups = list()
+    for i in range(n):
+        groups.append(list())
+    weights = np.asarray(weights)
+    for i in np.argsort(-weights):
+        j = np.argmin(sumweights)
+        groups[j].append(i)
+        sumweights[j] += weights[i]
+
+    return groups, np.array([np.sum(x) for x in sumweights])
+
+def spectra2outfiles(specfiles, inprefix, outprefix, ext=None, outdir=None):
+    '''
+    Convert a list of input spectra files to a list of output files
+
+    Args:
+        specfiles: list of spectra filepaths
+        inprefix: input file prefix, e.g. 'spectra' or 'spPlate'
+        outprefix: output file prefix, e.g. 'zbest' or 'redrock'
+
+    Options:
+        ext: output extension, e.g. 'h5' (default same as input extension)
+        outdir: output directory (default same as each input file directory)
+
+    Returns:
+        array of output filepaths
+
+    Example::
+
+        spectra2outfiles(['/a/b/blat-1.fits', '/c/d/blat-2.fits'], \
+            inprefix='blat', outprefix='foo', ext='h5', outdir='/tmp/')
+        --> array(['/tmp/foo-1.h5', '/tmp/foo-2.h5'], dtype='<U13')
+    '''
+    outfiles = list()
+    for specfile in specfiles:
+        dirname, basename = os.path.split(specfile)
+        outfile = basename.replace(inprefix, outprefix)
+        if ext is not None:
+            outfile = outfile.replace('.fits', '.'+ext)
+        if outdir is None:
+            outfiles.append(os.path.join(dirname, outfile))
+        else:
+            outfiles.append(os.path.join(outdir, outfile))
+
+    return np.array(outfiles)
+
+def find_specfiles(reduxdir, outdir=None, prefix='zbest', avoiddir=None, photfit=False):
+    '''
+    Returns list of spectra files under reduxdir that need to be processed.
+
+    Options:
+        reduxdir: path to redux directory
+        outdir: path to output directory [default to same dir as inputs]
+        prefix: filename prefix, e.g. 'spectra'
+        avoiddir: subdirectory *not* to traverse
+
+    Returns:
+        list of spectra files to process
+
+    Notes:
+        Recursively walks directories under `reduxdir` looking for files
+        matching prefix*.fits.  Looks for redrock*.h5 and zbest*.fits in the
+        same directory as each spectra file, or in outdir if specified.
+    
+    '''
+    if avoiddir is not None:
+        avoiddir = os.path.normpath(avoiddir)
+
+    specfiles = list()
+    for dirpath, dirnames, filenames in os.walk(reduxdir, followlinks=True, topdown=True):
+        if os.path.normpath(dirpath) == avoiddir:
+            while True:
+                try:
+                    dirnames.pop()
+                except IndexError:
+                    break
+
+        for filename in filenames:
+            if filename.startswith(prefix) and filename.endswith('.fits'):
+                specfiles.append(os.path.join(dirpath, filename))
+
+    if len(specfiles) == 0:
+        log.warning('no specfiles found')
+        raise IOError
+
+    if photfit:
+        outprefix = 'photfit'
+    else:
+        outprefix = 'specfit'
+    outfiles = spectra2outfiles(specfiles, prefix, outprefix, outdir=outdir)
+
+    npix = len(specfiles)
+    todo = np.ones(npix, dtype=bool)
+    for i in range(npix):
+        if os.path.exists(outfiles[i]) and os.path.exists(specfitfiles[i]):
+            todo[i] = False
+
+    return np.array(specfiles)[todo]
+
+def group_specfiles(specfiles, maxnodes=256, comm=None):
+    '''
+    Group specfiles to balance runtimes
+
+    Args:
+        specfiles: list of spectra filepaths
+
+    Options:
+        maxnodes: split the spectra into this number of nodes
+        comm: MPI communicator
+
+    Returns (groups, ntargets, grouptimes):
+      * groups: list of lists of indices to specfiles
+      * list of number of targets per group
+      * grouptimes: list of expected runtimes for each group
+
+    '''
+    import fitsio
+    
+    if comm is None:
+        rank, size = 0, 1
+    else:
+        rank, size = comm.rank, comm.size
+
+    npix = len(specfiles)
+    pixgroups = np.array_split(np.arange(npix), size)
+    ntargets = np.zeros(len(pixgroups[rank]), dtype=int)
+    for i, j in enumerate(pixgroups[rank]):
+        zb = fitsio.read(specfiles[j], 'ZBEST')
+        fm = fitsio.read(specfiles[j], 'FIBERMAP')
+        _, I, _ = np.intersect1d(fm['TARGETID'], zb['TARGETID'], return_indices=True)            
+        fm = fm[I]
+        assert(np.all(zb['TARGETID'] == fm['TARGETID']))
+        J = ((zb['Z'] > 0) * (zb['ZWARN'] == 0) * (zb['SPECTYPE'] == 'GALAXY') * 
+             (fm['OBJTYPE'] == 'TGT') * (fm['FIBERSTATUS'] == 0))
+        ntargets[i] = np.count_nonzero(J)
+
+    if comm is not None:
+        ntargets = comm.gather(ntargets)
+        if rank == 0:
+            ntargets = np.concatenate(ntargets)
+        ntargets = comm.bcast(ntargets, root=0)
+
+    runtimes = 30 + 0.4*ntargets
+
+    # Aim for 25 minutes, but don't exceed maxnodes number of nodes.
+    ntime = 25
+    if comm is not None:
+        numnodes = comm.size
+    else:
+        numnodes = min(maxnodes, int(np.ceil(np.sum(runtimes)/(ntime*60))))
+
+    groups, grouptimes = weighted_partition(runtimes, numnodes)
+    ntargets = np.array([np.sum(ntargets[ii]) for ii in groups])
+    return groups, ntargets, grouptimes
+
+def backup_logs(logfile):
+    '''
+    Move logfile -> logfile.0 or logfile.1 or logfile.n as needed
+
+    TODO: make robust against logfile.abc also existing
+    '''
+    logfiles = glob.glob(logfile+'.*')
+    newlog = logfile+'.'+str(len(logfiles))
+    assert not os.path.exists(newlog)
+    os.rename(logfile, newlog)
+    return newlog
+
+def plan(args, comm=None):
+    from astropy.table import Table
+    
+    t0 = time.time()
+    if comm is None:
+        rank, size = 0, 1
+    else:
+        rank, size = comm.rank, comm.size
+
+    if rank == 0:
+        for key in ['FASTSPECFIT_DATA', 'FASTSPECFIT_TEMPLATES', 'DESI_ROOT', 'DUST_DIR']:
+            if key not in os.environ:
+                log.fatal('Required ${} environment variable not set'.format(key))
+                raise EnvironmentError('Required ${} environment variable not set'.format(key))
+        outdir = os.path.join(os.getenv('FASTSPECFIT_DATA'), args.specprod, 'tiles')
+        if not os.path.isdir(outdir):
+            os.makedirs(outdir, exist_ok=True)
+
+        specprod_dir = os.path.join(os.getenv('DESI_ROOT'), 'spectro', 'redux', args.specprod, 'tiles')
+        
+        # Unless we're given a specific tile and night (useful for debugging), get
+        # the list of tiles to process from the SV1 exposures table.
+        expfile = '/global/cfs/cdirs/desi/users/raichoor/fiberassign-sv1/sv1-exposures.fits'
+        explist = Table.read(expfile)
+        log.info('Read {} exposures from {}'.format(len(explist), expfile))
+        
+        if args.tile and args.night:
+            keep = (explist['TILEID'].astype(str) == args.tile) * (explist['NIGHT'].astype(str) == args.night)
+            explist = explist[keep]
+            log.info('Keeping {} extragalactic tiles.'.format(len(explist)))
+        else:
+            keep = np.zeros(len(explist), bool)
+            for targclass in ['BGS+MWS', 'ELG', 'QSO+LRG']:
+                keep = np.logical_or(keep, explist['TARGETS'] == targclass)
+            explist = explist[keep]
+            log.info('Keeping {} extragalactic tiles.'.format(len(explist)))
+
+            # Get the root directory and the set of tiles to process.
+            tiles = set(explist['TILEID'].astype(str).data)
+            keep = [os.path.isdir(os.path.join(specprod_dir, tile)) for tile in tiles]
+            log.info('Keeping {}/{} tiles with complete reductions.'.format(np.count_nonzero(keep), len(tiles)))
+            tiles = np.array(list(tiles))[keep]
+            explist = explist[np.isin(explist['TILEID'].astype(str), tiles)]
+
+        specfiles = []
+        alltiles = explist['TILEID'].astype(str)
+        for tile in set(alltiles):
+            I = tile == alltiles
+            allnights = explist['NIGHT'][I].astype(str)
+            for night in set(allnights):
+                nightdir = os.path.join(specprod_dir, tile, night)
+                outnightdir = os.path.join(outdir, tile, night)
+                if not os.path.isdir(outnightdir):
+                    os.makedirs(outnightdir, exist_ok=True)
+                _specfiles = find_specfiles(nightdir, outnightdir, prefix='zbest', photfit=args.photfit, avoiddir=None)
+            specfiles.append(_specfiles)
+        specfiles = np.hstack(specfiles)
+    else:
+        specfiles = None
+
+    if comm:
+        explist = comm.bcast(explist, root=0)
+        specfiles = comm.bcast(specfiles, root=0)
+        outdir = comm.bcast(outdir, root=0)
+        
+    if len(specfiles) == 0:
+        if rank == 0:
+            log.info('All files have been processed!')
+        return explist, list(), list(), list()
+
+    groups, ntargets, grouptimes = group_specfiles(specfiles, args.maxnodes, comm=comm)
+
+    if args.plan and rank == 0:
+        plantime = time.time() - t0
+        if plantime + np.max(grouptimes) <= (30*60):
+            queue = 'debug'
+        else:
+            queue = 'regular'
+
+        numnodes = len(groups)
+
+        if os.getenv('NERSC_HOST') == 'cori':
+            maxproc = 64
+        elif os.getenv('NERSC_HOST') == 'edison':
+            maxproc = 48
+        else:
+            maxproc = 8
+
+        if args.mp is None:
+            args.mp = maxproc // 2
+
+        #- scale longer if purposefullying using fewer cores (e.g. for memory)
+        if args.mp < maxproc // 2:
+            scale = (maxproc//2) / args.mp
+            grouptimes *= scale
+
+        jobtime = int(1.15 * (plantime + np.max(grouptimes)))
+        jobhours = jobtime // 3600
+        jobminutes = (jobtime - jobhours*3600) // 60
+        jobseconds = jobtime - jobhours*3600 - jobminutes*60
+
+        print('#!/bin/bash')
+        print('#SBATCH -N {}'.format(numnodes))
+        print('#SBATCH -q {}'.format(queue))
+        if args.photfit:
+            print('#SBATCH -J fastspecfit-phot')
+        else:
+            print('#SBATCH -J fastspecfit-spec')
+        if os.getenv('NERSC_HOST') == 'cori':
+            print('#SBATCH -C haswell')
+        print('#SBATCH -t {:02d}:{:02d}:{:02d}'.format(jobhours, jobminutes, jobseconds))
+        print()
+        print('# {} pixels with {} targets'.format(len(specfiles), np.sum(ntargets)))
+        ### print('# plan time {:.1f} minutes'.format(plantime / 60))
+        print('# Using {} nodes in {} queue'.format(numnodes, queue))
+        print('# expected rank runtimes ({:.1f}, {:.1f}, {:.1f}) min/mid/max minutes'.format(
+            np.min(grouptimes)/60, np.median(grouptimes)/60, np.max(grouptimes)/60
+        ))
+        ibiggest = np.argmax(grouptimes)
+        print('# Largest node has {} specfile(s) with {} total targets'.format(
+            len(groups[ibiggest]), ntargets[ibiggest]))
+
+        print()
+        print('export OMP_NUM_THREADS=1')
+        print('unset OMP_PLACES')
+        print('unset OMP_PROC_BIND')
+        print('export MPICH_GNI_FORK_MODE=FULLCOPY')
+        print()
+        print('nodes=$SLURM_JOB_NUM_NODES')
+        if False:
+            rrcmd = '{} --mp {} --reduxdir {}'.format(
+                os.path.abspath(__file__), args.mp, args.reduxdir)
+            if args.outdir is not None:
+                rrcmd += ' --outdir {}'.format(os.path.abspath(args.outdir))
+            print('srun -N $nodes -n $nodes -c {} {}'.format(maxproc, rrcmd))
+
+    return outdir, explist, specfiles, groups, grouptimes
+
+def run_fastspecfit(args, comm=None):
+    log = get_logger()
+
+    if comm is None:
+        rank, size = 0, 1
+    else:
+        rank, size = comm.rank, comm.size
+
+    args.maxnodes = min(args.maxnodes, size)
+
+    t0 = time.time()
+    if rank == 0:
+        log.info('Starting at {}'.format(time.asctime()))
+
+    outdir, explist, specfiles, groups, grouptimes = plan(args, comm=comm)
+
+    if rank == 0:
+        log.info('Initial setup took {:.1f} sec'.format(time.time() - t0))
+
+    sys.stdout.flush()
+    if comm:
+        groups = comm.bcast(groups, root=0)
+        specfiles = comm.bcast(specfiles, root=0)
+        explist = comm.bcast(explist, root=0)
+        outdir = comm.bcast(outdir, root=0)
+
+    assert(len(groups) == size)
+    assert(len(np.concatenate(groups)) == len(specfiles))
+
+    pixels = np.array([int(os.path.basename(os.path.dirname(x))) for x in specfiles])
+    if args.photfit:
+        outprefix = 'photfit'
+    else:
+        outprefix = 'specfit'
+        
+    outfiles = []
+    alltiles = explist['TILEID'].astype(str)
+    for tile in set(alltiles):
+        I = tile == alltiles
+        allnights = explist['NIGHT'][I].astype(str)
+        for night in set(allnights):
+            outnightdir = os.path.join(outdir, tile, night)
+            _outfiles = spectra2outfiles(specfiles, 'zbest', outprefix, outdir=outnightdir)
+            outfiles.append(_outfiles)
+    outfiles = np.hstack(outfiles)    
+
+    for ii in groups[rank]:
+        log.info('---- rank {} {}'.format(rank, time.asctime()))
+        sys.stdout.flush()
+
+        cmd = 'fastspecfit-desi {} -o {} --mp {}'.format(specfiles[ii], outfiles[ii], args.mp)
+
+        if args.photfit:
+            cmd += ' --photfit'
+        if args.solve_vdisp:
+            cmd += ' --solve-vdisp'
+
+        logfile = outfiles[ii].replace('.fits', '.log')
+        assert(logfile != outfiles[ii])
+
+        log.info('Rank {}: {}'.format(rank, cmd))
+        #log.info('LOGGING to {}'.format(logfile))
+        sys.stdout.flush()
+
+        if args.dryrun:
+            continue
+
+        try:
+            maxtries = 2
+            for retry in range(maxtries):
+                t1 = time.time()
+                if os.path.exists(logfile):
+                    backup_logs(logfile)
+                # memory leak?  Try making system call instead
+                with open(logfile, 'w') as log:
+                    err = subprocess.call(cmd.split(), stdout=log, stderr=log)
+                dt1 = time.time() - t1
+                if err == 0:
+                    log.info('FINISHED rank {} try {} in {:.1f} sec'.format(rank, retry, dt1))
+                    if not os.path.exists(outfiles[ii]):
+                        log.warning('ERROR missing {}'.format(outfiles[ii]))
+                    break
+                else:
+                    log.warning('FAILED rank {} try {} in {:.1f} sec error code {}'.format(rank, retry, dt1, err))
+                    if retry == maxtries-1:
+                        log.warning('FATAL failed {} times; giving up'.format(maxtries))
+                    else:
+                        time.sleep(np.random.uniform(1, 5))
+        except Exception as err:
+            log.warnings('FAILED: rank {} raised an exception'.format(rank))
+            import traceback
+            traceback.print_exc()
+
+    log.info('---- rank {} is done'.format(rank))
+    sys.stdout.flush()
+
+    if comm is not None:
+        comm.barrier()
+
+    if rank == 0 and not args.dryrun:
+        for outfile in outfiles:
+            if not os.path.exists(outfile):
+                log.warning('missing {}'.format(outfile))
+
+        log.info('all done at {}'.format(time.asctime()))
+        
+    pdb.set_trace()
+
+def main():
+    """Main wrapper on fastspecfit.
+
+    Currently only knows about SV1 observations.
+
+    """
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--specprod', type=str, default='daily', choices=['andes', 'daily'], help='Spectroscopic production to process.')
+    parser.add_argument('--tile', default=None, type=str, help='Tile number to process (default is to do all the SV1 exposures).')
+    parser.add_argument('--night', default=None, type=str, help='Night to process (default is to do all the SV1 exposures).')
+    parser.add_argument('--exposures', action='store_true', default=False, help='Process the individual exposures (based on EXPID).')
+    
+    parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
+    parser.add_argument('--maxnodes', type=int, default=256, help='maximum number of nodes to use')
+
+    parser.add_argument('--photfit', action='store_true', help='Fit just the broadband photometry.')
+    parser.add_argument('--solve-vdisp', action='store_true', help='Solve for the velocity disperion.')
+
+    parser.add_argument('--plan', action='store_true', help='Plan how many nodes to use and how to distribute the targets.')
+    parser.add_argument('--nompi', action='store_true', help='Do not use MPI parallelism.')
+    parser.add_argument('--dryrun', action='store_true', help='Generate but do not run commands')
+
+    args = parser.parse_args()
+
+    if args.nompi or nersc_login_node():
+        comm = None
+    else:
+        try:
+            from mpi4py import MPI
+            comm = MPI.COMM_WORLD
+        except ImportError:
+            comm = None
+
+    # Determine the set of tiles to process.
+    #if comm is not None:
+    #    sample = comm.bcast(sample, root=0)
+
+    if args.plan:
+        plan(args, comm=comm)
+    else:
+        ## Create output directory if needed
+        #if (args.outdir is not None) and ((comm is None) or (comm.rank == 0)):
+        #    os.makedirs(args.outdir, exist_ok=True)
+        ## All ranks wait for directory to be created.
+        #if comm is not None:
+        #    comm.barrier()
+
+        run_fastspecfit(args, comm=comm)
+
+if __name__ == '__main__':
+    main()

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -209,6 +209,7 @@ def backup_logs(logfile):
     return newlog
 
 def plan(args, comm=None):
+    from glob import glob
     from astropy.table import Table
     
     t0 = time.time()
@@ -272,11 +273,11 @@ def plan(args, comm=None):
             explist = explist[:10]
             
         if args.photfit:
-            _outprefix = 'photfit'
+            outprefix = 'photfit'
         else:
-            _outprefix = 'specfit'
+            outprefix = 'specfit'
 
-        specfiles = []
+        specfiles, outfiles = [], []
         alltiles = explist['TILEID'].astype(str)
         for tile in set(alltiles):
             I = tile == alltiles
@@ -288,20 +289,24 @@ def plan(args, comm=None):
                     os.makedirs(outnightdir, exist_ok=True)
                 #outprefix = '{}-{}-{}'.format(_outprefix, tile, night)                
                 #_specfiles = find_specfiles(nightdir, outnightdir, prefix='zbest', outprefix=outprefix)
-                if not os.path.isdir(nightdir): # no reductions
+                _specfiles = glob(os.path.join(nightdir, 'zbest-?-*.fits'))
+                if len(_specfiles) == 0:
+                    log.info('No redrock redshifts in {}'.format(nightdir))
                     continue
-                _specfiles = find_specfiles(nightdir, outnightdir, prefix='zbest', outprefix=_outprefix)
+                _outfiles = [os.path.join(outnightdir, os.path.basename(specfile).replace('zbest-', '{}-'.format(outprefix))) for specfile in _specfiles]
+                #_specfiles = find_specfiles(nightdir, outnightdir, prefix='zbest', outprefix=_outprefix)
                 specfiles.append(_specfiles)
-        specfiles = np.hstack(specfiles)
+                outfiles.append(_outfiles)
+        if len(specfiles) > 0:
+            specfiles = np.hstack(specfiles)
+            outfiles = np.hstack(outfiles)
     else:
-        explist = None
         specfiles = None
-        outdir = None
+        outfiles = None
 
     if comm:
-        explist = comm.bcast(explist, root=0)
         specfiles = comm.bcast(specfiles, root=0)
-        outdir = comm.bcast(outdir, root=0)
+        outfiles = comm.bcast(outfiles, root=0)
         
     if len(specfiles) == 0:
         if rank == 0:
@@ -374,7 +379,7 @@ def plan(args, comm=None):
                 rrcmd += ' --outdir {}'.format(os.path.abspath(args.outdir))
             print('srun -N $nodes -n $nodes -c {} {}'.format(maxproc, rrcmd))
 
-    return outdir, explist, specfiles, groups, grouptimes
+    return specfiles, outfiles, groups, grouptimes
 
 def run_fastspecfit(args, comm=None):
 
@@ -389,47 +394,32 @@ def run_fastspecfit(args, comm=None):
     if rank == 0:
         log.info('Starting at {}'.format(time.asctime()))
 
-    outdir, explist, specfiles, groups, grouptimes = plan(args, comm=comm)
+    specfiles, outfiles, groups, grouptimes = plan(args, comm=comm)
 
     if rank == 0:
         log.info('Initial setup took {:.1f} sec'.format(time.time() - t0))
 
     sys.stdout.flush()
     if comm:
-        groups = comm.bcast(groups, root=0)
         specfiles = comm.bcast(specfiles, root=0)
-        explist = comm.bcast(explist, root=0)
-        outdir = comm.bcast(outdir, root=0)
-
+        outfiles = comm.bcast(outfiles, root=0)
+        groups = comm.bcast(groups, root=0)
+        
     assert(len(groups) == size)
     assert(len(np.concatenate(groups)) == len(specfiles))
 
-    pixels = np.array([int(os.path.basename(os.path.dirname(x))) for x in specfiles])
-    if args.photfit:
-        _outprefix = 'photfit'
-    else:
-        _outprefix = 'specfit'
+    #pixels = np.array([int(os.path.basename(os.path.dirname(x))) for x in specfiles])
+    #if args.photfit:
+    #    _outprefix = 'photfit'
+    #else:
+    #    _outprefix = 'specfit'
         
-    outfiles = []
-    alltiles = explist['TILEID'].astype(str)
-    for tile in set(alltiles):
-        I = tile == alltiles
-        allnights = explist['NIGHT'][I].astype(str)
-        for night in set(allnights):
-            outnightdir = os.path.join(outdir, tile, night)
-            #outprefix = '{}-{}-{}'.format(_outprefix, tile, night)
-            #outfile = os.path.join(outdir, '{}.fits'.format(outprefix))
-            #outfiles.append(outfile)
-            _outfiles = spectra2outfiles(specfiles, 'zbest', _outprefix, outdir=outnightdir)
-            outfiles.append(_outfiles)
-    outfiles = np.hstack(outfiles)    
-
     for ii in groups[rank]:
         log.info('Rank {} started at {}'.format(rank, time.asctime()))
         sys.stdout.flush()
 
         cmd = 'fastspecfit-desi {} -o {} --mp {}'.format(specfiles[ii], outfiles[ii], args.mp)
-        #cmd += ' --ntargets 3'
+        cmd += ' --ntargets 6'
 
         if args.exposures:
             cmd += ' --exposures'

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -270,7 +270,7 @@ def plan(args, comm=None):
             log.info('Keeping {}/{} tiles with complete reductions.'.format(np.count_nonzero(keep), len(tiles)))
             tiles = np.array(list(tiles))[keep]
             explist = explist[np.isin(explist['TILEID'].astype(str), tiles)]
-            explist = explist[:10]
+            #explist = explist[:10]
             
         if args.photfit:
             outprefix = 'photfit'

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -84,7 +84,8 @@ def spectra2outfiles(specfiles, inprefix, outprefix, ext=None, outdir=None):
 
     return np.array(outfiles)
 
-def find_specfiles(reduxdir, outdir=None, prefix='zbest', avoiddir=None, photfit=False):
+def find_specfiles(reduxdir, outdir=None, prefix='zbest', outprefix='specfit',
+                   avoiddir=None):
     '''
     Returns list of spectra files under reduxdir that need to be processed.
 
@@ -119,23 +120,25 @@ def find_specfiles(reduxdir, outdir=None, prefix='zbest', avoiddir=None, photfit
             if filename.startswith(prefix) and filename.endswith('.fits'):
                 specfiles.append(os.path.join(dirpath, filename))
 
+    #log.info(reduxdir, outdir, prefix, outprefix, specfiles)
     if len(specfiles) == 0:
         log.warning('no specfiles found')
         raise IOError
 
-    if photfit:
-        outprefix = 'photfit'
+    # One output file per run.
+    #outfiles = spectra2outfiles(specfiles, prefix, outprefix, outdir=outdir)
+    outfile = os.path.join(outdir, '{}.fits'.format(outprefix))
+    if os.path.exists(outfile):
+        return np.array([])
     else:
-        outprefix = 'specfit'
-    outfiles = spectra2outfiles(specfiles, prefix, outprefix, outdir=outdir)
+        return np.array(specfiles)
 
-    npix = len(specfiles)
-    todo = np.ones(npix, dtype=bool)
-    for i in range(npix):
-        if os.path.exists(outfiles[i]) and os.path.exists(specfitfiles[i]):
-            todo[i] = False
-
-    return np.array(specfiles)[todo]
+    #npix = len(specfiles)
+    #todo = np.ones(npix, dtype=bool)
+    #for i in range(npix):
+    #    if os.path.exists(outfiles[i]) and os.path.exists(specfitfiles[i]):
+    #        todo[i] = False
+    #return np.array(specfiles)[todo]
 
 def group_specfiles(specfiles, maxnodes=256, comm=None):
     '''
@@ -229,18 +232,36 @@ def plan(args, comm=None):
         # the list of tiles to process from the SV1 exposures table.
         expfile = '/global/cfs/cdirs/desi/users/raichoor/fiberassign-sv1/sv1-exposures.fits'
         explist = Table.read(expfile)
+        explist = explist[np.argsort(explist['NIGHT'])]
         log.info('Read {} exposures from {}'.format(len(explist), expfile))
         
         if args.tile and args.night:
             keep = (explist['TILEID'].astype(str) == args.tile) * (explist['NIGHT'].astype(str) == args.night)
             explist = explist[keep]
-            log.info('Keeping {} extragalactic tiles.'.format(len(explist)))
+            log.info('Keeping {} exposures from tile {} on night {}.'.format(len(explist), args.tile, args.night))
         else:
             keep = np.zeros(len(explist), bool)
-            for targclass in ['BGS+MWS', 'ELG', 'QSO+LRG']:
+            targclasses = ['BGS+MWS', 'ELG', 'QSO+LRG']
+            for targclass in targclasses:
                 keep = np.logical_or(keep, explist['TARGETS'] == targclass)
             explist = explist[keep]
-            log.info('Keeping {} extragalactic tiles.'.format(len(explist)))
+            log.info('Keeping {} {} exposures.'.format(len(explist), ' '.join(targclasses)))
+
+            # Make sure the data have been reduced.
+            keep = np.ones(len(explist), bool)
+            alltiles = explist['TILEID'].astype(str)
+            for tile in set(alltiles):
+                I = np.where(tile == alltiles)[0]
+                allnights = explist['NIGHT'][I].astype(str)
+                for night in set(allnights):
+                    J = np.where(night == allnights)[0]
+                    nightdir = os.path.join(specprod_dir, tile, night)
+                    if not os.path.isdir(nightdir):
+                        log.info('No reductions for night {}'.format(nightdir))
+                        keep[I[J]] = False
+                        
+            explist = explist[keep]
+            log.info('Keeping {} exposures with complete reductions.'.format(len(explist)))
 
             # Get the root directory and the set of tiles to process.
             tiles = set(explist['TILEID'].astype(str).data)
@@ -248,6 +269,12 @@ def plan(args, comm=None):
             log.info('Keeping {}/{} tiles with complete reductions.'.format(np.count_nonzero(keep), len(tiles)))
             tiles = np.array(list(tiles))[keep]
             explist = explist[np.isin(explist['TILEID'].astype(str), tiles)]
+            explist = explist[:10]
+            
+        if args.photfit:
+            _outprefix = 'photfit'
+        else:
+            _outprefix = 'specfit'
 
         specfiles = []
         alltiles = explist['TILEID'].astype(str)
@@ -259,11 +286,17 @@ def plan(args, comm=None):
                 outnightdir = os.path.join(outdir, tile, night)
                 if not os.path.isdir(outnightdir):
                     os.makedirs(outnightdir, exist_ok=True)
-                _specfiles = find_specfiles(nightdir, outnightdir, prefix='zbest', photfit=args.photfit, avoiddir=None)
-            specfiles.append(_specfiles)
+                #outprefix = '{}-{}-{}'.format(_outprefix, tile, night)                
+                #_specfiles = find_specfiles(nightdir, outnightdir, prefix='zbest', outprefix=outprefix)
+                if not os.path.isdir(nightdir): # no reductions
+                    continue
+                _specfiles = find_specfiles(nightdir, outnightdir, prefix='zbest', outprefix=_outprefix)
+                specfiles.append(_specfiles)
         specfiles = np.hstack(specfiles)
     else:
+        explist = None
         specfiles = None
+        outdir = None
 
     if comm:
         explist = comm.bcast(explist, root=0)
@@ -344,7 +377,6 @@ def plan(args, comm=None):
     return outdir, explist, specfiles, groups, grouptimes
 
 def run_fastspecfit(args, comm=None):
-    log = get_logger()
 
     if comm is None:
         rank, size = 0, 1
@@ -374,9 +406,9 @@ def run_fastspecfit(args, comm=None):
 
     pixels = np.array([int(os.path.basename(os.path.dirname(x))) for x in specfiles])
     if args.photfit:
-        outprefix = 'photfit'
+        _outprefix = 'photfit'
     else:
-        outprefix = 'specfit'
+        _outprefix = 'specfit'
         
     outfiles = []
     alltiles = explist['TILEID'].astype(str)
@@ -385,15 +417,19 @@ def run_fastspecfit(args, comm=None):
         allnights = explist['NIGHT'][I].astype(str)
         for night in set(allnights):
             outnightdir = os.path.join(outdir, tile, night)
-            _outfiles = spectra2outfiles(specfiles, 'zbest', outprefix, outdir=outnightdir)
+            #outprefix = '{}-{}-{}'.format(_outprefix, tile, night)
+            #outfile = os.path.join(outdir, '{}.fits'.format(outprefix))
+            #outfiles.append(outfile)
+            _outfiles = spectra2outfiles(specfiles, 'zbest', _outprefix, outdir=outnightdir)
             outfiles.append(_outfiles)
     outfiles = np.hstack(outfiles)    
 
     for ii in groups[rank]:
-        log.info('---- rank {} {}'.format(rank, time.asctime()))
+        log.info('Rank {} started at {}'.format(rank, time.asctime()))
         sys.stdout.flush()
 
         cmd = 'fastspecfit-desi {} -o {} --mp {}'.format(specfiles[ii], outfiles[ii], args.mp)
+        #cmd += ' --ntargets 3'
 
         if args.exposures:
             cmd += ' --exposures'
@@ -405,7 +441,7 @@ def run_fastspecfit(args, comm=None):
         logfile = outfiles[ii].replace('.fits', '.log')
         assert(logfile != outfiles[ii])
 
-        log.info('Rank {}: {}'.format(rank, cmd))
+        log.info('  rank {}: {}'.format(rank, cmd))
         #log.info('LOGGING to {}'.format(logfile))
         sys.stdout.flush()
 
@@ -413,32 +449,25 @@ def run_fastspecfit(args, comm=None):
             continue
 
         try:
-            maxtries = 2
-            for retry in range(maxtries):
-                t1 = time.time()
-                if os.path.exists(logfile):
-                    backup_logs(logfile)
-                # memory leak?  Try making system call instead
-                with open(logfile, 'w') as log:
-                    err = subprocess.call(cmd.split(), stdout=log, stderr=log)
-                dt1 = time.time() - t1
-                if err == 0:
-                    log.info('FINISHED rank {} try {} in {:.1f} sec'.format(rank, retry, dt1))
-                    if not os.path.exists(outfiles[ii]):
-                        log.warning('ERROR missing {}'.format(outfiles[ii]))
-                    break
-                else:
-                    log.warning('FAILED rank {} try {} in {:.1f} sec error code {}'.format(rank, retry, dt1, err))
-                    if retry == maxtries-1:
-                        log.warning('FATAL failed {} times; giving up'.format(maxtries))
-                    else:
-                        time.sleep(np.random.uniform(1, 5))
+            t1 = time.time()
+            if os.path.exists(logfile):
+                backup_logs(logfile)
+            # memory leak?  Try making system call instead
+            with open(logfile, 'w') as mylog:
+                err = subprocess.call(cmd.split(), stdout=mylog, stderr=mylog)
+            dt1 = time.time() - t1
+            if err == 0:
+                log.info('  rank {} done in {:.2f} sec'.format(rank, dt1))
+                if not os.path.exists(outfiles[ii]):
+                    log.warning('  rank {} missing {}'.format(rank, outfiles[ii]))
+            else:
+                log.warning('  rank {} broke after {:.1f} sec with error code {}'.format(rank, dt1, err))
         except Exception as err:
-            log.warnings('FAILED: rank {} raised an exception'.format(rank))
+            log.warning('  rank {} raised an exception'.format(rank))
             import traceback
             traceback.print_exc()
 
-    log.info('---- rank {} is done'.format(rank))
+    log.info('  rank {} is done'.format(rank))
     sys.stdout.flush()
 
     if comm is not None:
@@ -447,12 +476,10 @@ def run_fastspecfit(args, comm=None):
     if rank == 0 and not args.dryrun:
         for outfile in outfiles:
             if not os.path.exists(outfile):
-                log.warning('missing {}'.format(outfile))
+                log.warning('Missing {}'.format(outfile))
 
-        log.info('all done at {}'.format(time.asctime()))
+        log.info('All done at {}'.format(time.asctime()))
         
-    pdb.set_trace()
-
 def main():
     """Main wrapper on fastspecfit.
 
@@ -485,10 +512,6 @@ def main():
             comm = MPI.COMM_WORLD
         except ImportError:
             comm = None
-
-    # Determine the set of tiles to process.
-    #if comm is not None:
-    #    sample = comm.bcast(sample, root=0)
 
     if args.plan:
         plan(args, comm=comm)

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -293,10 +293,13 @@ def plan(args, comm=None):
                 if len(_specfiles) == 0:
                     log.info('No redrock redshifts in {}'.format(nightdir))
                     continue
-                _outfiles = [os.path.join(outnightdir, os.path.basename(specfile).replace('zbest-', '{}-'.format(outprefix))) for specfile in _specfiles]
                 #_specfiles = find_specfiles(nightdir, outnightdir, prefix='zbest', outprefix=_outprefix)
-                specfiles.append(_specfiles)
-                outfiles.append(_outfiles)
+                # How many have we done already?
+                for specfile in _specfiles:
+                    outfile = os.path.join(outnightdir, os.path.basename(specfile).replace('zbest-', '{}-'.format(outprefix)))
+                    if args.overwrite or not os.path.isfile(outfile):
+                        specfiles.append(specfile)
+                        outfiles.append(outfile)
         if len(specfiles) > 0:
             specfiles = np.hstack(specfiles)
             outfiles = np.hstack(outfiles)
@@ -311,7 +314,7 @@ def plan(args, comm=None):
     if len(specfiles) == 0:
         if rank == 0:
             log.info('All files have been processed!')
-        return explist, list(), list(), list()
+        return list(), list(), list(), list()
 
     groups, ntargets, grouptimes = group_specfiles(specfiles, args.maxnodes, comm=comm)
 
@@ -404,6 +407,10 @@ def run_fastspecfit(args, comm=None):
         specfiles = comm.bcast(specfiles, root=0)
         outfiles = comm.bcast(outfiles, root=0)
         groups = comm.bcast(groups, root=0)
+
+    # all done
+    if len(specfiles) == 0:
+        return
         
     assert(len(groups) == size)
     assert(len(np.concatenate(groups)) == len(specfiles))
@@ -488,6 +495,7 @@ def main():
     parser.add_argument('--photfit', action='store_true', help='Fit just the broadband photometry.')
     parser.add_argument('--solve-vdisp', action='store_true', help='Solve for the velocity disperion.')
 
+    parser.add_argument('--overwrite', action='store_true', help='Overwrite any existing output files.')
     parser.add_argument('--plan', action='store_true', help='Plan how many nodes to use and how to distribute the targets.')
     parser.add_argument('--nompi', action='store_true', help='Do not use MPI parallelism.')
     parser.add_argument('--dryrun', action='store_true', help='Generate but do not run commands')

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -426,7 +426,7 @@ def run_fastspecfit(args, comm=None):
         sys.stdout.flush()
 
         cmd = 'fastspecfit-desi {} -o {} --mp {}'.format(specfiles[ii], outfiles[ii], args.mp)
-        cmd += ' --ntargets 6'
+        cmd += ' --ntargets 32'
 
         if args.exposures:
             cmd += ' --exposures'

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -395,6 +395,8 @@ def run_fastspecfit(args, comm=None):
 
         cmd = 'fastspecfit-desi {} -o {} --mp {}'.format(specfiles[ii], outfiles[ii], args.mp)
 
+        if args.exposures:
+            cmd += ' --exposures'
         if args.photfit:
             cmd += ' --photfit'
         if args.solve_vdisp:

--- a/bin/mpi-fastspecfit.sh
+++ b/bin/mpi-fastspecfit.sh
@@ -6,9 +6,9 @@
 
 # Example: build the coadds using 16 MPI tasks with 8 cores per node (and therefore 16*8/32=4 nodes)
 
-#salloc -N 4 -C haswell -A desi -L cfs,SCRATCH -t 04:00:00 --qos interactive --image=desihub/fastspecfit:v0.0.1
-#srun -n 32 -c 4 --kill-on-bad-exit=0 --no-kill shifter --module=mpich-cle6 /global/homes/i/ioannis/repos/desihub/fastspecfit/mpi-fastspecfit.sh photfit 32 > photfit.log.1 2>&1 &
-#srun -n 32 -c 4 --kill-on-bad-exit=0 --no-kill shifter --module=mpich-cle6 /global/homes/i/ioannis/repos/desihub/fastspecfit/mpi-fastspecfit.sh specfit 32 > specfit.log.1 2>&1 &
+#salloc -N 4 -C haswell -A desi -L cfs,SCRATCH -t 04:00:00 --qos interactive --image=docker:desihub/fastspecfit:v0.0.1
+#srun -n 32 -c 4 --kill-on-bad-exit=0 --no-kill shifter --module=mpich-cle6 /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit.sh photfit 4 > photfit.log.1 2>&1 &
+#srun -n 32 -c 4 --kill-on-bad-exit=0 --no-kill shifter --module=mpich-cle6 /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit.sh specfit 4 > specfit.log.1 2>&1 &
 
 # Grab the input arguments--
 stage=$1
@@ -33,11 +33,11 @@ export KMP_AFFINITY=disabled
 export MPICH_GNI_FORK_MODE=FULLCOPY
 
 if [ $stage = "test" ]; then
-    time python mpi-fastspecfit --help
+    time python /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit --help
 elif [ $stage = "specfit" ]; then
-    time python mpi-fastspecfit --mp $mp --specprod $specprod
+    time python /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit --mp $mp --specprod $specprod
 elif [ $stage = "photfit" ]; then
-    time python mpi-fastspecfit --photfit --mp $ncores --specprod $specprod
+    time python /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit --photfit --mp $mp --specprod $specprod
 else
     echo "Unrecognized stage "$stage
 fi

--- a/bin/mpi-fastspecfit.sh
+++ b/bin/mpi-fastspecfit.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+
+# Shell script for running mpi-fastspecfit with MPI+shifter at NERSC. Required arguments:
+#   {1} stage [specfit, photfit, test]
+#   {2} mp [should match the resources requested.]
+
+# Example: build the coadds using 16 MPI tasks with 8 cores per node (and therefore 16*8/32=4 nodes)
+
+#salloc -N 4 -C haswell -A desi -L cfs,SCRATCH -t 04:00:00 --qos interactive --image=desihub/fastspecfit:v0.0.1
+#srun -n 32 -c 4 --kill-on-bad-exit=0 --no-kill shifter --module=mpich-cle6 /global/homes/i/ioannis/repos/desihub/fastspecfit/mpi-fastspecfit.sh photfit 32 > photfit.log.1 2>&1 &
+#srun -n 32 -c 4 --kill-on-bad-exit=0 --no-kill shifter --module=mpich-cle6 /global/homes/i/ioannis/repos/desihub/fastspecfit/mpi-fastspecfit.sh specfit 32 > specfit.log.1 2>&1 &
+
+# Grab the input arguments--
+stage=$1
+mp=$2
+
+specprod=daily
+
+package=fastspecfit
+export PATH=/global/homes/i/ioannis/repos/desihub/$package/bin:${PATH}
+export PYTHONPATH=/global/homes/i/ioannis/repos/desihub/$package/py:${PYTHONPATH}
+#export PYTHONPATH=/global/homes/i/ioannis/repos/git/fnnls/src/fnnls:${PYTHONPATH}
+#export PYTHONPATH=/global/homes/i/ioannis/repos/git/fast-nnls:${PYTHONPATH}
+
+export DESI_ROOT=/global/cfs/cdirs/desi
+export DUST_DIR=/global/cfs/cdirs/cosmo/data/dust/v0_1
+export FASTSPECFIT_DATA=/global/cfs/cdirs/desi/users/ioannis/fastspecfit
+export FASTSPECFIT_TEMPLATES=$DESI_ROOT/science/gqp/templates/SSP-CKC14z
+
+export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export KMP_AFFINITY=disabled
+export MPICH_GNI_FORK_MODE=FULLCOPY
+
+if [ $stage = "test" ]; then
+    time python mpi-fastspecfit --help
+elif [ $stage = "specfit" ]; then
+    time python mpi-fastspecfit --mp $mp --specprod $specprod
+elif [ $stage = "photfit" ]; then
+    time python mpi-fastspecfit --photfit --mp $ncores --specprod $specprod
+else
+    echo "Unrecognized stage "$stage
+fi

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -148,7 +148,7 @@ def _fnnls_continuum(myargs):
     return fnnls_continuum(*myargs)
 
 def fnnls_continuum(ZZ, xx, flux=None, ivar=None, modelflux=None,
-                        support=None, get_chi2=False):
+                    support=None, get_chi2=False, jvendrow=False):
     """Fit a continuum using fNNLS. This function is a simple wrapper on fnnls; see
     the ContinuumFit.fnnls_continuum method for documentation.
 
@@ -265,7 +265,11 @@ class ContinuumFit(object):
         self.nAV = len(AV)
 
         # photometry
-        self.nband = 5
+        self.bands = ['g', 'r', 'z', 'W1', 'W2']
+        self.nband = len(self.bands)
+        self.decam = filters.load_filters('decam2014-g', 'decam2014-r', 'decam2014-z')
+        self.bassmzls = filters.load_filters('BASS-g', 'BASS-r', 'MzLS-z')
+
         self.decamwise = filters.load_filters('decam2014-g', 'decam2014-r', 'decam2014-z',
                                               'wise2010-W1', 'wise2010-W2')
         self.bassmzlswise = filters.load_filters('BASS-g', 'BASS-r', 'MzLS-z',
@@ -685,6 +689,8 @@ class ContinuumFit(object):
         To be documented.
 
         """
+        from redrock import fitz
+        
         if xparam is not None:
             nn = len(xparam)
         ww = np.sqrt(ivar)
@@ -773,7 +779,6 @@ class ContinuumFit(object):
 
         """
         from fnnls import fnnls
-        from redrock import fitz
 
         # Initialize the output table; see init_fastspecfit for the data model.
         result = self.init_phot_output()
@@ -865,7 +870,6 @@ class ContinuumFit(object):
 
         """
         from fnnls import fnnls
-        from redrock import fitz
 
         # Initialize the output table; see init_fastspecfit for the data model.
         result = self.init_spec_output()

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -224,6 +224,8 @@ class EMLineFit(object):
         from astropy.table import Table, Column
         
         out = Table()
+        out.add_column(Column(name='SYNTHPHOT_GRZ', length=nobj, shape=(3,), dtype='f4', unit=u.nanomaggy)) # grzW1W2 photometry
+        #out.add_column(Column(name='SYNTHPHOT_GRZ_IVAR', length=nobj, shape=(3,), dtype='f4', unit=u.nanomaggy)) 
         out.add_column(Column(name='LINEVSHIFT_FORBIDDEN', length=nobj, dtype='f4'))
         out.add_column(Column(name='LINEVSHIFT_FORBIDDEN_IVAR', length=nobj, dtype='f4'))
         out.add_column(Column(name='LINEVSHIFT_BALMER', length=nobj, dtype='f4'))
@@ -355,6 +357,8 @@ class EMLineFit(object):
 
         # Initialize the output table; see init_fastspecfit for the data model.
         result = self.init_output(self.EMLineModel.linetable)
+        result['SYNTHPHOT_GRZ'] = data['synthphot']['nanomaggies']
+        #result['SYNTHPHOT_GRZ_IVAR'] = data['phot']['nanomaggies_ivar']
 
         specflux_nolines = specflux - emlinemodel
 
@@ -494,7 +498,9 @@ class EMLineFit(object):
             result['{}_CONT_IVAR'.format(line)] = civar
 
             if result['{}_CONT_IVAR'.format(line)] != 0.0:
-                factor = (1 + redshift) / result['{}_CONT'.format(line)]
+                #if result['{}_CONT'.format(line)] == 0:
+                #    pdb.set_trace()
+                factor = (1 + redshift) / result['{}_CONT'.format(line)] # --> rest frame
                 ew = result['{}_FLUX'.format(line)] * factor   # rest frame [A]
                 ewivar = result['{}_FLUX_IVAR'.format(line)] / factor**2
 

--- a/py/fastspecfit/external/desi.py
+++ b/py/fastspecfit/external/desi.py
@@ -81,360 +81,239 @@ def fastspecfit_one(indx, data, CFit, EMFit, out, photfit=False, solve_vdisp=Fal
         
     return out
 
-def read_spectra(tile, night, specprod='andes', use_vi=False, write_spectra=True,
-                 overwrite=False, verbose=False):
-    """Read the spectra and redshift catalog for a given tile and night.
+class DESISpectra(object):
+    def __init__(self, zbestfile, exposures=False):
+        """Class to read in the DESI data needed by fastspecfit.
 
-    Parameters
-    ----------
-    tile : :class:`str`
-        Tile number to analyze.
-    night : :class:`str`
-        Night on which `tile` was observed.
-    specprod : :class:`str`, defaults to `andes`.
-        Spectroscopic production to read.
-    use_vi : :class:`bool`, optional, defaults to False
-        Select the subset of spectra with high-quality visual inspections.
-    write_spectra : :class:`bool`, optional, defaults to True
-        Write out the selected spectra (useful for testing.)
-    overwrite : :class:`bool`, optional, defaults to False
-        Overwrite output files if they exist on-disk.
-    verbose : :class:`bool`, optional, defaults to False
-        Trigger more verbose output.
+        """
+        import fitsio
+        from astropy.table import Table
+        #from desispec.spectra import Spectra
 
-    Returns
-    -------
-    :class:`astropy.table.Table`
-        Redrock redshift table for the given tile and night.
-    :class:`desispec.spectra.Spectra`
-        DESI spectra for the given tile and night (in the standard format).
+        self.zbestfile = zbestfile
 
-    Notes
-    -----
-    The spectra from all 10 spectrographs are combined and only the subset of
-    galaxy spectra with good redshifts (and, optionally, high-quality visual
-    inspections) are returned.
-
-    """
-    import fitsio
-    from astropy.table import Table, vstack
-    from desispec.spectra import Spectra
-    import desispec.io
-    from desitarget.io import read_targets_in_tiles
-
-    if False:
-        hpdirname = '/global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/targets/sv1/resolve/dark'
-        print('Assuming hpdirname={}'.format(hpdirname))
-        from desimodel.io import load_tiles
-        tileinfo = load_tiles()
-        tileinfo = tileinfo[tileinfo['TILEID'] == tile]
-
-    data_dir = os.path.join(os.getenv('FASTSPECFIT_DATA'), 'spectra', specprod)
-    zbestoutfile = os.path.join(data_dir, 'zbest-{}-{}.fits'.format(tile, night))
-    coaddoutfile = os.path.join(data_dir, 'coadd-{}-{}.fits'.format(tile, night))
-    if os.path.isfile(coaddoutfile) and not overwrite:
-        zbest = Table(fitsio.read(zbestoutfile))
-        log.info('Read {} redshifts from {}'.format(len(zbest), zbestoutfile))
-
-        coadd = desispec.io.read_spectra(coaddoutfile)
-        log.info('Read {} spectra from {}'.format(len(zbest), coaddoutfile))
-
-        assert(np.all(zbest['TARGETID'] == coadd.fibermap['TARGETID']))
-        return zbest, coadd
-
-    log.info('Parsing tile, night {}, {} from specprod {}'.format(tile, night, specprod))
-
-    specprod_dir = os.path.join(os.getenv('DESI_ROOT'), 'spectro', 'redux', specprod)
-    desidatadir = os.path.join(specprod_dir, 'tiles', tile, night)
-
-    # use visual inspection results?
-    if use_vi:
-        truthdir = os.path.join(os.getenv('DESI_ROOT'), 'sv', 'vi', 'TruthTables')
-        tile2file = {
-            '66003': os.path.join(truthdir, 'truth_table_BGS_v1.2.csv'),
-            '70500': os.path.join(truthdir, 'truth_table_ELG_v1.2_latest.csv'),
-            }
-        if tile not in tile2file.keys():
-            log.warning('No (known) truth file exists for tile {}. Setting use_vi=False.'.format(tile))
-            use_vi = False
+        if exposures:
+            self.specfile = zbestfile.replace('zbest-', 'spectra-')
         else:
-            truth = Table.read(truthfile)
-            best = np.where(
-                (truth['best quality'] >= 2.5) * 
-                (truth['Redrock spectype'] == 'GALAXY')# *
-                #(truth['Redrock z'] < 0.75) 
-            )[0]
-            #goodobj = np.where((zb['DELTACHI2'] > 100) * (zb['ZWARN'] == 0) * (zb['SPECTYPE'] == 'GALAXY'))[0]
+            self.specfile = zbestfile.replace('zbest-', 'coadd-')            
 
-            log.info('Read {}/{} good redshifts from {}'.format(len(best), len(truth), truthfile))
-            truth = truth[best]
-    
-    zbest = []
-    spectra, keepindx = [], []
-    if False:
-        targets = read_targets_in_tiles(tiles=np.atleast_1d(tileinfo), hpdirname=hpdirname, quick=True)
-    
-    #for spectro in ('0'):
-    for spectro in ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'):
-        zbestfile = os.path.join(desidatadir, 'zbest-{}-{}-{}.fits'.format(spectro, tile, night))
-        coaddfile = os.path.join(desidatadir, 'coadd-{}-{}-{}.fits'.format(spectro, tile, night))
-        if os.path.isfile(zbestfile) and os.path.isfile(coaddfile):
-            zb = Table(fitsio.read(zbestfile))
-            fmap = fitsio.read(coaddfile, ext='FIBERMAP', columns=['FIBERSTATUS', 'OBJTYPE'])
-            if use_vi:
-                keep = np.where(np.isin(zb['TARGETID'], truth['TARGETID']))[0]
+        # Hack! Gather tile and targets info.
+        if False:
+            tilefile = '/global/cfs/cdirs/desi/users/raichoor/fiberassign-sv1/sv1-tiles.fits'
+            log.info('Reading {}'.format(tilefile))
+            tiles = fitsio.read(tilefile)
+            thistile = tiles[tiles['TILEID'] == np.int(tile)]
+
+            hpdirname = '/global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/targets/sv1/resolve/dark'
+            log.info('Assuming hpdirname {}'.format(hpdirname))
+
+            targets = read_targets_in_tiles(hpdirname, tiles=thistile, quick=True)
+            #rr = read_targets_in_cap('/global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/targets/sv1/resolve/dark', (36.448, -4.601, 1.5), quick=True)
+
+        # Read the zbest file and fibermap and select the objects to fit.
+        zb = fitsio.read(self.zbestfile, 'ZBEST')
+        #fm = fitsio.read(zbestfile, 'FIBERMAP')
+        fm = fitsio.read(self.specfile, 'FIBERMAP')
+        
+        if exposures:
+            pdb.set_trace()
+            _, I, _ = np.intersect1d(fm['TARGETID'], zb['TARGETID'], return_indices=True)            
+            fm = fm[I]
+            assert(np.all(zb['TARGETID'] == fm['TARGETID']))
+        else:
+            J = ((zb['Z'] > 0) * (zb['ZWARN'] == 0) * (zb['SPECTYPE'] == 'GALAXY') * 
+                 (fm['OBJTYPE'] == 'TGT') * (fm['FIBERSTATUS'] == 0))
+            #zb = zb[J]
+            #fm = fm[J]
+
+            self.zbest = Table(zb[J])
+
+    @staticmethod
+    def desitarget_resolve_dec():
+        """Default Dec cut to separate targets in BASS/MzLS from DECaLS."""
+        dec = 32.375
+        return dec
+
+    def read_and_unpack(self, CFit, firsttarget=0, targetids=None, ntargets=None,
+                        exposures=False):
+        """Unpack and pre-process a single DESI spectrum.
+        
+        Parameters
+        ----------
+        specobj : :class:`desispec.spectra.Spectra`
+            DESI spectra (in the standard format).
+        zbest : :class:`astropy.table.Table`
+            Redrock redshift table (row-aligned to `specobj`).
+        CFit : :class:`fastspecfit.continuum.ContinuumFit`
+            Continuum-fitting class which contains filter curves and some additional
+            photometric convenience functions.
+        indx : :class:`int`
+            Index number (0-indexed) of the spectrum to unpack and pre-process.
+
+        Returns
+        -------
+        :class:`dict` with the following keys:
+            zredrock : :class:`numpy.float64`
+                Redrock redshift.
+            wave : :class:`list`
+                Three-element list of `numpy.ndarray` wavelength vectors, one for
+                each camera.    
+            flux : :class:`list`    
+                Three-element list of `numpy.ndarray` flux spectra, one for each
+                camera and corrected for Milky Way extinction.
+            ivar : :class:`list`    
+                Three-element list of `numpy.ndarray` inverse variance spectra, one
+                for each camera.    
+            res : :class:`list`
+                Three-element list of `desispec.resolution.Resolution` objects, one
+                for each camera.
+            snr : :class:`numpy.ndarray`
+                Median per-pixel signal-to-noise ratio in the grz cameras.
+            linemask : :class:`list`
+                Three-element list of `numpy.ndarray` boolean emission-line masks,
+                one for each camera. This mask is used during continuum-fitting.
+            coadd_wave : :class:`numpy.ndarray`
+                Coadded wavelength vector with all three cameras combined.
+            coadd_flux : :class:`numpy.ndarray`
+                Flux corresponding to `coadd_wave`.
+            coadd_ivar : :class:`numpy.ndarray`
+                Inverse variance corresponding to `coadd_flux`.
+            photsys_south : :class:`bool`
+                Boolean indicating whether this object is on the south (True) or
+                north (False) photometric system based on the declination cut coded
+                in `desitarget.io.desispec.resolution.Resolution`.
+            phot : :class:`astropy.table.Table`
+                Imaging photometry in `grzW1W2`, corrected for Milky Way extinction.
+            synthphot : :class:`astropy.table.Table`
+                Photometry in `grz` synthesized from the extinction-corrected
+                coadded spectra (with a mild extrapolation of the data blueward and
+                redward to accommodate the g-band and z-band filter curves,
+                respectively.
+
+        Notes
+        -----
+        Hard-coded to assume that all three cameras (grz) have spectra.
+
+        """
+        from desispec.io import read_spectra
+        from desispec.resolution import Resolution
+        from desiutil.dust import ext_odonnell
+        #from desitarget.io import desitarget_resolve_dec
+        from fastspecfit.util import C_LIGHT
+        
+        spec = read_spectra(self.specfile)#.select(targets=zb['TARGETID'])
+        if targetids is None:
+            targetids = self.zbest['TARGETID'].data
+
+        if ntargets is None:
+            ntargets = len(self.zbest)
+        if ntargets > len(self.zbest):
+            log.warning('ntargets exceeds the number of spectra.')
+            raise ValueError
+
+        targetids = targetids[firsttarget:firsttarget+ntargets]
+        self.fitindx = np.where([tid in targetids for tid in self.zbest['TARGETID']])[0]
+
+        self.zbest = self.zbest[self.fitindx]
+        self.fibermap = spec.fibermap[self.fitindx]
+
+        # Unpack the subset of objects we care about into a simple dictionary.
+        alldata = []
+        for indx in self.fitindx:
+            ra = spec.fibermap['TARGET_RA'][indx]
+            dec = spec.fibermap['TARGET_DEC'][indx]
+            ebv = CFit.SFDMap.ebv(ra, dec)
+
+            # Unpack the data and correct for Galactic extinction. Also flag pixels that
+            # may be affected by emission lines.
+            data = {'zredrock': self.zbest['Z'][indx], 'wave': [], 'flux': [], 'ivar': [],
+                    'res': [], 'linemask': [], 'snr': np.zeros(3).astype('f4')}
+            for icam, camera in enumerate(spec.bands):
+                dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(spec.wave[camera], Rv=CFit.RV))       
+                data['wave'].append(spec.wave[camera])
+                data['flux'].append(spec.flux[camera][indx, :] * dust)
+                data['ivar'].append(spec.ivar[camera][indx, :] / dust**2)
+                data['res'].append(Resolution(spec.resolution_data[camera][indx, :, :]))
+                data['snr'][icam] = np.median(spec.flux[camera][indx, :] * np.sqrt(spec.ivar[camera][indx, :]))
+
+                linemask = np.ones_like(spec.wave[camera], bool)
+                for line in CFit.linetable:
+                    zwave = line['restwave'] * (1 + data['zredrock'])
+                    I = np.where((spec.wave[camera] >= (zwave - 1.5*CFit.linemask_sigma * zwave / C_LIGHT)) *
+                                 (spec.wave[camera] <= (zwave + 1.5*CFit.linemask_sigma * zwave / C_LIGHT)))[0]
+                    if len(I) > 0:
+                        linemask[I] = False
+                data['linemask'].append(linemask)
+
+            # Synthesize photometry from a quick coadded (inverse-variance
+            # weighted) spectrum, being careful to resolve between the north and
+            # south.
+            coadd_wave = np.unique(np.hstack(data['wave']))
+            coadd_flux3d = np.zeros((len(coadd_wave), 3))
+            coadd_ivar3d = np.zeros_like(coadd_flux3d)
+            for icam in np.arange(len(spec.bands)):
+                I = np.where(np.isin(data['wave'][icam], coadd_wave))[0]
+                J = np.where(np.isin(coadd_wave, data['wave'][icam]))[0]
+                coadd_flux3d[J, icam] = data['flux'][icam][I]
+                coadd_ivar3d[J, icam] = data['ivar'][icam][I]
+
+            coadd_ivar = np.sum(coadd_ivar3d, axis=1)
+            coadd_flux = np.zeros_like(coadd_ivar)
+            good = np.where(coadd_ivar > 0)[0]
+            coadd_flux[good] = np.sum(coadd_ivar3d[good, :] * coadd_flux3d[good, :], axis=1) / coadd_ivar[good]
+            
+            #data.update({'coadd_wave': coadd_wave, 'coadd_flux': coadd_flux, 'coadd_ivar': coadd_ivar})
+            #del coadd_wave, coadd_ivar, coadd_flux
+
+            decsplit = self.desitarget_resolve_dec()
+            data['photsys_south'] = spec.fibermap['TARGET_DEC'][indx] < decsplit
+            if data['photsys_south']:
+                filters = CFit.decam
+                allfilters = CFit.decamwise
             else:
-                keep = np.where((zb['Z'] > 0) * (zb['ZWARN'] == 0) * (fmap['OBJTYPE'] == 'TGT') *
-                                (zb['SPECTYPE'] == 'GALAXY') * (fmap['FIBERSTATUS'] == 0))[0]
+                filters = CFit.bassmzls
+                allfilters = CFit.bassmzlswise            
 
-            if verbose:
-                log.debug('Spectrograph {}: N={}'.format(spectro, len(keep)))
-            if len(keep) > 0:
-                zbest.append(zb[keep])
-                keepindx.append(keep)
-                spectra.append(desispec.io.read_spectra(coaddfile))
+            padflux, padwave = filters.pad_spectrum(coadd_flux, coadd_wave, method='edge')
+            synthmaggies = filters.get_ab_maggies(padflux / CFit.fluxnorm, padwave)
+            synthmaggies = synthmaggies.as_array().view('f8')
 
-    if len(zbest) == 0:
-        log.fatal('No spectra found!')
-        raise ValueError
-        
-    # combine the spectrographs
-    #log.debug('Stacking all the spectra.')
-    zbest = vstack(zbest)
+            # code to synthesize uncertainties from the variance spectrum
+            #var, mask = _ivar2var(data['coadd_ivar'])
+            #padvar, padwave = filters.pad_spectrum(var[mask], data['coadd_wave'][mask], method='edge')
+            #synthvarmaggies = filters.get_ab_maggies(1e-17**2 * padvar, padwave)
+            #synthivarmaggies = 1 / synthvarmaggies.as_array().view('f8')[:3] # keep just grz
+            #
+            #data['synthphot'] = CFit.parse_photometry(
+            #    maggies=synthmaggies, lambda_eff=lambda_eff[:3],
+            #    ivarmaggies=synthivarmaggies, nanomaggies=False)
 
-    coadd = None
-    for camera in ('b', 'r', 'z'):
-        wave = spectra[0].wave[camera]
-        fm, flux, ivar, mask, res = [], [], [], [], []
-        for ii in np.arange(len(spectra)):
-            fm.append(spectra[ii].fibermap[keepindx[ii]])
-            flux.append(spectra[ii].flux[camera][keepindx[ii], :])
-            ivar.append(spectra[ii].ivar[camera][keepindx[ii], :])
-            mask.append(spectra[ii].mask[camera][keepindx[ii], :])
-            res.append(spectra[ii].resolution_data[camera][keepindx[ii], :, :])
+            data['synthphot'] = CFit.parse_photometry(
+                maggies=synthmaggies, nanomaggies=False,
+                lambda_eff=filters.effective_wavelengths.value)
 
-        fm = vstack(fm)
-        flux = np.concatenate(flux)
-        ivar = np.concatenate(ivar)
-        mask = np.concatenate(mask)
-        res = np.concatenate(res)
+            # Unpack the imaging photometry.
+            maggies = np.zeros(CFit.nband)
+            ivarmaggies = np.zeros(CFit.nband)
+            dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(allfilters.effective_wavelengths.value, Rv=CFit.RV))
 
-        _coadd = Spectra([camera], {camera: wave}, {camera: flux}, {camera : ivar}, 
-                         resolution_data={camera: res}, mask={camera: mask}, 
-                         fibermap=fm, single=False)#, meta=meta) 
-        if coadd is None:
-            coadd = _coadd
-        else:
-            coadd.update(_coadd)
+            for iband, band in enumerate(CFit.bands):
+                maggies[iband] = spec.fibermap['FLUX_{}'.format(band.upper())][indx] / dust[iband]
 
-    assert(np.all(zbest['TARGETID'] == coadd.fibermap['TARGETID']))
-    
-    log.info('Writing {} redshifts to {}'.format(len(zbest), zbestoutfile))
-    zbest.write(zbestoutfile, overwrite=True)
+                ivarcol = 'FLUX_IVAR_{}'.format(band.upper())
+                if ivarcol in spec.fibermap.colnames:
+                    ivarmaggies[iband] = spec.fibermap[ivarcol][indx] * dust[iband]**2
+                else:
+                    if maggies[iband] > 0:
+                        ivarmaggies[iband] = (10.0 / maggies [iband])**2 # constant S/N hack!!
 
-    log.info('Writing {} spectra to {}'.format(len(zbest), coaddoutfile))
-    desispec.io.write_spectra(coaddoutfile, coadd)
+            data['phot'] = CFit.parse_photometry(
+                maggies=maggies, ivarmaggies=ivarmaggies, nanomaggies=True,
+                lambda_eff=allfilters.effective_wavelengths.value)
 
-    return zbest, coadd
+            alldata.append(data)
 
-def _unpack_one_spectrum(args):
-    """Multiprocessing wrapper."""
-    return unpack_one_spectrum(*args)
-
-def unpack_one_spectrum(specobj, zbest, CFit, indx):
-    """Unpack and pre-process a single DESI spectrum.
-
-    Parameters
-    ----------
-    specobj : :class:`desispec.spectra.Spectra`
-        DESI spectra (in the standard format).
-    zbest : :class:`astropy.table.Table`
-        Redrock redshift table (row-aligned to `specobj`).
-    CFit : :class:`fastspecfit.continuum.ContinuumFit`
-        Continuum-fitting class which contains filter curves and some additional
-        photometric convenience functions.
-    indx : :class:`int`
-        Index number (0-indexed) of the spectrum to unpack and pre-process.
-    
-    Returns
-    -------
-    :class:`dict` with the following keys:
-        zredrock : :class:`numpy.float64`
-            Redrock redshift.
-        wave : :class:`list`
-            Three-element list of `numpy.ndarray` wavelength vectors, one for
-            each camera.    
-        flux : :class:`list`    
-            Three-element list of `numpy.ndarray` flux spectra, one for each
-            camera and corrected for Milky Way extinction.
-        ivar : :class:`list`    
-            Three-element list of `numpy.ndarray` inverse variance spectra, one
-            for each camera.    
-        res : :class:`list`
-            Three-element list of `desispec.resolution.Resolution` objects, one
-            for each camera.
-        snr : :class:`numpy.ndarray`
-            Median per-pixel signal-to-noise ratio in the grz cameras.
-        linemask : :class:`list`
-            Three-element list of `numpy.ndarray` boolean emission-line masks,
-            one for each camera. This mask is used during continuum-fitting.
-        coadd_wave : :class:`numpy.ndarray`
-            Coadded wavelength vector with all three cameras combined.
-        coadd_flux : :class:`numpy.ndarray`
-            Flux corresponding to `coadd_wave`.
-        coadd_ivar : :class:`numpy.ndarray`
-            Inverse variance corresponding to `coadd_flux`.
-        photsys_south : :class:`bool`
-            Boolean indicating whether this object is on the south (True) or
-            north (False) photometric system based on the declination cut coded
-            in `desitarget.io.desispec.resolution.Resolution`.
-        phot : :class:`astropy.table.Table`
-            Imaging photometry in `grzW1W2`, corrected for Milky Way extinction.
-        synthphot : :class:`astropy.table.Table`
-            Photometry in `grz` synthesized from the extinction-corrected
-            coadded spectra (with a mild extrapolation of the data blueward and
-            redward to accommodate the g-band and z-band filter curves,
-            respectively.
-
-    Notes
-    -----
-    Hard-coded to assume that all three cameras (grz) have spectra.
-
-    """
-    from desispec.resolution import Resolution
-    from desiutil.dust import ext_odonnell
-    from desitarget.io import desitarget_resolve_dec
-    from fastspecfit.util import C_LIGHT
-
-    cameras = ['b', 'r', 'z']
-    ncam = len(cameras)
-
-    ra = specobj.fibermap['TARGET_RA'][indx]
-    dec = specobj.fibermap['TARGET_DEC'][indx]
-    ebv = CFit.SFDMap.ebv(ra, dec)
-
-    # Unpack the data and correct for Galactic extinction. Also flag pixels that
-    # may be affected by emission lines.
-    data = {'zredrock': zbest['Z'][indx], 'wave': [], 'flux': [], 'ivar': [],
-            'res': [], 'linemask': [], 'snr': np.zeros(3).astype('f4')}
-    for icam, camera in enumerate(cameras):
-        dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(specobj.wave[camera], Rv=CFit.RV))       
-        data['wave'].append(specobj.wave[camera])
-        data['flux'].append(specobj.flux[camera][indx, :] * dust)
-        data['ivar'].append(specobj.ivar[camera][indx, :] / dust**2)
-        data['res'].append(Resolution(specobj.resolution_data[camera][indx, :, :]))
-        data['snr'][icam] = np.median(specobj.flux[camera][indx, :] * np.sqrt(specobj.ivar[camera][indx, :]))
-
-        linemask = np.ones_like(specobj.wave[camera], bool)
-        for line in CFit.linetable:
-            zwave = line['restwave'] * (1 + data['zredrock'])
-            I = np.where((specobj.wave[camera] >= (zwave - 1.5*CFit.linemask_sigma * zwave / C_LIGHT)) *
-                         (specobj.wave[camera] <= (zwave + 1.5*CFit.linemask_sigma * zwave / C_LIGHT)))[0]
-            if len(I) > 0:
-                linemask[I] = False
-        data['linemask'].append(linemask)
-
-    # Make a quick coadd using inverse variance weights.
-    uspecwave = np.unique(np.hstack(data['wave']))
-    uspecflux3d = np.zeros((len(uspecwave), 3))
-    uspecivar3d = np.zeros_like(uspecflux3d)
-    for icam in np.arange(ncam):
-        I = np.where(np.isin(data['wave'][icam], uspecwave))[0]
-        J = np.where(np.isin(uspecwave, data['wave'][icam]))[0]
-        uspecflux3d[J, icam] = data['flux'][icam][I]
-        uspecivar3d[J, icam] = data['ivar'][icam][I]
-
-    uspecivar = np.sum(uspecivar3d, axis=1)
-    uspecflux = np.zeros_like(uspecivar)
-    good = np.where(uspecivar > 0)[0]
-    uspecflux[good] = np.sum(uspecivar3d[good, :] * uspecflux3d[good, :], axis=1) / uspecivar[good]
-    data.update({'coadd_wave': uspecwave, 'coadd_flux': uspecflux, 'coadd_ivar': uspecivar})
-    del uspecwave, uspecivar, uspecflux
-
-    # Synthesize photometry, resolved into north and south.
-    split = desitarget_resolve_dec()
-    isouth = specobj.fibermap['TARGET_DEC'][indx] < split
-    if isouth:
-        filters = CFit.decamwise
-    else:
-        filters = CFit.bassmzlswise
-    lambda_eff = filters.effective_wavelengths.value
-    data['photsys_south'] = isouth
-
-    padflux, padwave = filters.pad_spectrum(data['coadd_flux'], data['coadd_wave'], method='edge')
-    synthmaggies = filters.get_ab_maggies(1e-17 * padflux, padwave)
-    synthmaggies = synthmaggies.as_array().view('f8')[:3] # keep just grz
-
-    # code to synthesize uncertainties from the variance spectrum
-    #var, mask = _ivar2var(data['coadd_ivar'])
-    #padvar, padwave = filters.pad_spectrum(var[mask], data['coadd_wave'][mask], method='edge')
-    #synthvarmaggies = filters.get_ab_maggies(1e-17**2 * padvar, padwave)
-    #synthivarmaggies = 1 / synthvarmaggies.as_array().view('f8')[:3] # keep just grz
-    #
-    #data['synthphot'] = CFit.parse_photometry(
-    #    maggies=synthmaggies, lambda_eff=lambda_eff[:3],
-    #    ivarmaggies=synthivarmaggies, nanomaggies=False)
-
-    data['synthphot'] = CFit.parse_photometry(
-        maggies=synthmaggies, lambda_eff=lambda_eff[:3],
-        nanomaggies=False)
-
-    # Unpack the imaging photometry.
-    bands = ['g', 'r', 'z', 'W1', 'W2']
-    maggies = np.zeros(len(bands))
-    ivarmaggies = np.zeros(len(bands))
-    dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(lambda_eff, Rv=CFit.RV))
-    
-    for iband, band in enumerate(bands):
-        maggies[iband] = specobj.fibermap['FLUX_{}'.format(band.upper())][indx] / dust[iband]
-
-        ivarcol = 'FLUX_IVAR_{}'.format(band.upper())
-        if ivarcol in specobj.fibermap.colnames:
-            ivarmaggies[iband] = specobj.fibermap[ivarcol][indx] * dust[iband]**2
-        else:
-            if maggies[iband] > 0:
-                ivarmaggies[iband] = (10.0 / maggies [iband])**2 # constant S/N hack!!
-    
-    data['phot'] = CFit.parse_photometry(
-        maggies=maggies, lambda_eff=lambda_eff,
-        ivarmaggies=ivarmaggies, nanomaggies=True)
-
-    return data
-
-def unpack_all_spectra(specobj, zbest, CFit, fitindx, nproc=1):
-    """Wrapper on unpack_one_spectrum to parse all the input spectra.
-
-    Parameters
-    ----------
-    specobj : :class:`desispec.spectra.Spectra`
-        DESI spectra (in the standard format).
-    zbest : :class:`astropy.table.Table`
-        Redrock redshift table (row-aligned to `specobj`).
-    CFit : :class:`fastspecfit.continuum.ContinuumFit`
-        Continuum-fitting class.
-    fitindx : :class:`int`
-        Index numbers of the spectra to unpack and pre-process.
-    nproc : :class:`int`, optional, defaults to 1
-        Number of cores to use for multiprocessing.
-    
-    Returns
-    -------
-    :class:`list`
-        List of dictionaries (row-aligned to `fitindx`) populated by
-        `unpack_one_spectrum`.
-        
-    Notes
-    -----
-
-    """
-    args = [(specobj, zbest, CFit, indx) for indx in fitindx]
-    if nproc > 1:
-        with multiprocessing.Pool(nproc) as P:
-            data = np.vstack(P.map(_unpack_one_spectrum, args))
-    else:
-        data = [unpack_one_spectrum(*_args) for _args in args]
-
-    return data    
+        return alldata
 
 def init_output(tile, night, zbest, fibermap, CFit, EMFit, photfit=False):
     """Initialize the fastspecfit output data table.
@@ -490,9 +369,6 @@ def parse(options=None):
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    # required
-    parser.add_argument('zbestfiles', nargs='*', type=str, help='Full path to input zbest file(s).')
-
     ## required but with sensible defaults
     #parser.add_argument('--night', default='20200225', type=str, help='Night to process.')
     #parser.add_argument('--tile', default='70502', type=str, help='Tile number to process.')
@@ -501,22 +377,25 @@ def parse(options=None):
     parser.add_argument('-o', '--outfile', type=str, default='.', help='Full path to output FITS file.')
 
     parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
-    parser.add_argument('--mintarget', type=int, help='Index of first object to to process in each file (0-indexed).')
+    parser.add_argument('--firsttarget', type=int, default=0, help='Index of first object to to process in each file (0-indexed).')
     parser.add_argument('--targetids', type=str, default=None, help='Comma-separated list of target IDs to process.')
     parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
 
     #parser.add_argument('--specprod', type=str, default='daily', choices=['andes', 'daily', 'variance-model'],
     #                    help='Spectroscopic production to process.')
 
+    parser.add_argument('--exposures', action='store_true', help='Fit the individual exposures (not the coadds).')
     parser.add_argument('--photfit', action='store_true', help='Fit and write out just the broadband photometry.')
     parser.add_argument('--solve-vdisp', action='store_true', help='Solve for the velocity disperion.')
+    parser.add_argument('--verbose', action='store_true', help='Be (more) verbose.')
 
     #parser.add_argument('--use-vi', action='store_true', help='Select spectra with high-quality visual inspections (VI).')
     #parser.add_argument('--overwrite', action='store_true', help='Overwrite any existing files.')
     #parser.add_argument('--mpi', action='store_true', help='Parallelize using MPI.')
     #parser.add_argument('--no-write-spectra', dest='write_spectra', default=True, action='store_false',
     #                    help='Do not write out the selected spectra for the specified tile and night.')
-    #parser.add_argument('--verbose', action='store_true', help='Be verbose.')
+
+    parser.add_argument('zbestfiles', nargs='*', help='Input zbest file(s).')
 
     if options is None:
         args = parser.parse_args()
@@ -560,46 +439,33 @@ def main(args=None, comm=None):
     #    log.info('Output file {} exists; all done!'.format(outfile))
     #    return
 
-    pdb.set_trace()
-    
-    # Read the data 
-    t0 = time.time()
-    zbest, specobj = read_spectra(tile=args.tile, night=args.night,
-                                  specprod=args.specprod,
-                                  use_vi=args.use_vi, 
-                                  write_spectra=args.write_spectra,
-                                  verbose=args.verbose)
-    log.info('Reading the data took: {:.2f} sec'.format(time.time()-t0))
+    if args.targetids:
+        targetids = [int(x) for x in args.targetids.split(",")]
+    else:
+        targetids = args.targetids
 
-    if args.first is None:
-        args.first = 0
-    if args.last is None:
-        args.last = len(zbest) - 1
-    if args.first > args.last:
-        log.warning('Option --first cannot be larger than --last!')
-        raise ValueError
-    fitindx = np.arange(args.last - args.first + 1) + args.first
-
-    # Initialize the continuum- and emission-line fitting classes and the output
-    # data table.
+    # Initialize the continuum- and emission-line fitting classes.
     t0 = time.time()
     CFit = ContinuumFit(verbose=args.verbose)
     EMFit = EMLineFit(verbose=args.verbose)
-    out = init_output(args.tile, args.night, zbest, specobj.fibermap, CFit, EMFit, photfit=args.photfit)
+    #out = init_output(args.tile, args.night, zbest, specobj.fibermap, CFit, EMFit, photfit=args.photfit)
     log.info('Initializing the classes took: {:.2f} sec'.format(time.time()-t0))
 
-    # Unpacking with multiprocessing takes a lot longer (maybe pickling takes a
-    # long time?) so suppress the `nproc` argument here for now.
-    t0 = time.time()
-    data = unpack_all_spectra(specobj, zbest, CFit, fitindx)#, nproc=args.nproc)
-    del specobj, zbest # free memory
-    log.info('Unpacking the spectra to be fitted took: {:.2f} sec'.format(time.time()-t0))
+    # Iteratively read the data.
+    for zbestfile in args.zbestfiles:
+        t0 = time.time()
+        DESISpec = DESISpectra(zbestfile, exposures=args.exposures)
+
+        data = DESISpec.read_and_unpack(CFit, firsttarget=args.firsttarget, targetids=targetids,
+                                        ntargets=args.ntargets, exposures=args.exposures)
+        out = init_output('80605', '20201215', DESISpec.zbest, DESISpec.fibermap, CFit, EMFit, photfit=args.photfit)
+        log.info('Reading and unpacking the spectra to be fitted took: {:.2f} sec'.format(time.time()-t0))
 
     # Fit in parallel
     fitargs = [(indx, data[iobj], CFit, EMFit, out[indx], args.photfit, args.solve_vdisp)
-               for iobj, indx in enumerate(fitindx)]
-    if args.nproc > 1:
-        with multiprocessing.Pool(args.nproc) as P:
+               for iobj, indx in enumerate(DESISpec.fitindx)]
+    if args.mp > 1:
+        with multiprocessing.Pool(args.mp) as P:
             _out = P.map(_fastspecfit_one, fitargs)
     else:
         _out = [fastspecfit_one(*_fitargs) for _fitargs in fitargs]
@@ -608,6 +474,9 @@ def main(args=None, comm=None):
 
     # write out
     t0 = time.time()
-    log.info('Writing results for {} objects to {}'.format(len(out), outfile))
-    out.write(outfile, overwrite=True)
+    log.info('Writing results for {} objects to {}'.format(len(out), args.outfile))
+    out.write(args.outfile, overwrite=True)
     log.info('Writing out took {:.2f} sec'.format(time.time()-t0))
+
+    pdb.set_trace()
+    

--- a/py/fastspecfit/external/desi.py
+++ b/py/fastspecfit/external/desi.py
@@ -109,6 +109,11 @@ class DESISpectra(object):
                 stileid = '{:06d}'.format(tileid)
                 fahdr = fitsio.read_header('/global/cfs/cdirs/desi/target/fiberassign/tiles/trunk/{}/fiberassign-{}.fits.gz'.format(stileid[:3], stileid))
                 hpdirname = fahdr['TARG']
+
+                # sometimes this is a KPNO directory!
+                if not os.path.isdir(hpdirname):
+                    log.info('Targets directory not found {}'.format(hpdirname))
+                    hpdirname = os.path.join(os.getenv('DESI_ROOT'), hpdirname.replace('/data/', ''))
                 log.info('Reading targets from {}'.format(hpdirname))
                 alltargets = read_targets_in_tiles(hpdirname, tiles=thistile, quick=True)
 

--- a/py/fastspecfit/external/desi.py
+++ b/py/fastspecfit/external/desi.py
@@ -10,9 +10,10 @@ fastspecfit-desi /global/cfs/cdirs/desi/spectro/redux/daily/tiles/80605/20201215
 """
 import pdb # for debugging
 
-import os, sys, time
+import os, time
 import numpy as np
-import multiprocessing
+import fitsio
+from astropy.table import Table
 
 from desiutil.log import get_logger
 log = get_logger()
@@ -53,21 +54,24 @@ def fastspecfit_one(iobj, data, CFit, EMFit, out, photfit=False, solve_vdisp=Fal
     return out
 
 class DESISpectra(object):
-    def __init__(self, zbestfile, exposures=False):
+    def __init__(self, zbestdir, exposures=False):
         """Class to read in the DESI data needed by fastspecfit.
 
         """
-        import fitsio
-        from astropy.table import Table
-        #from desispec.spectra import Spectra
+        from glob import glob
 
-        self.zbestfile = zbestfile
-
+        zbestfiles = np.array(sorted(glob(os.path.join(zbestdir, 'zbest-?-*-????????.fits'))))
+        if len(zbestfiles) == 0:
+            log.warning('No zbest-?-*-????????.fits files found in {}'.format(zbestdir))
+            raise IOError
+        
+        self.zbestfiles = zbestfiles
+        
         if exposures:
-            self.specfile = zbestfile.replace('zbest-', 'spectra-')
+            self.specfiles = [zbestfile.replace('zbest-', 'spectra-') for zbestfile in zbestfiles]
         else:
-            self.specfile = zbestfile.replace('zbest-', 'coadd-')            
-
+            self.specfiles = [zbestfile.replace('zbest-', 'coadd-') for zbestfile in zbestfiles]
+        
         # Hack! Gather tile and targets info.
         if False:
             tilefile = '/global/cfs/cdirs/desi/users/raichoor/fiberassign-sv1/sv1-tiles.fits'
@@ -81,24 +85,30 @@ class DESISpectra(object):
             targets = read_targets_in_tiles(hpdirname, tiles=thistile, quick=True)
             #rr = read_targets_in_cap('/global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/targets/sv1/resolve/dark', (36.448, -4.601, 1.5), quick=True)
 
-        # Read the zbest file and fibermap and select the objects to fit.
-        zb = fitsio.read(self.zbestfile, 'ZBEST')
-        #fm = fitsio.read(zbestfile, 'FIBERMAP')
-        fm = fitsio.read(self.specfile, 'FIBERMAP')
-        
-        if exposures:
-            pdb.set_trace()
-            _, I, _ = np.intersect1d(fm['TARGETID'], zb['TARGETID'], return_indices=True)            
-            fm = fm[I]
-            assert(np.all(zb['TARGETID'] == fm['TARGETID']))
-        else:
-            J = ((zb['Z'] > 0) * (zb['ZWARN'] == 0) * (zb['SPECTYPE'] == 'GALAXY') * 
-                 (fm['OBJTYPE'] == 'TGT') * (fm['FIBERSTATUS'] == 0))
-            self.fitindx = np.where(J)[0]
-            #zb = zb[J]
-            #fm = fm[J]
+        zbest = []
+        self.fitindx = []
+        for zbestfile, specfile in zip(self.zbestfiles, self.specfiles):
+            # Read the zbest file and fibermap and select the objects to fit.
+            zb = fitsio.read(zbestfile, 'ZBEST')
+            #fm = fitsio.read(zbestfile, 'FIBERMAP')
+            fm = fitsio.read(specfile, 'FIBERMAP')
 
-            self.zbest = Table(zb[self.fitindx])
+            if exposures:
+                pdb.set_trace()
+                _, I, _ = np.intersect1d(fm['TARGETID'], zb['TARGETID'], return_indices=True)            
+                fm = fm[I]
+                assert(np.all(zb['TARGETID'] == fm['TARGETID']))
+            else:
+                J = ((zb['Z'] > 0) * (zb['ZWARN'] == 0) * (zb['SPECTYPE'] == 'GALAXY') * 
+                     (fm['OBJTYPE'] == 'TGT') * (fm['FIBERSTATUS'] == 0))
+                fitindx = np.where(J)[0]
+                self.fitindx.append(fitindx)
+                #zb = zb[J]
+                #fm = fm[J]
+
+            zbest.append(zb[fitindx])
+
+        self.zbest = Table(np.hstack(zbest))
 
     @staticmethod
     def desitarget_resolve_dec():
@@ -169,18 +179,10 @@ class DESISpectra(object):
         """
         from desispec.resolution import Resolution
         from desiutil.dust import ext_odonnell
+        from desispec.io import read_spectra
         #from desitarget.io import desitarget_resolve_dec
         from fastspecfit.util import C_LIGHT
 
-        if photfit:
-            import fitsio
-            from astropy.table import Table
-            fibermap = Table(fitsio.read(self.specfile, ext='FIBERMAP'))
-        else:
-            from desispec.io import read_spectra
-            spec = read_spectra(self.specfile)#.select(targets=zb['TARGETID'])
-            fibermap = spec.fibermap
-            
         if targetids is None:
             targetids = self.zbest['TARGETID'].data
 
@@ -195,191 +197,197 @@ class DESISpectra(object):
 
         self.ntargets = len(these)
         self.zbest = self.zbest[these]
-        self.fitindx = self.fitindx[these]
-        self.fibermap = fibermap[self.fitindx]
-        assert(np.all(self.fibermap['TARGETID'] == self.zbest['TARGETID']))
+
+        #self.fitindx = self.fitindx[these]
+        #self.fibermap = fibermap[self.fitindx]
 
         # Unpack the subset of objects we care about into a simple dictionary.
         alldata = []
-        for igal, indx in enumerate(self.fitindx):
-            ra = self.fibermap['TARGET_RA'][igal]
-            dec = self.fibermap['TARGET_DEC'][igal]
-            ebv = CFit.SFDMap.ebv(ra, dec)
-
-            # Unpack the data and correct for Galactic extinction. Also flag pixels that
-            # may be affected by emission lines.
-            data = {'zredrock': self.zbest['Z'][igal], 'photsys_south': dec < self.desitarget_resolve_dec()}
-
-            if data['photsys_south']:
-                filters = CFit.decam
-                allfilters = CFit.decamwise
-            else:
-                filters = CFit.bassmzls
-                allfilters = CFit.bassmzlswise            
+        fibermaps = []
+        for specfile, fitindx in zip(self.specfiles, self.fitindx):
 
             if photfit:
-                # Unpack the imaging photometry.
-
-                maggies = np.zeros(CFit.nband)
-                ivarmaggies = np.zeros(CFit.nband)
-                dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(allfilters.effective_wavelengths.value, Rv=CFit.RV))
-
-                for iband, band in enumerate(CFit.bands):
-                    maggies[iband] = self.fibermap['FLUX_{}'.format(band.upper())][igal] / dust[iband]
-
-                    ivarcol = 'FLUX_IVAR_{}'.format(band.upper())
-                    if ivarcol in self.fibermap.colnames:
-                        ivarmaggies[iband] = self.fibermap[ivarcol][igal] * dust[iband]**2
-                    else:
-                        if maggies[iband] > 0:
-                            ivarmaggies[iband] = (10.0 / maggies [iband])**2 # constant S/N hack!!
-
-                data['phot'] = CFit.parse_photometry(
-                    maggies=maggies, ivarmaggies=ivarmaggies, nanomaggies=True,
-                    lambda_eff=allfilters.effective_wavelengths.value)
+                fibermap = Table(fitsio.read(specfile, ext='FIBERMAP'))
             else:
-                data.update({'wave': [], 'flux': [], 'ivar': [], 'res': [],
-                             'linemask': [], 'snr': np.zeros(3).astype('f4')})
-                for icam, camera in enumerate(spec.bands):
-                    dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(spec.wave[camera], Rv=CFit.RV))       
-                    data['wave'].append(spec.wave[camera])
-                    data['flux'].append(spec.flux[camera][indx, :] * dust)
-                    data['ivar'].append(spec.ivar[camera][indx, :] / dust**2)
-                    data['res'].append(Resolution(spec.resolution_data[camera][indx, :, :]))
-                    data['snr'][icam] = np.median(spec.flux[camera][indx, :] * np.sqrt(spec.ivar[camera][indx, :]))
+                spec = read_spectra(specfile)#.select(targets=zb['TARGETID'])
+                fibermap = spec.fibermap
 
-                    linemask = np.ones_like(spec.wave[camera], bool)
-                    for line in CFit.linetable:
-                        zwave = line['restwave'] * (1 + data['zredrock'])
-                        I = np.where((spec.wave[camera] >= (zwave - 1.5*CFit.linemask_sigma * zwave / C_LIGHT)) *
-                                     (spec.wave[camera] <= (zwave + 1.5*CFit.linemask_sigma * zwave / C_LIGHT)))[0]
-                        if len(I) > 0:
-                            linemask[I] = False
-                    data['linemask'].append(linemask)
+            these = np.where([tid in fibermap['TARGETID'] for tid in self.zbest['TARGETID']])[0]
+            if len(these) == 0:
+                continue
 
-                # Synthesize photometry from a quick coadded (inverse-variance
-                # weighted) spectrum, being careful to resolve between the north and
-                # south.
-                coadd_wave = np.unique(np.hstack(data['wave']))
-                coadd_flux3d = np.zeros((len(coadd_wave), 3))
-                coadd_ivar3d = np.zeros_like(coadd_flux3d)
-                for icam in np.arange(len(spec.bands)):
-                    I = np.where(np.isin(data['wave'][icam], coadd_wave))[0]
-                    J = np.where(np.isin(coadd_wave, data['wave'][icam]))[0]
-                    coadd_flux3d[J, icam] = data['flux'][icam][I]
-                    coadd_ivar3d[J, icam] = data['ivar'][icam][I]
+            fitindx = fitindx[these]
+            fibermap = fibermap[fitindx]
+            fibermaps.append(fibermap)
+            
+            for igal, indx in enumerate(fitindx):
+                ra = fibermap['TARGET_RA'][igal]
+                dec = fibermap['TARGET_DEC'][igal]
+                ebv = CFit.SFDMap.ebv(ra, dec)
 
-                coadd_ivar = np.sum(coadd_ivar3d, axis=1)
-                coadd_flux = np.zeros_like(coadd_ivar)
-                good = np.where(coadd_ivar > 0)[0]
-                coadd_flux[good] = np.sum(coadd_ivar3d[good, :] * coadd_flux3d[good, :], axis=1) / coadd_ivar[good]
+                # Unpack the data and correct for Galactic extinction. Also flag pixels that
+                # may be affected by emission lines.
+                data = {'zredrock': self.zbest['Z'][igal], 'photsys_south': dec < self.desitarget_resolve_dec()}
 
-                #data.update({'coadd_wave': coadd_wave, 'coadd_flux': coadd_flux, 'coadd_ivar': coadd_ivar})
-                #del coadd_wave, coadd_ivar, coadd_flux
+                if data['photsys_south']:
+                    filters = CFit.decam
+                    allfilters = CFit.decamwise
+                else:
+                    filters = CFit.bassmzls
+                    allfilters = CFit.bassmzlswise            
 
-                padflux, padwave = filters.pad_spectrum(coadd_flux, coadd_wave, method='edge')
-                synthmaggies = filters.get_ab_maggies(padflux / CFit.fluxnorm, padwave)
-                synthmaggies = synthmaggies.as_array().view('f8')
+                if photfit:
+                    # Unpack the imaging photometry.
 
-                # code to synthesize uncertainties from the variance spectrum
-                #var, mask = _ivar2var(data['coadd_ivar'])
-                #padvar, padwave = filters.pad_spectrum(var[mask], data['coadd_wave'][mask], method='edge')
-                #synthvarmaggies = filters.get_ab_maggies(1e-17**2 * padvar, padwave)
-                #synthivarmaggies = 1 / synthvarmaggies.as_array().view('f8')[:3] # keep just grz
-                #
-                #data['synthphot'] = CFit.parse_photometry(
-                #    maggies=synthmaggies, lambda_eff=lambda_eff[:3],
-                #    ivarmaggies=synthivarmaggies, nanomaggies=False)
+                    maggies = np.zeros(CFit.nband)
+                    ivarmaggies = np.zeros(CFit.nband)
+                    dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(allfilters.effective_wavelengths.value, Rv=CFit.RV))
 
-                data['synthphot'] = CFit.parse_photometry(
-                    maggies=synthmaggies, nanomaggies=False,
-                    lambda_eff=filters.effective_wavelengths.value)
+                    for iband, band in enumerate(CFit.bands):
+                        maggies[iband] = fibermap['FLUX_{}'.format(band.upper())][igal] / dust[iband]
 
-            alldata.append(data)
+                        ivarcol = 'FLUX_IVAR_{}'.format(band.upper())
+                        if ivarcol in fibermap.colnames:
+                            ivarmaggies[iband] = fibermap[ivarcol][igal] * dust[iband]**2
+                        else:
+                            if maggies[iband] > 0:
+                                ivarmaggies[iband] = (10.0 / maggies [iband])**2 # constant S/N hack!!
+
+                    data['phot'] = CFit.parse_photometry(
+                        maggies=maggies, ivarmaggies=ivarmaggies, nanomaggies=True,
+                        lambda_eff=allfilters.effective_wavelengths.value)
+                else:
+                    data.update({'wave': [], 'flux': [], 'ivar': [], 'res': [],
+                                 'linemask': [], 'snr': np.zeros(3).astype('f4')})
+                    for icam, camera in enumerate(spec.bands):
+                        dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(spec.wave[camera], Rv=CFit.RV))       
+                        data['wave'].append(spec.wave[camera])
+                        data['flux'].append(spec.flux[camera][indx, :] * dust)
+                        data['ivar'].append(spec.ivar[camera][indx, :] / dust**2)
+                        data['res'].append(Resolution(spec.resolution_data[camera][indx, :, :]))
+                        data['snr'][icam] = np.median(spec.flux[camera][indx, :] * np.sqrt(spec.ivar[camera][indx, :]))
+
+                        linemask = np.ones_like(spec.wave[camera], bool)
+                        for line in CFit.linetable:
+                            zwave = line['restwave'] * (1 + data['zredrock'])
+                            I = np.where((spec.wave[camera] >= (zwave - 1.5*CFit.linemask_sigma * zwave / C_LIGHT)) *
+                                         (spec.wave[camera] <= (zwave + 1.5*CFit.linemask_sigma * zwave / C_LIGHT)))[0]
+                            if len(I) > 0:
+                                linemask[I] = False
+                        data['linemask'].append(linemask)
+
+                    # Synthesize photometry from a quick coadded (inverse-variance
+                    # weighted) spectrum, being careful to resolve between the north and
+                    # south.
+                    coadd_wave = np.unique(np.hstack(data['wave']))
+                    coadd_flux3d = np.zeros((len(coadd_wave), 3))
+                    coadd_ivar3d = np.zeros_like(coadd_flux3d)
+                    for icam in np.arange(len(spec.bands)):
+                        I = np.where(np.isin(data['wave'][icam], coadd_wave))[0]
+                        J = np.where(np.isin(coadd_wave, data['wave'][icam]))[0]
+                        coadd_flux3d[J, icam] = data['flux'][icam][I]
+                        coadd_ivar3d[J, icam] = data['ivar'][icam][I]
+
+                    coadd_ivar = np.sum(coadd_ivar3d, axis=1)
+                    coadd_flux = np.zeros_like(coadd_ivar)
+                    good = np.where(coadd_ivar > 0)[0]
+                    coadd_flux[good] = np.sum(coadd_ivar3d[good, :] * coadd_flux3d[good, :], axis=1) / coadd_ivar[good]
+
+                    #data.update({'coadd_wave': coadd_wave, 'coadd_flux': coadd_flux, 'coadd_ivar': coadd_ivar})
+                    #del coadd_wave, coadd_ivar, coadd_flux
+
+                    padflux, padwave = filters.pad_spectrum(coadd_flux, coadd_wave, method='edge')
+                    synthmaggies = filters.get_ab_maggies(padflux / CFit.fluxnorm, padwave)
+                    synthmaggies = synthmaggies.as_array().view('f8')
+
+                    # code to synthesize uncertainties from the variance spectrum
+                    #var, mask = _ivar2var(data['coadd_ivar'])
+                    #padvar, padwave = filters.pad_spectrum(var[mask], data['coadd_wave'][mask], method='edge')
+                    #synthvarmaggies = filters.get_ab_maggies(1e-17**2 * padvar, padwave)
+                    #synthivarmaggies = 1 / synthvarmaggies.as_array().view('f8')[:3] # keep just grz
+                    #
+                    #data['synthphot'] = CFit.parse_photometry(
+                    #    maggies=synthmaggies, lambda_eff=lambda_eff[:3],
+                    #    ivarmaggies=synthivarmaggies, nanomaggies=False)
+
+                    data['synthphot'] = CFit.parse_photometry(
+                        maggies=synthmaggies, nanomaggies=False,
+                        lambda_eff=filters.effective_wavelengths.value)
+
+                alldata.append(data)
+
+        #self.fitindx = np.hstack(fitindxs)
+        self.fibermap = Table(np.hstack(fibermaps))
+        assert(np.all(self.fibermap['TARGETID'] == self.zbest['TARGETID']))
 
         return alldata
+        
+    def init_output(self, CFit, EMFit, photfit=False):
+        """Initialize the fastspecfit output data table.
 
-def init_output(tile, night, zbest, fibermap, CFit, EMFit, photfit=False):
-    """Initialize the fastspecfit output data table.
+        Parameters
+        ----------
+        tile : :class:`str`
+            Tile number.
+        night : :class:`str`
+            Night on which `tile` was observed.
+        zbest : :class:`astropy.table.Table`
+            Redrock redshift table (row-aligned to `fibermap`).
+        fibermap : :class:`astropy.table.Table`
+            Fiber map (row-aligned to `zbest`).
+        CFit : :class:`fastspecfit.continuum.ContinuumFit`
+            Continuum-fitting class.
+        EMFit : :class:`fastspecfit.emlines.EMLineFit`
+            Emission-line fitting class.
 
-    Parameters
-    ----------
-    tile : :class:`str`
-        Tile number.
-    night : :class:`str`
-        Night on which `tile` was observed.
-    zbest : :class:`astropy.table.Table`
-        Redrock redshift table (row-aligned to `fibermap`).
-    fibermap : :class:`astropy.table.Table`
-        Fiber map (row-aligned to `zbest`).
-    CFit : :class:`fastspecfit.continuum.ContinuumFit`
-        Continuum-fitting class.
-    EMFit : :class:`fastspecfit.emlines.EMLineFit`
-        Emission-line fitting class.
+        Returns
+        -------
 
-    Returns
-    -------
-    
 
-    Notes
-    -----
+        Notes
+        -----
 
-    """
-    from astropy.table import Table, Column, hstack
+        """
+        from astropy.table import hstack
 
-    # Grab info on the emission lines and the continuum.
-    nobj = len(zbest)
+        # Grab info on the emission lines and the continuum.
+        nobj = len(self.zbest)
 
-    out = Table()
-    for zbestcol in ['TARGETID', 'Z']:#, 'ZERR']:#, 'SPECTYPE', 'DELTACHI2']
-        out[zbestcol] = zbest[zbestcol]
-    for fibermapcol in ['FIBER']:
-        out[fibermapcol] = fibermap[fibermapcol]
-    out.add_column(Column(name='NIGHT', data=np.repeat(night, nobj)), index=0)
-    out.add_column(Column(name='TILE', data=np.repeat(tile, nobj)), index=0)
+        out = Table()
+        for fibermapcol in ['NIGHT', 'TILEID', 'FIBER']:
+            out[fibermapcol] = self.fibermap[fibermapcol]
+        for zbestcol in ['TARGETID', 'Z']:#, 'ZERR']:#, 'SPECTYPE', 'DELTACHI2']
+            out[zbestcol] = self.zbest[zbestcol]
 
-    if photfit:
-        out = hstack((out, CFit.init_phot_output(nobj)))
-    else:
-        out = hstack((out, CFit.init_spec_output(nobj), EMFit.init_output(CFit.linetable, nobj)))
+        if photfit:
+            out = hstack((out, CFit.init_phot_output(nobj)))
+        else:
+            out = hstack((out, CFit.init_spec_output(nobj), EMFit.init_output(CFit.linetable, nobj)))
 
-    return out
+        return out
 
 def parse(options=None):
     """Parse input arguments.
 
     """
-    import argparse
+    import argparse, sys
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    ## required but with sensible defaults
-    #parser.add_argument('--night', default='20200225', type=str, help='Night to process.')
-    #parser.add_argument('--tile', default='70502', type=str, help='Tile number to process.')
-
-    # optional inputs
-    parser.add_argument('-o', '--outfile', type=str, default='.', help='Full path to output FITS file.')
+    parser.add_argument('-z', '--zbestdir', type=str, default='.', help='Full path to input zbest file(s).')
+    parser.add_argument('-o', '--outdir', type=str, default='.', help='Full path to output files.')
 
     parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
     parser.add_argument('--firsttarget', type=int, default=0, help='Index of first object to to process in each file (0-indexed).')
     parser.add_argument('--targetids', type=str, default=None, help='Comma-separated list of target IDs to process.')
     parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
-
-    #parser.add_argument('--specprod', type=str, default='daily', choices=['andes', 'daily', 'variance-model'],
-    #                    help='Spectroscopic production to process.')
+    parser.add_argument('--suffix', type=str, default=None, help='Optional suffix for output filename.')
 
     parser.add_argument('--exposures', action='store_true', help='Fit the individual exposures (not the coadds).')
+
     parser.add_argument('--photfit', action='store_true', help='Fit and write out just the broadband photometry.')
     parser.add_argument('--solve-vdisp', action='store_true', help='Solve for the velocity disperion.')
     parser.add_argument('--verbose', action='store_true', help='Be (more) verbose.')
-
-    #parser.add_argument('--use-vi', action='store_true', help='Select spectra with high-quality visual inspections (VI).')
-    #parser.add_argument('--overwrite', action='store_true', help='Overwrite any existing files.')
-    #parser.add_argument('--mpi', action='store_true', help='Parallelize using MPI.')
-    #parser.add_argument('--no-write-spectra', dest='write_spectra', default=True, action='store_false',
-    #                    help='Do not write out the selected spectra for the specified tile and night.')
-
-    parser.add_argument('zbestfiles', nargs='*', help='Input zbest file(s).')
 
     if options is None:
         args = parser.parse_args()
@@ -394,12 +402,14 @@ def main(args=None, comm=None):
     """Main module.
 
     """
-    from astropy.table import vstack
     from fastspecfit.continuum import ContinuumFit
     from fastspecfit.emlines import EMLineFit
 
     if isinstance(args, (list, tuple, type(None))):
         args = parse(args)
+
+    if not os.path.isdir(args.outdir):
+        os.makedirs(args.outdir, exist_ok=True)
 
     ## Create directories as needed.
     #fastspecfit_dir = os.getenv('FASTSPECFIT_DATA')
@@ -432,35 +442,43 @@ def main(args=None, comm=None):
     t0 = time.time()
     CFit = ContinuumFit(verbose=args.verbose)
     EMFit = EMLineFit(verbose=args.verbose)
-    #out = init_output(args.tile, args.night, zbest, specobj.fibermap, CFit, EMFit, photfit=args.photfit)
     log.info('Initializing the classes took: {:.2f} sec'.format(time.time()-t0))
 
-    # Iteratively read the data.
-    for zbestfile in args.zbestfiles:
-        t0 = time.time()
-        DESISpec = DESISpectra(zbestfile, exposures=args.exposures)
+    # Read the data.
+    t0 = time.time()
+    DESISpec = DESISpectra(args.zbestdir, exposures=args.exposures)
 
-        data = DESISpec.read_and_unpack(CFit, firsttarget=args.firsttarget, targetids=targetids,
-                                        ntargets=args.ntargets, exposures=args.exposures,
-                                        photfit=args.photfit)
-        print('Hacked output!!')
-        out = init_output('80605', '20201215', DESISpec.zbest, DESISpec.fibermap, CFit, EMFit, photfit=args.photfit)
-        log.info('Reading and unpacking the spectra to be fitted took: {:.2f} sec'.format(time.time()-t0))
+    data = DESISpec.read_and_unpack(CFit, firsttarget=args.firsttarget, targetids=targetids,
+                                    ntargets=args.ntargets, exposures=args.exposures,
+                                    photfit=args.photfit)
+    out = DESISpec.init_output(CFit, EMFit, photfit=args.photfit)
+    log.info('Reading and unpacking the spectra to be fitted took: {:.2f} sec'.format(time.time()-t0))
 
     # Fit in parallel
     fitargs = [(iobj, data[iobj], CFit, EMFit, out[iobj], args.photfit, args.solve_vdisp)
                for iobj in np.arange(DESISpec.ntargets)]
     if args.mp > 1:
+        import multiprocessing
         with multiprocessing.Pool(args.mp) as P:
             _out = P.map(_fastspecfit_one, fitargs)
     else:
         _out = [fastspecfit_one(*_fitargs) for _fitargs in fitargs]
-    out = vstack(_out)
+    out = Table(np.hstack(_out))
     del _out
 
     # write out
     t0 = time.time()
-    log.info('Writing results for {} objects to {}'.format(len(out), args.outfile))
-    out.write(args.outfile, overwrite=True)
+    if args.photfit:
+        prefix = 'photfit'
+    else:
+        prefix = 'specfit'
+    if args.suffix:
+        suffix = '-{}'.format(args.suffix)
+    else:
+        suffix = ''
+        
+    outfile = os.path.join(args.outdir, '{}{}.fits'.format(prefix, suffix))
+    log.info('Writing results for {} objects to {}'.format(len(out), outfile))
+    out.write(outfile, overwrite=True)
     log.info('Writing out took {:.2f} sec'.format(time.time()-t0))
     

--- a/sandbox/sandbox.py
+++ b/sandbox/sandbox.py
@@ -1,0 +1,355 @@
+def read_spectra(tile, night, specprod='andes', use_vi=False, write_spectra=True,
+                 overwrite=False, verbose=False):
+    """Read the spectra and redshift catalog for a given tile and night.
+
+    Parameters
+    ----------
+    tile : :class:`str`
+        Tile number to analyze.
+    night : :class:`str`
+        Night on which `tile` was observed.
+    specprod : :class:`str`, defaults to `andes`.
+        Spectroscopic production to read.
+    use_vi : :class:`bool`, optional, defaults to False
+        Select the subset of spectra with high-quality visual inspections.
+    write_spectra : :class:`bool`, optional, defaults to True
+        Write out the selected spectra (useful for testing.)
+    overwrite : :class:`bool`, optional, defaults to False
+        Overwrite output files if they exist on-disk.
+    verbose : :class:`bool`, optional, defaults to False
+        Trigger more verbose output.
+
+    Returns
+    -------
+    :class:`astropy.table.Table`
+        Redrock redshift table for the given tile and night.
+    :class:`desispec.spectra.Spectra`
+        DESI spectra for the given tile and night (in the standard format).
+
+    Notes
+    -----
+    The spectra from all 10 spectrographs are combined and only the subset of
+    galaxy spectra with good redshifts (and, optionally, high-quality visual
+    inspections) are returned.
+
+    """
+    import fitsio
+    from astropy.table import Table, vstack
+    from desispec.spectra import Spectra
+    import desispec.io
+    from desitarget.io import read_targets_in_tiles
+
+    if False:
+        hpdirname = '/global/cfs/cdirs/desi/target/catalogs/dr9/0.47.0/targets/sv1/resolve/dark'
+        print('Assuming hpdirname={}'.format(hpdirname))
+        from desimodel.io import load_tiles
+        tileinfo = load_tiles()
+        tileinfo = tileinfo[tileinfo['TILEID'] == tile]
+
+    data_dir = os.path.join(os.getenv('FASTSPECFIT_DATA'), 'spectra', specprod)
+    zbestoutfile = os.path.join(data_dir, 'zbest-{}-{}.fits'.format(tile, night))
+    coaddoutfile = os.path.join(data_dir, 'coadd-{}-{}.fits'.format(tile, night))
+    if os.path.isfile(coaddoutfile) and not overwrite:
+        zbest = Table(fitsio.read(zbestoutfile))
+        log.info('Read {} redshifts from {}'.format(len(zbest), zbestoutfile))
+
+        coadd = desispec.io.read_spectra(coaddoutfile)
+        log.info('Read {} spectra from {}'.format(len(zbest), coaddoutfile))
+
+        assert(np.all(zbest['TARGETID'] == coadd.fibermap['TARGETID']))
+        return zbest, coadd
+
+    log.info('Parsing tile, night {}, {} from specprod {}'.format(tile, night, specprod))
+
+    specprod_dir = os.path.join(os.getenv('DESI_ROOT'), 'spectro', 'redux', specprod)
+    desidatadir = os.path.join(specprod_dir, 'tiles', tile, night)
+
+    # use visual inspection results?
+    if use_vi:
+        truthdir = os.path.join(os.getenv('DESI_ROOT'), 'sv', 'vi', 'TruthTables')
+        tile2file = {
+            '66003': os.path.join(truthdir, 'truth_table_BGS_v1.2.csv'),
+            '70500': os.path.join(truthdir, 'truth_table_ELG_v1.2_latest.csv'),
+            }
+        if tile not in tile2file.keys():
+            log.warning('No (known) truth file exists for tile {}. Setting use_vi=False.'.format(tile))
+            use_vi = False
+        else:
+            truth = Table.read(truthfile)
+            best = np.where(
+                (truth['best quality'] >= 2.5) * 
+                (truth['Redrock spectype'] == 'GALAXY')# *
+                #(truth['Redrock z'] < 0.75) 
+            )[0]
+            #goodobj = np.where((zb['DELTACHI2'] > 100) * (zb['ZWARN'] == 0) * (zb['SPECTYPE'] == 'GALAXY'))[0]
+
+            log.info('Read {}/{} good redshifts from {}'.format(len(best), len(truth), truthfile))
+            truth = truth[best]
+    
+    zbest = []
+    spectra, keepindx = [], []
+    if False:
+        targets = read_targets_in_tiles(tiles=np.atleast_1d(tileinfo), hpdirname=hpdirname, quick=True)
+    
+    #for spectro in ('0'):
+    for spectro in ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9'):
+        zbestfile = os.path.join(desidatadir, 'zbest-{}-{}-{}.fits'.format(spectro, tile, night))
+        coaddfile = os.path.join(desidatadir, 'coadd-{}-{}-{}.fits'.format(spectro, tile, night))
+        if os.path.isfile(zbestfile) and os.path.isfile(coaddfile):
+            zb = Table(fitsio.read(zbestfile))
+            fmap = fitsio.read(coaddfile, ext='FIBERMAP', columns=['FIBERSTATUS', 'OBJTYPE'])
+            if use_vi:
+                keep = np.where(np.isin(zb['TARGETID'], truth['TARGETID']))[0]
+            else:
+                keep = np.where((zb['Z'] > 0) * (zb['ZWARN'] == 0) * (fmap['OBJTYPE'] == 'TGT') *
+                                (zb['SPECTYPE'] == 'GALAXY') * (fmap['FIBERSTATUS'] == 0))[0]
+
+            if verbose:
+                log.debug('Spectrograph {}: N={}'.format(spectro, len(keep)))
+            if len(keep) > 0:
+                zbest.append(zb[keep])
+                keepindx.append(keep)
+                spectra.append(desispec.io.read_spectra(coaddfile))
+
+    if len(zbest) == 0:
+        log.fatal('No spectra found!')
+        raise ValueError
+        
+    # combine the spectrographs
+    #log.debug('Stacking all the spectra.')
+    zbest = vstack(zbest)
+
+    coadd = None
+    for camera in ('b', 'r', 'z'):
+        wave = spectra[0].wave[camera]
+        fm, flux, ivar, mask, res = [], [], [], [], []
+        for ii in np.arange(len(spectra)):
+            fm.append(spectra[ii].fibermap[keepindx[ii]])
+            flux.append(spectra[ii].flux[camera][keepindx[ii], :])
+            ivar.append(spectra[ii].ivar[camera][keepindx[ii], :])
+            mask.append(spectra[ii].mask[camera][keepindx[ii], :])
+            res.append(spectra[ii].resolution_data[camera][keepindx[ii], :, :])
+
+        fm = vstack(fm)
+        flux = np.concatenate(flux)
+        ivar = np.concatenate(ivar)
+        mask = np.concatenate(mask)
+        res = np.concatenate(res)
+
+        _coadd = Spectra([camera], {camera: wave}, {camera: flux}, {camera : ivar}, 
+                         resolution_data={camera: res}, mask={camera: mask}, 
+                         fibermap=fm, single=False)#, meta=meta) 
+        if coadd is None:
+            coadd = _coadd
+        else:
+            coadd.update(_coadd)
+
+    assert(np.all(zbest['TARGETID'] == coadd.fibermap['TARGETID']))
+    
+    log.info('Writing {} redshifts to {}'.format(len(zbest), zbestoutfile))
+    zbest.write(zbestoutfile, overwrite=True)
+
+    log.info('Writing {} spectra to {}'.format(len(zbest), coaddoutfile))
+    desispec.io.write_spectra(coaddoutfile, coadd)
+
+    return zbest, coadd
+
+def _unpack_one_spectrum(args):
+    """Multiprocessing wrapper."""
+    return unpack_one_spectrum(*args)
+
+def unpack_one_spectrum(specobj, zbest, CFit, indx):
+    """Unpack and pre-process a single DESI spectrum.
+
+    Parameters
+    ----------
+    specobj : :class:`desispec.spectra.Spectra`
+        DESI spectra (in the standard format).
+    zbest : :class:`astropy.table.Table`
+        Redrock redshift table (row-aligned to `specobj`).
+    CFit : :class:`fastspecfit.continuum.ContinuumFit`
+        Continuum-fitting class which contains filter curves and some additional
+        photometric convenience functions.
+    indx : :class:`int`
+        Index number (0-indexed) of the spectrum to unpack and pre-process.
+    
+    Returns
+    -------
+    :class:`dict` with the following keys:
+        zredrock : :class:`numpy.float64`
+            Redrock redshift.
+        wave : :class:`list`
+            Three-element list of `numpy.ndarray` wavelength vectors, one for
+            each camera.    
+        flux : :class:`list`    
+            Three-element list of `numpy.ndarray` flux spectra, one for each
+            camera and corrected for Milky Way extinction.
+        ivar : :class:`list`    
+            Three-element list of `numpy.ndarray` inverse variance spectra, one
+            for each camera.    
+        res : :class:`list`
+            Three-element list of `desispec.resolution.Resolution` objects, one
+            for each camera.
+        snr : :class:`numpy.ndarray`
+            Median per-pixel signal-to-noise ratio in the grz cameras.
+        linemask : :class:`list`
+            Three-element list of `numpy.ndarray` boolean emission-line masks,
+            one for each camera. This mask is used during continuum-fitting.
+        coadd_wave : :class:`numpy.ndarray`
+            Coadded wavelength vector with all three cameras combined.
+        coadd_flux : :class:`numpy.ndarray`
+            Flux corresponding to `coadd_wave`.
+        coadd_ivar : :class:`numpy.ndarray`
+            Inverse variance corresponding to `coadd_flux`.
+        photsys_south : :class:`bool`
+            Boolean indicating whether this object is on the south (True) or
+            north (False) photometric system based on the declination cut coded
+            in `desitarget.io.desispec.resolution.Resolution`.
+        phot : :class:`astropy.table.Table`
+            Imaging photometry in `grzW1W2`, corrected for Milky Way extinction.
+        synthphot : :class:`astropy.table.Table`
+            Photometry in `grz` synthesized from the extinction-corrected
+            coadded spectra (with a mild extrapolation of the data blueward and
+            redward to accommodate the g-band and z-band filter curves,
+            respectively.
+
+    Notes
+    -----
+    Hard-coded to assume that all three cameras (grz) have spectra.
+
+    """
+    from desispec.resolution import Resolution
+    from desiutil.dust import ext_odonnell
+    from desitarget.io import desitarget_resolve_dec
+    from fastspecfit.util import C_LIGHT
+
+    cameras = ['b', 'r', 'z']
+    ncam = len(cameras)
+
+    ra = specobj.fibermap['TARGET_RA'][indx]
+    dec = specobj.fibermap['TARGET_DEC'][indx]
+    ebv = CFit.SFDMap.ebv(ra, dec)
+
+    # Unpack the data and correct for Galactic extinction. Also flag pixels that
+    # may be affected by emission lines.
+    data = {'zredrock': zbest['Z'][indx], 'wave': [], 'flux': [], 'ivar': [],
+            'res': [], 'linemask': [], 'snr': np.zeros(3).astype('f4')}
+    for icam, camera in enumerate(cameras):
+        dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(specobj.wave[camera], Rv=CFit.RV))       
+        data['wave'].append(specobj.wave[camera])
+        data['flux'].append(specobj.flux[camera][indx, :] * dust)
+        data['ivar'].append(specobj.ivar[camera][indx, :] / dust**2)
+        data['res'].append(Resolution(specobj.resolution_data[camera][indx, :, :]))
+        data['snr'][icam] = np.median(specobj.flux[camera][indx, :] * np.sqrt(specobj.ivar[camera][indx, :]))
+
+        linemask = np.ones_like(specobj.wave[camera], bool)
+        for line in CFit.linetable:
+            zwave = line['restwave'] * (1 + data['zredrock'])
+            I = np.where((specobj.wave[camera] >= (zwave - 1.5*CFit.linemask_sigma * zwave / C_LIGHT)) *
+                         (specobj.wave[camera] <= (zwave + 1.5*CFit.linemask_sigma * zwave / C_LIGHT)))[0]
+            if len(I) > 0:
+                linemask[I] = False
+        data['linemask'].append(linemask)
+
+    # Make a quick coadd using inverse variance weights.
+    uspecwave = np.unique(np.hstack(data['wave']))
+    uspecflux3d = np.zeros((len(uspecwave), 3))
+    uspecivar3d = np.zeros_like(uspecflux3d)
+    for icam in np.arange(ncam):
+        I = np.where(np.isin(data['wave'][icam], uspecwave))[0]
+        J = np.where(np.isin(uspecwave, data['wave'][icam]))[0]
+        uspecflux3d[J, icam] = data['flux'][icam][I]
+        uspecivar3d[J, icam] = data['ivar'][icam][I]
+
+    uspecivar = np.sum(uspecivar3d, axis=1)
+    uspecflux = np.zeros_like(uspecivar)
+    good = np.where(uspecivar > 0)[0]
+    uspecflux[good] = np.sum(uspecivar3d[good, :] * uspecflux3d[good, :], axis=1) / uspecivar[good]
+    data.update({'coadd_wave': uspecwave, 'coadd_flux': uspecflux, 'coadd_ivar': uspecivar})
+    del uspecwave, uspecivar, uspecflux
+
+    # Synthesize photometry, resolved into north and south.
+    split = desitarget_resolve_dec()
+    isouth = specobj.fibermap['TARGET_DEC'][indx] < split
+    if isouth:
+        filters = CFit.decamwise
+    else:
+        filters = CFit.bassmzlswise
+    lambda_eff = filters.effective_wavelengths.value
+    data['photsys_south'] = isouth
+
+    padflux, padwave = filters.pad_spectrum(data['coadd_flux'], data['coadd_wave'], method='edge')
+    synthmaggies = filters.get_ab_maggies(1e-17 * padflux, padwave)
+    synthmaggies = synthmaggies.as_array().view('f8')[:3] # keep just grz
+
+    # code to synthesize uncertainties from the variance spectrum
+    #var, mask = _ivar2var(data['coadd_ivar'])
+    #padvar, padwave = filters.pad_spectrum(var[mask], data['coadd_wave'][mask], method='edge')
+    #synthvarmaggies = filters.get_ab_maggies(1e-17**2 * padvar, padwave)
+    #synthivarmaggies = 1 / synthvarmaggies.as_array().view('f8')[:3] # keep just grz
+    #
+    #data['synthphot'] = CFit.parse_photometry(
+    #    maggies=synthmaggies, lambda_eff=lambda_eff[:3],
+    #    ivarmaggies=synthivarmaggies, nanomaggies=False)
+
+    data['synthphot'] = CFit.parse_photometry(
+        maggies=synthmaggies, lambda_eff=lambda_eff[:3],
+        nanomaggies=False)
+
+    # Unpack the imaging photometry.
+    bands = ['g', 'r', 'z', 'W1', 'W2']
+    maggies = np.zeros(len(bands))
+    ivarmaggies = np.zeros(len(bands))
+    dust = 10**(-0.4 * ebv * CFit.RV * ext_odonnell(lambda_eff, Rv=CFit.RV))
+    
+    for iband, band in enumerate(bands):
+        maggies[iband] = specobj.fibermap['FLUX_{}'.format(band.upper())][indx] / dust[iband]
+
+        ivarcol = 'FLUX_IVAR_{}'.format(band.upper())
+        if ivarcol in specobj.fibermap.colnames:
+            ivarmaggies[iband] = specobj.fibermap[ivarcol][indx] * dust[iband]**2
+        else:
+            if maggies[iband] > 0:
+                ivarmaggies[iband] = (10.0 / maggies [iband])**2 # constant S/N hack!!
+    
+    data['phot'] = CFit.parse_photometry(
+        maggies=maggies, lambda_eff=lambda_eff,
+        ivarmaggies=ivarmaggies, nanomaggies=True)
+
+    return data
+
+def unpack_all_spectra(specobj, zbest, CFit, fitindx, nproc=1):
+    """Wrapper on unpack_one_spectrum to parse all the input spectra.
+
+    Parameters
+    ----------
+    specobj : :class:`desispec.spectra.Spectra`
+        DESI spectra (in the standard format).
+    zbest : :class:`astropy.table.Table`
+        Redrock redshift table (row-aligned to `specobj`).
+    CFit : :class:`fastspecfit.continuum.ContinuumFit`
+        Continuum-fitting class.
+    fitindx : :class:`int`
+        Index numbers of the spectra to unpack and pre-process.
+    nproc : :class:`int`, optional, defaults to 1
+        Number of cores to use for multiprocessing.
+    
+    Returns
+    -------
+    :class:`list`
+        List of dictionaries (row-aligned to `fitindx`) populated by
+        `unpack_one_spectrum`.
+        
+    Notes
+    -----
+
+    """
+    args = [(specobj, zbest, CFit, indx) for indx in fitindx]
+    if nproc > 1:
+        with multiprocessing.Pool(nproc) as P:
+            data = np.vstack(P.map(_unpack_one_spectrum, args))
+    else:
+        data = [unpack_one_spectrum(*_args) for _args in args]
+
+    return data    
+


### PR DESCRIPTION
Testing the MPI wrapper now with a subset of the daily reductions (but waiting for `blanc` before launching everything). Specifically, testing with 4 interactive nodes with 32 multiprocessing cores per MPI task with:

```
salloc -N 4 -C haswell -A desi -L cfs,SCRATCH -t 01:00:00 --qos interactive --image=docker:desihub/fastspecfit:v0.0.1
srun -n 4 -c 32 --kill-on-bad-exit=0 --no-kill shifter --module=mpich-cle6 /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit.sh specfit 32 > specfit.log.1 2>&1 &
```

Outputs are being written to 
```
/global/cfs/cdirs/desi/users/ioannis/fastspecfit/daily/tiles
```