### PR TITLE
additional updates for Denali

### DIFF
--- a/bin/fastspecfit-qa
+++ b/bin/fastspecfit-qa
@@ -138,7 +138,7 @@ def main(args=None, comm=None):
 
     if args.outdir:
         if not os.path.isdir(args.outdir):
-            os.makedirs(args.outdir)
+            os.makedirs(args.outdir, exist_ok=True)
         
     # Construct the zbestfiles filenames based on the input.
     zbestdir = os.path.join(os.getenv('DESI_SPECTRO_REDUX'), specprod, 'tiles')

--- a/bin/fastspecfit-stack
+++ b/bin/fastspecfit-stack
@@ -33,6 +33,42 @@ def deredshift_one(coaddwave, coaddflux, coaddivar, restwave, Iwave):
         resampivar[Iwave] = ivar
     return resampflux, resampivar
 
+def write_stacked(wave, flux, ivar, fastspec, fastphot, metadata,
+                  outfile, specprod, coadd_type):
+    """Write out.
+
+    """
+    from astropy.io import fits
+    
+    t0 = time.time()
+
+    hduflux = fits.PrimaryHDU(flux.astype('f4'))
+    hduflux.header['EXTNAME'] = 'FLUX'
+
+    hduivar = fits.ImageHDU(ivar.astype('f4'))
+    hduivar.header['EXTNAME'] = 'IVAR'
+
+    hduwave = fits.ImageHDU(wave.astype('f8'))
+    hduwave.header['EXTNAME'] = 'WAVE'
+    hduwave.header['BUNIT'] = 'Angstrom'
+    hduwave.header['AIRORVAC'] = ('vac', 'vacuum wavelengths')
+
+    hduspec = fits.convenience.table_to_hdu(fastspec)
+    hduspec.header['EXTNAME'] = 'FASTSPEC'
+
+    hduphot = fits.convenience.table_to_hdu(fastphot)
+    hduphot.header['EXTNAME'] = 'FASTPHOT'
+
+    hdumeta = fits.convenience.table_to_hdu(metadata)
+    hdumeta.header['EXTNAME'] = 'METADATA'
+    hdumeta.header['SPECPROD'] = (specprod, 'spectroscopic production name')
+    hdumeta.header['COADDTYP'] = (coadd_type, 'spectral coadd fitted')
+
+    hx = fits.HDUList([hduflux, hduwave, hduspec, hduphot, hdumeta])
+    hx.writeto(outfile, overwrite=True, checksum=True)
+    print('Writing {} spectra to {} took {:.2f} sec'.format(
+        len(fastphot), outfile, time.time()-t0))
+
 def parse(options=None):
     """Parse input arguments.
 
@@ -179,13 +215,14 @@ def main(args=None, comm=None):
     obswave_min, obswave_max = 3600.0, 9800.0
     zmax = {'ELG': 1.6, 'LRG': 1.3, 'QSO': 3.5, 'BGS_ANY': 0.7}
 
-    pixkms = 25.0                            # pixel size [km/s]Traceback (most recent call last):
+    pixkms = 20.0                            # pixel size [km/s]Traceback (most recent call last):
     dlogwave = pixkms / C_LIGHT / np.log(10) # pixel size [log-lambda]
 
     # For each unique tile, select targets of each class and build the
     # rest-frame spectra.
     targetclasses = ('ELG', 'LRG', 'QSO', 'BGS_ANY')#, 'MWS_ANY')
 
+    tall = time.time()
     for tinfo in tileinfo:
         tile = tinfo['TILEID']
         log.info('Working on tile {}'.format(tile))
@@ -216,10 +253,13 @@ def main(args=None, comm=None):
             thrunightcol = 'THRUNIGHT'
             
         for targetclass in targetclasses:
+            log.info('Working on {} on tile {}'.format(targetclass, tile))
+            
             targintile = np.where(
-                (metadata['Z_SPEC'] > 1.0) * # minimum redshift!
-                (metadata['Z_SPEC'] < 1.1) * # minimum redshift!
                 (tile == metadata['TILEID']) *
+                (metadata['Z_SPEC'] > 0.01) * # minimum redshift!
+                #(metadata['Z_SPEC'] > 1.0) *
+                #(metadata['Z_SPEC'] < 1.1) *
                 metadata[desibit] & desi_mask.mask(targetclass) != 0)[0]
             if len(targintile) == 0:
                 log.info('No good {} targets in tile {}...moving on.'.format(targetclass, tile))
@@ -280,11 +320,15 @@ def main(args=None, comm=None):
             restivar = np.vstack(res[1]).astype('f4')
             log.info('De-redshifting done in {:.2f} sec'.format(time.time()-t0))
 
-            import matplotlib.pyplot as plt
-            plt.plot(restwave, np.sum(restflux, axis=0)) ; plt.xlim(3000, 4200) ; plt.savefig('test.png')
+            #import matplotlib.pyplot as plt
+            #plt.plot(restwave, np.sum(restflux, axis=0)) ; plt.xlim(3000, 4200) ; plt.savefig('test.png')
+            #pdb.set_trace()
+
+            write_stacked(restwave, restflux, restivar, fastspec, fastphot,
+                          metadata, outfile, specprod, coadd_type):
             pdb.set_trace()
 
-    log.info('QA for everything took: {:.2f} sec'.format(time.time()-t0))
+    log.info('Stacking everything took: {:.2f} sec'.format(time.time()-tall))
 
 if __name__ == '__main__':
     main()

--- a/bin/fastspecfit-stack
+++ b/bin/fastspecfit-stack
@@ -11,8 +11,27 @@ import pdb # for debugging
 import os, sys, time
 import numpy as np
 
+from fastspecfit.util import C_LIGHT
+
+#from redrock.rebin import trapz_rebin
+from desispec.interpolation import resample_flux
 from desiutil.log import get_logger
 log = get_logger()
+
+def _deredshift_one(args):
+    """Multiprocessing wrapper."""
+    return deredshift_one(*args)
+
+def deredshift_one(coaddwave, coaddflux, coaddivar, restwave, Iwave):
+    """QA on one spectrum."""
+    resampflux = np.zeros_like(restwave)
+    resampivar = np.zeros_like(restwave)
+    if len(Iwave) > 0:
+        #resampflux[Iwave] = trapz_rebin(coaddwave, coaddflux, restwave[Iwave])
+        flux, ivar = resample_flux(restwave[Iwave], coaddwave, coaddflux, ivar=coaddivar)
+        resampflux[Iwave] = flux
+        resampivar[Iwave] = ivar
+    return resampflux, resampivar
 
 def parse(options=None):
     """Parse input arguments.
@@ -51,189 +70,6 @@ def parse(options=None):
 
     return args
 
-def build_htmlhome(fastfit, metadata, tileinfo, coadd_type='cumulative',
-                   specprod='denali', htmlhome='index.html'):
-    """Build the home (index.html) page.
-
-    """
-    htmldir_https = htmldir.replace(cfsroot, httpsroot)
-
-    htmlhomefile = os.path.join(htmldir, htmlhome)
-    htmlhomefile_https = os.path.join(htmldir_https, htmlhome)
-    print('Building {}'.format(htmlhomefile))
-
-    targetclasses = ('ELG', 'LRG', 'QSO', 'BGS_ANY', 'MWS_ANY')
-
-    with open(htmlhomefile, 'w') as html:
-        html.write('<html><body>\n')
-        html.write('<style type="text/css">\n')
-        html.write('table, td, th {padding: 5px; text-align: center; border: 1px solid black;}\n')
-        html.write('p {display: inline-block;;}\n')
-        html.write('</style>\n')
-
-        html.write('<br />\n')
-        html.write('<h1><a href="https://fastspecfit.readthedocs.io/en/latest/index.html">FastSpecFit</a> Visualizations</h1>\n')
-        html.write('<h3><a href="https://data.desi.lbl.gov/desi/spectro/redux/denali">{} Data Release</a></h3>\n'.format(specprod))
-
-        #html.write('<p style="width: 75%">\n')
-        #html.write("""Write me.</p>\n""")
-
-        html.write('<br />\n')
-        html.write('<table>\n')
-        html.write('<tr>\n')
-        html.write('<th></th>\n')
-        html.write('<th></th>\n')
-        html.write('<th></th>\n')
-        html.write('<th></th>\n')
-        html.write('<th colspan="2">Effective Time (minutes)</th>\n')
-        html.write('</tr>\n')
-        
-        html.write('<tr>\n')
-        html.write('<th>Tile</th>\n')
-        html.write('<th>Survey</th>\n')
-        html.write('<th>Program</th>\n')
-        html.write('<th>Nexp</th>\n')
-        html.write('<th>ELG, dark</th>\n')
-        html.write('<th>BGS, bright</th>\n')
-        html.write('</tr>\n')
-
-        for tinfo in tileinfo:
-            tile = tinfo['TILEID']
-            tiledatafile = os.path.join(htmldir, 'tiles', coadd_type, str(tile), '{}-{}.html'.format(tile, coadd_type))
-            tilehtmlfile = os.path.join(htmldir_https, 'tiles', coadd_type, str(tile), '{}-{}.html'.format(tile, coadd_type))
-            
-            html.write('<tr>\n')
-            html.write('<td><a href="{}">{}</a></td>\n'.format(tilehtmlfile, tile))
-            html.write('<td>{}</td>\n'.format(tinfo['SURVEY'].upper()))
-            html.write('<td>{}</td>\n'.format(tinfo['FAPRGRM'].upper()))
-            html.write('<td>{}</td>\n'.format(tinfo['NEXP']))
-            html.write('<td>{:.0f}</td>\n'.format(tinfo['ELG_EFFTIME_DARK']/60))
-            html.write('<td>{:.0f}</td>\n'.format(tinfo['BGS_EFFTIME_BRIGHT']/60))
-            html.write('</tr>\n')
-        html.write('</table>\n')
-
-        # close up shop
-        html.write('<br /><br />\n')
-        html.write('</html></body>\n')
-
-    # Now the individual tile pages are more finely subdivided by target classes.
-    for tinfo in tileinfo:
-        tile = tinfo['TILEID']
-        tiledatafile = os.path.join(htmldir, 'tiles', coadd_type, str(tile), '{}-{}.html'.format(tile, coadd_type))
-        log.info('Building {}'.format(tiledatafile))
-
-        if tinfo['SURVEY'].upper() == 'SV1':
-            from desitarget.sv1.sv1_targetmask import desi_mask#, bgs_mask, mws_mask
-            desibit = 'SV1_DESI_TARGET'
-            bgsbit = 'SV1_BGS_TARGET'
-            mwsbit = 'SV1_MWS_TARGET'
-        elif tinfo['SURVEY'].upper() == 'SV2':
-            from desitarget.sv2.sv2_targetmask import desi_mask#, bgs_mask, mws_mask
-            desibit = 'SV2_DESI_TARGET'
-            bgsbit = 'SV2_BGS_TARGET'
-            mwsbit = 'SV2_MWS_TARGET'
-        else:
-            NotImplementedError
-
-        # need to account for the join suffix when we have both fastspec and
-        # fastphot output
-        if 'DESI_TARGET_SPEC' in metadata.colnames:
-            desibit = desibit+'_SPEC'
-            bgsbit = bgsbit+'_SPEC'
-            mwsbit = mwsbit+'_SPEC'
-
-        with open(tiledatafile, 'w') as html:
-            html.write('<html><body>\n')
-            html.write('<style type="text/css">\n')
-            html.write('table, td, th {padding: 5px; text-align: center; border: 1px solid black;}\n')
-            html.write('p {width: "75%";}\n')
-            html.write('</style>\n')
-
-            html.write('<h3><a href="{}">Home</a></h3>\n'.format(htmlhomefile_https))
-
-            html.write('<h2>Tile {}</h2>\n'.format(tile))
-            html.write('<br />\n')
-            html.write('<table>\n')
-            html.write('<tr>\n')
-            html.write('<th></th>\n')
-            html.write('<th></th>\n')
-            html.write('<th></th>\n')
-            html.write('<th colspan="2">Effective Time (minutes)</th>\n')
-            html.write('</tr>\n')
-
-            html.write('<tr>\n')
-            html.write('<th>Survey</th>\n')
-            html.write('<th>Program</th>\n')
-            html.write('<th>Nexp</th>\n')
-            html.write('<th>ELG, dark</th>\n')
-            html.write('<th>BGS, bright</th>\n')
-            html.write('</tr>\n')
-            html.write('<tr>\n')
-            html.write('<td>{}</td>\n'.format(tinfo['SURVEY'].upper()))
-            html.write('<td>{}</td>\n'.format(tinfo['FAPRGRM'].upper()))
-            html.write('<td>{}</td>\n'.format(tinfo['NEXP']))
-            html.write('<td>{:.0f}</td>\n'.format(tinfo['ELG_EFFTIME_DARK']/60))
-            html.write('<td>{:.0f}</td>\n'.format(tinfo['BGS_EFFTIME_BRIGHT']/60))
-            html.write('</tr>\n')
-            html.write('</table>\n')
-            
-            html.write('<br /><br />\n')
-            html.write('<table>\n')
-            html.write('<tr>\n')
-            html.write('<th>Target Class</th>\n')
-            html.write('<th>N</th>\n')
-            html.write('</tr>\n')
-                
-            for targetclass in targetclasses:
-                targhtmlfile = os.path.join(htmldir_https, 'tiles', coadd_type, str(tile), '{}-{}-{}.html'.format(tile, targetclass, coadd_type))
-                targdatafile = os.path.join(htmldir, 'tiles', coadd_type, str(tile), '{}-{}-{}.html'.format(tile, targetclass, coadd_type))
-                log.info('  Building {}'.format(targdatafile))
-
-                targintile = np.where((tile == metadata['TILEID']) *
-                                      metadata[desibit] & desi_mask.mask(targetclass) != 0)[0]
-                nobj = len(targintile)
-
-                html.write('<tr>\n')
-                html.write('<td><a href="{}">{}</a></td>\n'.format(targhtmlfile, targetclass))
-                html.write('<td>{}</td>\n'.format(nobj))
-                html.write('</tr>\n')
-
-                with open(targdatafile, 'w') as targhtml:
-                    targhtml.write('<html><body>\n')
-                    targhtml.write('<style type="text/css">\n')
-                    targhtml.write('table, td, th {padding: 5px; text-align: center; border: 1px solid black;}\n')
-                    targhtml.write('p {width: "75%";}\n')
-                    targhtml.write('</style>\n')
-                    targhtml.write('<h3><a href="{}">Home</a></h3>\n'.format(htmlhomefile_https))
-                    targhtml.write('<h3>Tile {} - {} (N={})</h3>\n'.format(tile, targetclass, nobj))
-                    targhtml.write('<table>\n')
-                    targhtml.write('<tr>\n')
-                    targhtml.write('<th>TargetID</th>\n')
-                    targhtml.write('<th>fastspec</th>\n')
-                    targhtml.write('<th>fastphot</th>\n')
-                    targhtml.write('</tr>\n')
-                
-                    for targetid in metadata['TARGETID'][targintile]:
-                        targhtml.write('<tr>\n')
-                        targhtml.write('<td>{}</td>\n'.format(targetid))
-
-                        for prefix in ('fastspec', 'fastphot'):
-                            httpfile = os.path.join(htmldir_https, 'tiles', coadd_type, str(tile), '{}-{}-{}-{}.png'.format(
-                                prefix, tile, coadd_type, targetid))
-                            pngfile = os.path.join(htmldir, 'tiles', coadd_type, str(tile), '{}-{}-{}-{}.png'.format(
-                                prefix, tile, coadd_type, targetid))
-                            if os.path.isfile(pngfile):
-                                targhtml.write('<td><a href="{0}"><img src="{0}" height="auto" width="512px"></a></td>\n'.format(httpfile))
-                            else:
-                                targhtml.write('<td>Not Available</td>\n')
-                    targhtml.write('</table>\n')
-                    targhtml.write('<br /><br />\n')
-                    targhtml.write('</html></body>\n')
-
-            html.write('</table>\n')
-            html.write('<br /><br />\n')
-            html.write('</html></body>\n')
-
 def main(args=None, comm=None):
     """Stack the spectra.
 
@@ -259,19 +95,16 @@ def main(args=None, comm=None):
             return
 
         from astropy.table import join
-        fastspec['TILEID'] = metaspec['TILEID']
-        fastphot['TILEID'] = metaphot['TILEID']
-
+        # temporarily add TILEID to the tables so we can use it to join,
+        # together with TARGETID and, optionally, NIGHT.
         joinkeys = ['TARGETID', 'TILEID']
         if 'NIGHT' in fastspec.colnames:
             joinkeys += 'NIGHT'
-            fastspec['NIGHT'] = metaspec['NIGHT']
-            fastphot['NIGHT'] = metaphot['NIGHT']
-            
-        fastfit = join(fastspec, fastphot, keys=joinkeys, join_type='outer',
-                       table_names=['SPEC', 'PHOT'])
-        metadata = join(metaspec, metaphot, keys=joinkeys, join_type='outer',
-                       table_names=['SPEC', 'PHOT'])
+        fastspec['TILEID'] = metaspec['TILEID']
+        fastphot['TILEID'] = metaphot['TILEID']
+        
+        fastfit = join(fastspec, fastphot, join_type='outer', table_names=['SPEC', 'PHOT'], keys=joinkeys)
+        metadata = join(metaspec, metaphot, join_type='outer', table_names=['SPEC', 'PHOT'], keys=joinkeys)
         assert(np.all(fastfit['TARGETID'] == metadata['TARGETID']))
         assert(np.all(fastfit['TILEID'] == metadata['TILEID']))
 
@@ -340,16 +173,18 @@ def main(args=None, comm=None):
     tilefile = os.path.join(os.getenv('DESI_SPECTRO_REDUX'), specprod, 'tiles-{}.csv'.format(specprod))
     tileinfo = Table.read(tilefile)
     tileinfo = tileinfo[np.isin(tileinfo['TILEID'], np.unique(metadata['TILEID']))]
-
-    log.info('Fix SURVEY for tiles 80605-80610, which are incorrectly identified as cmx tiles.')    
-    surveyfix = np.where((tileinfo['TILEID'] >= 80605) * (tileinfo['TILEID'] <= 80610))[0]
-    if len(surveyfix) > 0:
-        tileinfo['SURVEY'][surveyfix] = 'sv1'
     log.info('Read survey info for {} tiles'.format(len(tileinfo)))
+
+    # rest-frame resampling parameters
+    obswave_min, obswave_max = 3600.0, 9800.0
+    zmax = {'ELG': 1.6, 'LRG': 1.3, 'QSO': 3.5, 'BGS_ANY': 0.7}
+
+    pixkms = 25.0                            # pixel size [km/s]Traceback (most recent call last):
+    dlogwave = pixkms / C_LIGHT / np.log(10) # pixel size [log-lambda]
 
     # For each unique tile, select targets of each class and build the
     # rest-frame spectra.
-    targetclasses = ('ELG', 'LRG', 'QSO', 'BGS_ANY', 'MWS_ANY')
+    targetclasses = ('ELG', 'LRG', 'QSO', 'BGS_ANY')#, 'MWS_ANY')
 
     for tinfo in tileinfo:
         tile = tinfo['TILEID']
@@ -381,10 +216,19 @@ def main(args=None, comm=None):
             thrunightcol = 'THRUNIGHT'
             
         for targetclass in targetclasses:
-            targintile = np.where((tile == metadata['TILEID']) *
-                                  metadata[desibit] & desi_mask.mask(targetclass) != 0)[0]
+            targintile = np.where(
+                (metadata['Z_SPEC'] > 1.0) * # minimum redshift!
+                (metadata['Z_SPEC'] < 1.1) * # minimum redshift!
+                (tile == metadata['TILEID']) *
+                metadata[desibit] & desi_mask.mask(targetclass) != 0)[0]
+            if len(targintile) == 0:
+                log.info('No good {} targets in tile {}...moving on.'.format(targetclass, tile))
+                continue
+            #targintile = targintile[:22]
+            
             targ_fastfit = fastfit[targintile]
             targ_metadata = metadata[targintile]
+            nobj = len(targ_metadata)
 
             # Construct the zbestfiles filenames based on the input (only
             # supports coadd_type=='cumulative').
@@ -405,14 +249,40 @@ def main(args=None, comm=None):
             #dataphot = Spec.read_and_unpack(CFit, fastphot=True, synthphot=False)
             dataspec = Spec.read_and_unpack(CFit, fastphot=False, synthphot=False,
                                             remember_coadd=True)
-            assert(len(dataspec) == len(targ_metadata))
-            
+            assert(len(dataspec) == nobj)
+
+            # now resample onto a constant log-lambda binning scale
+            restwave = 10**np.arange(np.log10(obswave_min / (1+zmax[targetclass])), np.log10(obswave_max), dlogwave)
+            restwave_min = np.min(restwave)
+            restwave_max = np.max(restwave)
+            npix = len(restwave)
+
+            pad = 2 # [angstroms]
+            mpargs = []
+            for iobj in np.arange(nobj):
+                oneplusz = 1 + dataspec[iobj]['zredrock']
+                coaddwave = dataspec[iobj]['coadd_wave'] / oneplusz
+                coaddflux = dataspec[iobj]['coadd_flux'] * oneplusz
+                coaddivar = dataspec[iobj]['coadd_ivar'] / oneplusz**2
+                Iwave = np.where((restwave > np.min(coaddwave+pad)) * (restwave < np.max(coaddwave-pad)))[0]
+                mpargs.append((coaddwave, coaddflux, coaddivar, restwave, Iwave))
+                
+            t0 = time.time()
+            if args.mp > 1:
+                import multiprocessing
+                with multiprocessing.Pool(args.mp) as P:
+                    res = P.map(_deredshift_one, mpargs)
+            else:
+                res = [deredshift_one(*_mpargs) for _mpargs in mpargs]
+                
+            res = list(zip(*res))
+            restflux = np.vstack(res[0]).astype('f4')
+            restivar = np.vstack(res[1]).astype('f4')
+            log.info('De-redshifting done in {:.2f} sec'.format(time.time()-t0))
+
+            import matplotlib.pyplot as plt
+            plt.plot(restwave, np.sum(restflux, axis=0)) ; plt.xlim(3000, 4200) ; plt.savefig('test.png')
             pdb.set_trace()
-
-    # Build the home (index.html) page (always, irrespective of clobber)--
-    build_htmlhome(htmldir, fastfit, metadata, tileinfo, htmlhome=args.htmlhome,
-                   specprod=specprod)
-
 
     log.info('QA for everything took: {:.2f} sec'.format(time.time()-t0))
 

--- a/bin/fastspecfit-stack
+++ b/bin/fastspecfit-stack
@@ -33,8 +33,8 @@ def deredshift_one(coaddwave, coaddflux, coaddivar, restwave, Iwave):
         resampivar[Iwave] = ivar
     return resampflux, resampivar
 
-def write_stacked(wave, flux, ivar, fastspec, fastphot, metadata,
-                  outfile, specprod, coadd_type):
+def write_stacks(wave, flux, ivar, fastspec, fastphot, metadata,
+                 outfile, specprod, coadd_type):
     """Write out.
 
     """
@@ -88,14 +88,12 @@ def parse(options=None):
     parser.add_argument('--firsttarget', type=int, default=0, help='Index of first object to to process in each file (0-indexed).')
     parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
 
-    parser.add_argument('--htmlhome', type=str, default='index.html', help='Main HTML page name.')
-    parser.add_argument('--htmldir', type=str, help='Output directory for HTML files.')
-
-    parser.add_argument('--outprefix', default=None, type=str, help='Optional prefix for output filename.')
-    parser.add_argument('-o', '--outdir', default='.', type=str, help='Full path to desired output directory.')
+    parser.add_argument('-o', '--outdir', default=None, type=str, help='Full path to desired output directory.')
 
     parser.add_argument('--fastphotfile', default=None, type=str, help='Full path to fastphot fitting results.')
     parser.add_argument('--fastspecfile', default=None, type=str, help='Full path to fastphot fitting results.')
+
+    parser.add_argument('--overwrite', action='store_true', help='Overwrite any existing output files.')
     
     if options is None:
         args = parser.parse_args()
@@ -195,7 +193,7 @@ def main(args=None, comm=None):
         outdir = args.outdir
     if not os.path.isdir(outdir):
         os.makedirs(outdir, exist_ok=True)
-        
+
     # Initialize the continuum- and emission-line fitting classes.
     t0 = time.time()
     CFit = ContinuumFit()
@@ -207,7 +205,10 @@ def main(args=None, comm=None):
     tilefile = os.path.join(os.getenv('DESI_SPECTRO_REDUX'), specprod, 'tiles-{}.csv'.format(specprod))
     tileinfo = Table.read(tilefile)
     tileinfo = tileinfo[np.isin(tileinfo['TILEID'], np.unique(metadata['TILEID']))]
+    tileinfo = tileinfo[np.argsort(tileinfo['TILEID'])]
     log.info('Read survey info for {} tiles'.format(len(tileinfo)))
+
+    pdb.set_trace()
 
     # rest-frame resampling parameters
     obswave_min, obswave_max = 3600.0, 9800.0
@@ -218,7 +219,7 @@ def main(args=None, comm=None):
 
     # For each unique tile, select targets of each class and build the
     # rest-frame spectra.
-    targetclasses = ('ELG', 'LRG', 'QSO', 'BGS_ANY')#, 'MWS_ANY')
+    targetclasses = ['BGS_ANY', 'ELG', 'LRG', 'QSO']#, 'MWS_ANY'
 
     tall = time.time()
     for tinfo in tileinfo:
@@ -238,6 +239,13 @@ def main(args=None, comm=None):
             NotImplementedError
             
         for targetclass in targetclasses:
+
+            nicetargetclass = targetclass.replace('BGS_ANY', 'BGS').lower()
+            outfile = os.path.join(outdir, '{}-{}-restflux.fits'.format(nicetargetclass, tile))
+            if os.path.isfile(outfile) and not args.overwrite:
+                log.info('Output file {} exists; skipping.'.format(outfile))
+                continue
+
             targintile = np.where(
                 (tile == metadata['TILEID']) *
                 (metadata['Z'] > 0.01) * # minimum redshift!
@@ -251,7 +259,7 @@ def main(args=None, comm=None):
                 log.info('No good {} targets in tile {}...moving on.'.format(targetclass, tile))
                 continue
             #targintile = targintile[:22]
-            
+
             targ_fastspec = fastspec[targintile]
             targ_fastphot = fastphot[targintile]
             targ_metadata = metadata[targintile]
@@ -311,12 +319,9 @@ def main(args=None, comm=None):
             #plt.plot(restwave, np.sum(restflux, axis=0)) ; plt.xlim(3000, 4200) ; plt.savefig('test.png')
             #pdb.set_trace()
 
-            nicetargetclass = targetclass.replace('BGS_ANY', 'BGS').lower()
-            outfile = os.path.join(outdir, '{}-{}-restflux.fits'.format(nicetargetclass, tile))
-            write_stacked(restwave, restflux, restivar, targ_fastspec,
-                          targ_fastphot, targ_metadata, outfile, specprod,
-                          coadd_type)
-            pdb.set_trace()
+            write_stacks(restwave, restflux, restivar, targ_fastspec,
+                         targ_fastphot, targ_metadata, outfile, specprod,
+                         coadd_type)
 
     log.info('Stacking everything took: {:.2f} sec'.format(time.time()-tall))
 

--- a/bin/fastspecfit-stack
+++ b/bin/fastspecfit-stack
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
-"""fastspecfit stacking code
+"""Stacking code.
 
-fastspecfit-stack --specfitfile /global/cfs/cdirs/desi/users/ioannis/fastspecfit/blanc/tiles/specfit-80607-80613-20201214-20201223.fits --outdir /global/cfs/cdirs/desi/users/ioannis/fastspecfit/blanc/tiles/qa/stacks --tile 80608 --mp 32 --ntargets 5
+fastspecfit-stack --fastspecfile ./fastspect.fits
+
+fastspecfit-stack --fastphotfile /global/cfs/cdirs/desi/spectro/fastspecfit/denali/tiles/merged/fastphot-denali-cumulative.fits \
+  --fastspecfile /global/cfs/cdirs/desi/spectro/fastspecfit/denali/tiles/merged/fastspec-denali-cumulative.fits
 
 """
 import pdb # for debugging
@@ -11,10 +14,6 @@ import numpy as np
 from desiutil.log import get_logger
 log = get_logger()
 
-# ridiculousness!
-import tempfile
-os.environ['MPLCONFIGDIR'] = tempfile.mkdtemp()
-
 def parse(options=None):
     """Parse input arguments.
 
@@ -22,209 +21,401 @@ def parse(options=None):
     import sys, argparse
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-    parser.add_argument('--tile', default=None, type=str, nargs='*', help='Generate QA for all objects on this tile.')
-    parser.add_argument('--night', default=None, type=str, nargs='*', help='Generate QA for all objects observed on this night.')
+    parser.add_argument('--specprod', type=str, default='denali', choices=['denali', 'cascades', 'daily'],
+                        help='Spectroscopic production to process.')
+    parser.add_argument('--coadd-type', type=str, default='cumulative', choices=['cumulative', 'pernight', 'perexp'],
+                        help='Type of spectral coadds corresponding to the input zbestfiles.')
+    parser.add_argument('--tile', default=None, type=str, nargs='*', help='Tile(s) to process.')
+    parser.add_argument('--night', default=None, type=str, nargs='*', help='Night(s) to process (ignored if coadd-type is cumulative).')
+    
     parser.add_argument('--targetids', type=str, default=None, help='Comma-separated list of target IDs to process.')
     parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
     parser.add_argument('--firsttarget', type=int, default=0, help='Index of first object to to process in each file (0-indexed).')
     parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
 
-    parser.add_argument('--suffix', default=None, type=str, help='Optional suffix for output filename.')
-    parser.add_argument('-o', '--outdir', default=None, type=str, help='Full path to desired output directory.')
-    
-    parser.add_argument('--specfitfile', default=None, type=str, help='Full path to specfit fitting results.')
+    parser.add_argument('--htmlhome', type=str, default='index.html', help='Main HTML page name.')
+    parser.add_argument('--htmldir', type=str, help='Output directory for HTML files.')
+
+    parser.add_argument('--outprefix', default=None, type=str, help='Optional prefix for output filename.')
+    parser.add_argument('-o', '--outdir', default='.', type=str, help='Full path to desired output directory.')
+
+    parser.add_argument('--fastphotfile', default=None, type=str, help='Full path to fastphot fitting results.')
+    parser.add_argument('--fastspecfile', default=None, type=str, help='Full path to fastphot fitting results.')
     
     if options is None:
         args = parser.parse_args()
         log.info(' '.join(sys.argv))
     else:
         args = parser.parse_args(options)
-        log.info('fastspecfit-stack {}'.format(' '.join(options)))
+        log.info('fastspecfit-html {}'.format(' '.join(options)))
 
     return args
 
-def main(args=None, comm=None):
-    """Main module.
+def build_htmlhome(fastfit, metadata, tileinfo, coadd_type='cumulative',
+                   specprod='denali', htmlhome='index.html'):
+    """Build the home (index.html) page.
 
     """
-    import fitsio
+    htmldir_https = htmldir.replace(cfsroot, httpsroot)
+
+    htmlhomefile = os.path.join(htmldir, htmlhome)
+    htmlhomefile_https = os.path.join(htmldir_https, htmlhome)
+    print('Building {}'.format(htmlhomefile))
+
+    targetclasses = ('ELG', 'LRG', 'QSO', 'BGS_ANY', 'MWS_ANY')
+
+    with open(htmlhomefile, 'w') as html:
+        html.write('<html><body>\n')
+        html.write('<style type="text/css">\n')
+        html.write('table, td, th {padding: 5px; text-align: center; border: 1px solid black;}\n')
+        html.write('p {display: inline-block;;}\n')
+        html.write('</style>\n')
+
+        html.write('<br />\n')
+        html.write('<h1><a href="https://fastspecfit.readthedocs.io/en/latest/index.html">FastSpecFit</a> Visualizations</h1>\n')
+        html.write('<h3><a href="https://data.desi.lbl.gov/desi/spectro/redux/denali">{} Data Release</a></h3>\n'.format(specprod))
+
+        #html.write('<p style="width: 75%">\n')
+        #html.write("""Write me.</p>\n""")
+
+        html.write('<br />\n')
+        html.write('<table>\n')
+        html.write('<tr>\n')
+        html.write('<th></th>\n')
+        html.write('<th></th>\n')
+        html.write('<th></th>\n')
+        html.write('<th></th>\n')
+        html.write('<th colspan="2">Effective Time (minutes)</th>\n')
+        html.write('</tr>\n')
+        
+        html.write('<tr>\n')
+        html.write('<th>Tile</th>\n')
+        html.write('<th>Survey</th>\n')
+        html.write('<th>Program</th>\n')
+        html.write('<th>Nexp</th>\n')
+        html.write('<th>ELG, dark</th>\n')
+        html.write('<th>BGS, bright</th>\n')
+        html.write('</tr>\n')
+
+        for tinfo in tileinfo:
+            tile = tinfo['TILEID']
+            tiledatafile = os.path.join(htmldir, 'tiles', coadd_type, str(tile), '{}-{}.html'.format(tile, coadd_type))
+            tilehtmlfile = os.path.join(htmldir_https, 'tiles', coadd_type, str(tile), '{}-{}.html'.format(tile, coadd_type))
+            
+            html.write('<tr>\n')
+            html.write('<td><a href="{}">{}</a></td>\n'.format(tilehtmlfile, tile))
+            html.write('<td>{}</td>\n'.format(tinfo['SURVEY'].upper()))
+            html.write('<td>{}</td>\n'.format(tinfo['FAPRGRM'].upper()))
+            html.write('<td>{}</td>\n'.format(tinfo['NEXP']))
+            html.write('<td>{:.0f}</td>\n'.format(tinfo['ELG_EFFTIME_DARK']/60))
+            html.write('<td>{:.0f}</td>\n'.format(tinfo['BGS_EFFTIME_BRIGHT']/60))
+            html.write('</tr>\n')
+        html.write('</table>\n')
+
+        # close up shop
+        html.write('<br /><br />\n')
+        html.write('</html></body>\n')
+
+    # Now the individual tile pages are more finely subdivided by target classes.
+    for tinfo in tileinfo:
+        tile = tinfo['TILEID']
+        tiledatafile = os.path.join(htmldir, 'tiles', coadd_type, str(tile), '{}-{}.html'.format(tile, coadd_type))
+        log.info('Building {}'.format(tiledatafile))
+
+        if tinfo['SURVEY'].upper() == 'SV1':
+            from desitarget.sv1.sv1_targetmask import desi_mask#, bgs_mask, mws_mask
+            desibit = 'SV1_DESI_TARGET'
+            bgsbit = 'SV1_BGS_TARGET'
+            mwsbit = 'SV1_MWS_TARGET'
+        elif tinfo['SURVEY'].upper() == 'SV2':
+            from desitarget.sv2.sv2_targetmask import desi_mask#, bgs_mask, mws_mask
+            desibit = 'SV2_DESI_TARGET'
+            bgsbit = 'SV2_BGS_TARGET'
+            mwsbit = 'SV2_MWS_TARGET'
+        else:
+            NotImplementedError
+
+        # need to account for the join suffix when we have both fastspec and
+        # fastphot output
+        if 'DESI_TARGET_SPEC' in metadata.colnames:
+            desibit = desibit+'_SPEC'
+            bgsbit = bgsbit+'_SPEC'
+            mwsbit = mwsbit+'_SPEC'
+
+        with open(tiledatafile, 'w') as html:
+            html.write('<html><body>\n')
+            html.write('<style type="text/css">\n')
+            html.write('table, td, th {padding: 5px; text-align: center; border: 1px solid black;}\n')
+            html.write('p {width: "75%";}\n')
+            html.write('</style>\n')
+
+            html.write('<h3><a href="{}">Home</a></h3>\n'.format(htmlhomefile_https))
+
+            html.write('<h2>Tile {}</h2>\n'.format(tile))
+            html.write('<br />\n')
+            html.write('<table>\n')
+            html.write('<tr>\n')
+            html.write('<th></th>\n')
+            html.write('<th></th>\n')
+            html.write('<th></th>\n')
+            html.write('<th colspan="2">Effective Time (minutes)</th>\n')
+            html.write('</tr>\n')
+
+            html.write('<tr>\n')
+            html.write('<th>Survey</th>\n')
+            html.write('<th>Program</th>\n')
+            html.write('<th>Nexp</th>\n')
+            html.write('<th>ELG, dark</th>\n')
+            html.write('<th>BGS, bright</th>\n')
+            html.write('</tr>\n')
+            html.write('<tr>\n')
+            html.write('<td>{}</td>\n'.format(tinfo['SURVEY'].upper()))
+            html.write('<td>{}</td>\n'.format(tinfo['FAPRGRM'].upper()))
+            html.write('<td>{}</td>\n'.format(tinfo['NEXP']))
+            html.write('<td>{:.0f}</td>\n'.format(tinfo['ELG_EFFTIME_DARK']/60))
+            html.write('<td>{:.0f}</td>\n'.format(tinfo['BGS_EFFTIME_BRIGHT']/60))
+            html.write('</tr>\n')
+            html.write('</table>\n')
+            
+            html.write('<br /><br />\n')
+            html.write('<table>\n')
+            html.write('<tr>\n')
+            html.write('<th>Target Class</th>\n')
+            html.write('<th>N</th>\n')
+            html.write('</tr>\n')
+                
+            for targetclass in targetclasses:
+                targhtmlfile = os.path.join(htmldir_https, 'tiles', coadd_type, str(tile), '{}-{}-{}.html'.format(tile, targetclass, coadd_type))
+                targdatafile = os.path.join(htmldir, 'tiles', coadd_type, str(tile), '{}-{}-{}.html'.format(tile, targetclass, coadd_type))
+                log.info('  Building {}'.format(targdatafile))
+
+                targintile = np.where((tile == metadata['TILEID']) *
+                                      metadata[desibit] & desi_mask.mask(targetclass) != 0)[0]
+                nobj = len(targintile)
+
+                html.write('<tr>\n')
+                html.write('<td><a href="{}">{}</a></td>\n'.format(targhtmlfile, targetclass))
+                html.write('<td>{}</td>\n'.format(nobj))
+                html.write('</tr>\n')
+
+                with open(targdatafile, 'w') as targhtml:
+                    targhtml.write('<html><body>\n')
+                    targhtml.write('<style type="text/css">\n')
+                    targhtml.write('table, td, th {padding: 5px; text-align: center; border: 1px solid black;}\n')
+                    targhtml.write('p {width: "75%";}\n')
+                    targhtml.write('</style>\n')
+                    targhtml.write('<h3><a href="{}">Home</a></h3>\n'.format(htmlhomefile_https))
+                    targhtml.write('<h3>Tile {} - {} (N={})</h3>\n'.format(tile, targetclass, nobj))
+                    targhtml.write('<table>\n')
+                    targhtml.write('<tr>\n')
+                    targhtml.write('<th>TargetID</th>\n')
+                    targhtml.write('<th>fastspec</th>\n')
+                    targhtml.write('<th>fastphot</th>\n')
+                    targhtml.write('</tr>\n')
+                
+                    for targetid in metadata['TARGETID'][targintile]:
+                        targhtml.write('<tr>\n')
+                        targhtml.write('<td>{}</td>\n'.format(targetid))
+
+                        for prefix in ('fastspec', 'fastphot'):
+                            httpfile = os.path.join(htmldir_https, 'tiles', coadd_type, str(tile), '{}-{}-{}-{}.png'.format(
+                                prefix, tile, coadd_type, targetid))
+                            pngfile = os.path.join(htmldir, 'tiles', coadd_type, str(tile), '{}-{}-{}-{}.png'.format(
+                                prefix, tile, coadd_type, targetid))
+                            if os.path.isfile(pngfile):
+                                targhtml.write('<td><a href="{0}"><img src="{0}" height="auto" width="512px"></a></td>\n'.format(httpfile))
+                            else:
+                                targhtml.write('<td>Not Available</td>\n')
+                    targhtml.write('</table>\n')
+                    targhtml.write('<br /><br />\n')
+                    targhtml.write('</html></body>\n')
+
+            html.write('</table>\n')
+            html.write('<br /><br />\n')
+            html.write('</html></body>\n')
+
+def main(args=None, comm=None):
+    """Stack the spectra.
+
+    """
     from astropy.table import Table
-    from astropy.io import fits
-
-    from desispec.interpolation import resample_flux
-    from desitarget.sv1.sv1_targetmask import desi_mask
-
     from fastspecfit.continuum import ContinuumFit
     from fastspecfit.emlines import EMLineFit
-    from fastspecfit.external.desi import DESISpectra
-
+    from fastspecfit.io import DESISpectra, read_fastspecfit
+    
     if isinstance(args, (list, tuple, type(None))):
         args = parse(args)
 
-    # Read the fitting results.
-    if args.specfitfile is None:
-        log.warning('Must provide --specfitfile.')
+    # Read the fitting results and get all the unique targetids.
+    if (args.fastphotfile is None and args.fastspecfile is None):
+        log.warning('Must provide one of --fastphotfile or --fastspecfile.')
         return
+    
+    elif (args.fastphotfile is not None and args.fastspecfile is not None):
+        fastspec, metaspec, specprod, coadd_type = read_fastspecfit(args.fastspecfile)
+        fastphot, metaphot, _specprod, _coadd_type = read_fastspecfit(args.fastphotfile, fastphot=True)
+        if (specprod != _specprod) or (coadd_type != _coadd_type):
+            log.warning('Mis-matching specprod or coadd_type in fastspec vs fastphot fitting results!')
+            return
 
-    def _check_and_read(filename):
-        if os.path.isfile(filename):
-            fastfit, hdr = fitsio.read(filename, header=True, ext='RESULTS')
-            specprod = hdr['SPECPROD']
-            fastfit = Table(fastfit)
-            log.info('Read {} objects from {}'.format(len(fastfit), filename))
-            return fastfit, specprod
-        else:
-            log.warning('File {} not found.'.format(filename))
-            raise IOError
+        from astropy.table import join
+        fastspec['TILEID'] = metaspec['TILEID']
+        fastphot['TILEID'] = metaphot['TILEID']
 
-    specfit, specprod = _check_and_read(args.specfitfile)
+        joinkeys = ['TARGETID', 'TILEID']
+        if 'NIGHT' in fastspec.colnames:
+            joinkeys += 'NIGHT'
+            fastspec['NIGHT'] = metaspec['NIGHT']
+            fastphot['NIGHT'] = metaphot['NIGHT']
+            
+        fastfit = join(fastspec, fastphot, keys=joinkeys, join_type='outer',
+                       table_names=['SPEC', 'PHOT'])
+        metadata = join(metaspec, metaphot, keys=joinkeys, join_type='outer',
+                       table_names=['SPEC', 'PHOT'])
+        assert(np.all(fastfit['TARGETID'] == metadata['TARGETID']))
+        assert(np.all(fastfit['TILEID'] == metadata['TILEID']))
+
+    elif args.fastphotfile is None and args.fastspecfile is not None:
+        fastfit, metadata, specprod, coadd_type = read_fastspecfit(args.fastspecfile)
+        
+    elif args.fastphotfile is not None and args.fastspecfile is None:
+        fastfit, metadata, specprod, coadd_type = read_fastspecfit(args.fastphotfile, fastphot=True)
+
+    else:
+        pass # should never get here
+
+    # optionally trim to a particular tile and/or night
+    def _select_tiles_nights_targets(fastfit, metadata, tiles=None, nights=None):
+        if fastfit is None or metadata is None:
+            return fastfit, metadata
+        keep = np.ones(len(fastfit), bool)
+        if tiles:
+            tilekeep = np.zeros(len(fastfit), bool)
+            for tile in tiles:
+                tilekeep = np.logical_or(tilekeep, metadata['TILEID'].astype(str) == tile)
+            keep = np.logical_and(keep, tilekeep)
+            log.info('Keeping {} objects from tile(s) {}'.format(len(fastfit), ','.join(tiles)))
+        if nights and 'NIGHT' in metadata:
+            nightkeep = np.zeros(len(fastfit), bool)
+            for night in nights:
+                nightkeep = np.logical_or(nightkeep, metadata['NIGHT'].astype(str) == night)
+            keep = np.logical_and(keep, nightkeep)
+            log.info('Keeping {} objects from night(s) {}'.format(len(fastfit), ','.join(nights)))
+        return fastfit[keep], metadata[keep]
+    
+    fastfit, metadata = _select_tiles_nights_targets(
+        fastfit, metadata, tiles=args.tile, nights=args.night)
 
     # parse the targetids optional input
     if args.targetids:
         targetids = [int(x) for x in args.targetids.split(',')]
-    else:
-        targetids = args.targetids
 
-    # optionally trim to a particular tile and/or night
-    def _select_tiles_nights_targets(fastfit, tiles=None, nights=None, targetids=None):
-        if fastfit and (tiles or nights or targetids):
-            keep = np.ones(len(fastfit), bool)
-            if targetids:
-                targetkeep = np.zeros(len(fastfit), bool)
-                for targetid in targetids:
-                    targetkeep = np.logical_or(targetkeep, fastfit['TARGETID'] == targetid)
-                keep = np.logical_and(keep, targetkeep)
-            if tiles:
-                tilekeep = np.zeros(len(fastfit), bool)
-                for tile in tiles:
-                    tilekeep = np.logical_or(tilekeep, fastfit['TILEID'].astype(str) == tile)
-                keep = np.logical_and(keep, tilekeep)
-            if nights:
-                nightkeep = np.zeros(len(fastfit), bool)
-                for night in nights:
-                    nightkeep = np.logical_or(nightkeep, fastfit['NIGHT'].astype(str) == night)
-                keep = np.logical_and(keep, nightkeep)
-            fastfit = fastfit[keep]
-            #log.info('Keeping {} spectra from tile {} on night {}.'.format(len(fastfit), tile, night))
-        return fastfit
+        keep = np.where(np.isin(fastfit['TARGETID'], targetids))[0]
+        if len(keep) == 0:
+            log.warning('No matching targetids found!')
+            return
+        fastfit = fastfit[keep]
+        metadata = metadata[keep]
 
-    specfit = _select_tiles_nights_targets(specfit, tiles=args.tile, nights=args.night, targetids=targetids)
+    if args.ntargets is not None:
+        keep = np.arange(args.ntargets) + args.firsttarget
+        log.info('Keeping {} targets.'.format(args.ntargets))
+        fastfit = fastfit[keep]
+        metadata = metadata[keep]
 
+    zbestdir = os.path.join(os.getenv('DESI_SPECTRO_REDUX'), specprod, 'tiles')
+
+    if args.outdir:
+        if not os.path.isdir(args.outdir):
+            os.makedirs(args.outdir, exist_ok=True)
+        
     # Initialize the continuum- and emission-line fitting classes.
     t0 = time.time()
     CFit = ContinuumFit()
     EMFit = EMLineFit()
-    log.info('Initializing the classes took: {:.2f} sec'.format(time.time()-t0))
-
     Spec = DESISpectra()
-
-    # select ELGs
-    ielg = np.where((specfit['SV1_DESI_TARGET'] & desi_mask.mask('ELG') != 0) *
-                    (specfit['OII_3726_FLUX'] > 0) *
-                    (specfit['OII_3729_FLUX'] > 0))[0]
-    specfit = specfit[ielg]
-
-    Spec.find_specfiles(fastfit=specfit, specprod=specprod, targetids=targetids,
-                        firsttarget=args.firsttarget, ntargets=args.ntargets)
-    if len(Spec.specfiles) == 0:
-        return
-    data = Spec.read_and_unpack(CFit, synthphot=True, remember_coadd=True)
-
-    # sort specfit so it matches 'data', 'Spec.fibermap', and 'Spec.zbest'
-    refindx = np.array(['{}-{}-{}'.format(night, tile, tid) for night, tile, tid in zip(Spec.fibermap['FIRST_NIGHT'], Spec.fibermap['FIRST_TILEID'], Spec.fibermap['TARGETID'])])
-    sindx = np.array(['{}-{}-{}'.format(night, tile, tid) for night, tile, tid in zip(specfit['NIGHT'], specfit['TILEID'], specfit['TARGETID'])])
-    specfit = specfit[np.hstack([np.where(rindx == sindx)[0] for rindx in refindx])]
+    log.info('Initializing the classes took: {:.2f} sec'.format(time.time()-t0))
     
-    wave = np.arange(1200.0, 8000.0, 0.5)
-    npix = len(wave)
+    # read the tile info file for this production
+    tilefile = os.path.join(os.getenv('DESI_SPECTRO_REDUX'), specprod, 'tiles-{}.csv'.format(specprod))
+    tileinfo = Table.read(tilefile)
+    tileinfo = tileinfo[np.isin(tileinfo['TILEID'], np.unique(metadata['TILEID']))]
 
-    # Build the stacks!
-    ngal = len(specfit)
-    flux = np.zeros((ngal, npix))
-    ivar = np.zeros((ngal, npix))
-    keep = np.ones(ngal, bool)
-    t0 = time.time()
-    pad = 10.0
-    for igal, onegal in enumerate(data):
-        cwave = onegal['coadd_wave'] / (1 + onegal['zredrock'])
-        #I = np.where((wave > (cwave.min()+0)) * (wave < (cwave.max()-0)))[0]
-        I = np.where((wave > (cwave.min()+pad)) * (wave < (cwave.max()-pad)))[0]
-        #I = np.where((wave > (cwave.min()+5)) * (wave < (cwave.max()-5)) * (onegal['coadd_ivar'] > 0))[0]
-        if len(I) > 5:# and np.count_nonzero(onegal['coadd_ivar'] > 0) > 10:
-            try:
-                _flux, _ivar = resample_flux(wave[I], cwave, onegal['coadd_flux'], ivar=onegal['coadd_ivar'])
-                flux[igal, I] = _flux
-                ivar[igal, I] = _ivar
-            except:
-                log.info('Rejecting object {}'.format(igal))
-                pdb.set_trace()
-                keep[igal] = False
+    log.info('Fix SURVEY for tiles 80605-80610, which are incorrectly identified as cmx tiles.')    
+    surveyfix = np.where((tileinfo['TILEID'] >= 80605) * (tileinfo['TILEID'] <= 80610))[0]
+    if len(surveyfix) > 0:
+        tileinfo['SURVEY'][surveyfix] = 'sv1'
+    log.info('Read survey info for {} tiles'.format(len(tileinfo)))
+
+    # For each unique tile, select targets of each class and build the
+    # rest-frame spectra.
+    targetclasses = ('ELG', 'LRG', 'QSO', 'BGS_ANY', 'MWS_ANY')
+
+    for tinfo in tileinfo:
+        tile = tinfo['TILEID']
+        log.info('Working on tile {}'.format(tile))
+
+        if tinfo['SURVEY'].upper() == 'SV1':
+            from desitarget.sv1.sv1_targetmask import desi_mask#, bgs_mask, mws_mask
+            desibit = 'SV1_DESI_TARGET'
+            bgsbit = 'SV1_BGS_TARGET'
+            mwsbit = 'SV1_MWS_TARGET'
+        elif tinfo['SURVEY'].upper() == 'SV2':
+            from desitarget.sv2.sv2_targetmask import desi_mask#, bgs_mask, mws_mask
+            desibit = 'SV2_DESI_TARGET'
+            bgsbit = 'SV2_BGS_TARGET'
+            mwsbit = 'SV2_MWS_TARGET'
         else:
-            log.info('Rejecting object {}'.format(igal))
-            keep[igal] = False
-        #_ivar = resample_flux(wave, onegal['coadd_wave'] / (1 + onegal['zredrock']),
-        #                      onegal['coadd_flux'], extrapolate=False)
-        #norm = np.median(_flux)
-        #if norm > 0:
-        #    _flux /= norm
-        #    _ivar *= norm**2
-#        _flux /= CFit.fluxnorm * onegal['synthphot']['flam'][1] # r-band flux
-    log.info('Done in {:.2f} sec'.format(time.time()-t0))
+            NotImplementedError
 
-    #INFO:fastspecfit-stack:159:main: Rejecting object 7944
-    #INFO:fastspecfit-stack:159:main: Rejecting object 14511
-    #INFO:fastspecfit-stack:159:main: Rejecting object 17092
-    #INFO:fastspecfit-stack:159:main: Rejecting object 18932
-    #INFO:fastspecfit-stack:159:main: Rejecting object 19148
-    reject = np.where(np.logical_not(keep))[0]
-    keep = np.where(keep)[0]
-    if len(reject) > 0:
-        pdb.set_trace()
+        # need to account for the join suffix when we have both fastspec and
+        # fastphot output
+        if 'DESI_TARGET_SPEC' in metadata.colnames:
+            desibit = desibit+'_SPEC'
+            bgsbit = bgsbit+'_SPEC'
+            mwsbit = mwsbit+'_SPEC'
+            fibercol = 'FIBER_SPEC'
+            thrunightcol = 'THRUNIGHT_SPEC'
+        else:
+            fibercol = 'FIBER'
+            thrunightcol = 'THRUNIGHT'
+            
+        for targetclass in targetclasses:
+            targintile = np.where((tile == metadata['TILEID']) *
+                                  metadata[desibit] & desi_mask.mask(targetclass) != 0)[0]
+            targ_fastfit = fastfit[targintile]
+            targ_metadata = metadata[targintile]
 
-    try:
-        flux = flux[keep, :]
-        ivar = ivar[keep, :]
-        specfit = specfit[keep]
-        zbest = Spec.zbest[keep]
-        fibermap = Spec.fibermap[keep]
+            # Construct the zbestfiles filenames based on the input (only
+            # supports coadd_type=='cumulative').
+            allpetals = targ_metadata[fibercol].data // 500
+            thrunights = targ_metadata[thrunightcol].astype(str).data
+            targetids = targ_metadata['TARGETID']
+            assert(len(np.unique(thrunights)) == 1)
 
-        # write out
-        t0 = time.time()
-        if args.outdir is None:
-            args.outdir = '.'
-        if not os.path.isdir(args.outdir):
-            os.makedirs(args.outdir)
+            zbestfiles = []
+            for petal in set(allpetals):
+                indx = np.where((petal == allpetals))[0]
+                zbestfile = os.path.join(zbestdir, 'cumulative', str(tile), thrunights[indx[0]], 'zbest-{}-{}-thru{}.fits'.format(
+                    petal, tile, thrunights[indx[0]]))
+                zbestfiles.append(zbestfile)
 
-        outfile = os.path.join(args.outdir, 'rest-elgs-{}.fits'.format(args.tile[0]))
+            Spec.find_specfiles(zbestfiles=zbestfiles, specprod=specprod,
+                                coadd_type='cumulative', targetids=targetids)
+            #dataphot = Spec.read_and_unpack(CFit, fastphot=True, synthphot=False)
+            dataspec = Spec.read_and_unpack(CFit, fastphot=False, synthphot=False,
+                                            remember_coadd=True)
+            assert(len(dataspec) == len(targ_metadata))
+            
+            pdb.set_trace()
 
-        hduflux = fits.PrimaryHDU(flux.astype('f4'))
-        hduflux.header['EXTNAME'] = 'FLUX'
+    # Build the home (index.html) page (always, irrespective of clobber)--
+    build_htmlhome(htmldir, fastfit, metadata, tileinfo, htmlhome=args.htmlhome,
+                   specprod=specprod)
 
-        hduivar = fits.ImageHDU(ivar.astype('f4'))
-        hduivar.header['EXTNAME'] = 'IVAR'
 
-        hduwave = fits.ImageHDU(wave.astype('f8'))
-        hduwave.header['EXTNAME'] = 'WAVE'
-        hduwave.header['BUNIT'] = 'Angstrom'
-        hduwave.header['AIRORVAC'] = ('vac', 'vacuum wavelengths')
-
-        hduspecfit = fits.convenience.table_to_hdu(specfit)
-        hduspecfit.header['EXTNAME'] = 'SPECFIT'
-
-        hduzbest = fits.convenience.table_to_hdu(zbest)
-        hduzbest.header['EXTNAME'] = 'ZBEST'
-
-        hdufmap = fits.convenience.table_to_hdu(fibermap)
-        hdufmap.header['EXTNAME'] = 'FIBERMAP'
-
-        hx = fits.HDUList([hduflux, hduwave, hduspecfit, hduzbest, hdufmap])
-
-        print('Writing {}'.format(outfile))
-        hx.writeto(outfile, overwrite=True)
-        log.info('Time to write is {:.2f} sec'.format(time.time()-t0))
-    except:
-        pdb.set_trace()
+    log.info('QA for everything took: {:.2f} sec'.format(time.time()-t0))
 
 if __name__ == '__main__':
     main()
+    

--- a/bin/fastspecfit-stack
+++ b/bin/fastspecfit-stack
@@ -64,7 +64,7 @@ def write_stacked(wave, flux, ivar, fastspec, fastphot, metadata,
     hdumeta.header['SPECPROD'] = (specprod, 'spectroscopic production name')
     hdumeta.header['COADDTYP'] = (coadd_type, 'spectral coadd fitted')
 
-    hx = fits.HDUList([hduflux, hduwave, hduspec, hduphot, hdumeta])
+    hx = fits.HDUList([hduflux, hduivar, hduwave, hduspec, hduphot, hdumeta])
     hx.writeto(outfile, overwrite=True, checksum=True)
     print('Writing {} spectra to {} took {:.2f} sec'.format(
         len(fastphot), outfile, time.time()-t0))
@@ -119,39 +119,32 @@ def main(args=None, comm=None):
         args = parse(args)
 
     # Read the fitting results and get all the unique targetids.
-    if (args.fastphotfile is None and args.fastspecfile is None):
-        log.warning('Must provide one of --fastphotfile or --fastspecfile.')
+    if (args.fastphotfile is None or args.fastspecfile is None):
+        log.warning('Must provide both --fastphotfile or --fastspecfile.')
         return
     
-    elif (args.fastphotfile is not None and args.fastspecfile is not None):
-        fastspec, metaspec, specprod, coadd_type = read_fastspecfit(args.fastspecfile)
-        fastphot, metaphot, _specprod, _coadd_type = read_fastspecfit(args.fastphotfile, fastphot=True)
-        if (specprod != _specprod) or (coadd_type != _coadd_type):
-            log.warning('Mis-matching specprod or coadd_type in fastspec vs fastphot fitting results!')
-            return
+    fastspec, metadata, specprod, coadd_type = read_fastspecfit(args.fastspecfile)
+    fastphot, metaphot, _specprod, _coadd_type = read_fastspecfit(args.fastphotfile, fastphot=True)
+    if (specprod != _specprod) or (coadd_type != _coadd_type):
+        log.warning('Mis-matching specprod or coadd_type in fastspec vs fastphot fitting results!')
+        return
+    assert(np.all(fastspec['TARGETID'] == fastphot['TARGETID']))
+    assert(np.all(fastspec['TARGETID'] == metaphot['TARGETID']))
+    assert(np.all(metadata['TILEID'] == metaphot['TILEID']))
 
-        from astropy.table import join
-        # temporarily add TILEID to the tables so we can use it to join,
-        # together with TARGETID and, optionally, NIGHT.
-        joinkeys = ['TARGETID', 'TILEID']
-        if 'NIGHT' in fastspec.colnames:
-            joinkeys += 'NIGHT'
-        fastspec['TILEID'] = metaspec['TILEID']
-        fastphot['TILEID'] = metaphot['TILEID']
-        
-        fastfit = join(fastspec, fastphot, join_type='outer', table_names=['SPEC', 'PHOT'], keys=joinkeys)
-        metadata = join(metaspec, metaphot, join_type='outer', table_names=['SPEC', 'PHOT'], keys=joinkeys)
-        assert(np.all(fastfit['TARGETID'] == metadata['TARGETID']))
-        assert(np.all(fastfit['TILEID'] == metadata['TILEID']))
-
-    elif args.fastphotfile is None and args.fastspecfile is not None:
-        fastfit, metadata, specprod, coadd_type = read_fastspecfit(args.fastspecfile)
-        
-    elif args.fastphotfile is not None and args.fastspecfile is None:
-        fastfit, metadata, specprod, coadd_type = read_fastspecfit(args.fastphotfile, fastphot=True)
-
-    else:
-        pass # should never get here
+    #from astropy.table import join
+    ## temporarily add TILEID to the tables so we can use it to join,
+    ## together with TARGETID and, optionally, NIGHT.
+    #joinkeys = ['TARGETID', 'TILEID']
+    #if 'NIGHT' in fastspec.colnames:
+    #    joinkeys += 'NIGHT'
+    #fastspec['TILEID'] = metaspec['TILEID']
+    #fastphot['TILEID'] = metaphot['TILEID']
+    #
+    #fastfit = join(fastspec, fastphot, join_type='outer', table_names=['SPEC', 'PHOT'], keys=joinkeys)
+    #metadata = join(metaspec, metaphot, join_type='outer', table_names=['SPEC', 'PHOT'], keys=joinkeys)
+    #assert(np.all(fastfit['TARGETID'] == metadata['TARGETID']))
+    #assert(np.all(fastfit['TILEID'] == metadata['TILEID']))
 
     # optionally trim to a particular tile and/or night
     def _select_tiles_nights_targets(fastfit, metadata, tiles=None, nights=None):
@@ -172,8 +165,10 @@ def main(args=None, comm=None):
             log.info('Keeping {} objects from night(s) {}'.format(len(fastfit), ','.join(nights)))
         return fastfit[keep], metadata[keep]
     
-    fastfit, metadata = _select_tiles_nights_targets(
-        fastfit, metadata, tiles=args.tile, nights=args.night)
+    fastspec, metadata = _select_tiles_nights_targets(
+        fastspec, metadata, tiles=args.tile, nights=args.night)
+    fastphot, metaphot = _select_tiles_nights_targets(
+        fastphot, metaphot, tiles=args.tile, nights=args.night)
 
     # parse the targetids optional input
     if args.targetids:
@@ -189,14 +184,17 @@ def main(args=None, comm=None):
     if args.ntargets is not None:
         keep = np.arange(args.ntargets) + args.firsttarget
         log.info('Keeping {} targets.'.format(args.ntargets))
-        fastfit = fastfit[keep]
+        fastspec = fastspec[keep]
+        fastphot = fastphot[keep]
         metadata = metadata[keep]
 
-    zbestdir = os.path.join(os.getenv('DESI_SPECTRO_REDUX'), specprod, 'tiles')
-
-    if args.outdir:
-        if not os.path.isdir(args.outdir):
-            os.makedirs(args.outdir, exist_ok=True)
+    zbestdir = os.path.join(os.getenv('DESI_SPECTRO_REDUX'), specprod, 'tiles')    
+    if args.outdir is None:
+        outdir = os.path.join(os.getenv('FASTSPECFIT_DATA'), specprod, 'tiles', 'stacks')
+    else:
+        outdir = args.outdir
+    if not os.path.isdir(outdir):
+        os.makedirs(outdir, exist_ok=True)
         
     # Initialize the continuum- and emission-line fitting classes.
     t0 = time.time()
@@ -225,7 +223,6 @@ def main(args=None, comm=None):
     tall = time.time()
     for tinfo in tileinfo:
         tile = tinfo['TILEID']
-        log.info('Working on tile {}'.format(tile))
 
         if tinfo['SURVEY'].upper() == 'SV1':
             from desitarget.sv1.sv1_targetmask import desi_mask#, bgs_mask, mws_mask
@@ -239,41 +236,31 @@ def main(args=None, comm=None):
             mwsbit = 'SV2_MWS_TARGET'
         else:
             NotImplementedError
-
-        # need to account for the join suffix when we have both fastspec and
-        # fastphot output
-        if 'DESI_TARGET_SPEC' in metadata.colnames:
-            desibit = desibit+'_SPEC'
-            bgsbit = bgsbit+'_SPEC'
-            mwsbit = mwsbit+'_SPEC'
-            fibercol = 'FIBER_SPEC'
-            thrunightcol = 'THRUNIGHT_SPEC'
-        else:
-            fibercol = 'FIBER'
-            thrunightcol = 'THRUNIGHT'
             
         for targetclass in targetclasses:
-            log.info('Working on {} on tile {}'.format(targetclass, tile))
-            
             targintile = np.where(
                 (tile == metadata['TILEID']) *
-                (metadata['Z_SPEC'] > 0.01) * # minimum redshift!
+                (metadata['Z'] > 0.01) * # minimum redshift!
                 #(metadata['Z_SPEC'] > 1.0) *
                 #(metadata['Z_SPEC'] < 1.1) *
                 metadata[desibit] & desi_mask.mask(targetclass) != 0)[0]
+            
+            log.info('Working on {} {}s on tile {}'.format(len(targintile), targetclass, tile))
+            
             if len(targintile) == 0:
                 log.info('No good {} targets in tile {}...moving on.'.format(targetclass, tile))
                 continue
             #targintile = targintile[:22]
             
-            targ_fastfit = fastfit[targintile]
+            targ_fastspec = fastspec[targintile]
+            targ_fastphot = fastphot[targintile]
             targ_metadata = metadata[targintile]
             nobj = len(targ_metadata)
 
             # Construct the zbestfiles filenames based on the input (only
             # supports coadd_type=='cumulative').
-            allpetals = targ_metadata[fibercol].data // 500
-            thrunights = targ_metadata[thrunightcol].astype(str).data
+            allpetals = targ_metadata['FIBER'].data // 500
+            thrunights = targ_metadata['THRUNIGHT'].astype(str).data
             targetids = targ_metadata['TARGETID']
             assert(len(np.unique(thrunights)) == 1)
 
@@ -324,8 +311,11 @@ def main(args=None, comm=None):
             #plt.plot(restwave, np.sum(restflux, axis=0)) ; plt.xlim(3000, 4200) ; plt.savefig('test.png')
             #pdb.set_trace()
 
-            write_stacked(restwave, restflux, restivar, fastspec, fastphot,
-                          metadata, outfile, specprod, coadd_type):
+            nicetargetclass = targetclass.replace('BGS_ANY', 'BGS').lower()
+            outfile = os.path.join(outdir, '{}-{}-restflux.fits'.format(nicetargetclass, tile))
+            write_stacked(restwave, restflux, restivar, targ_fastspec,
+                          targ_fastphot, targ_metadata, outfile, specprod,
+                          coadd_type)
             pdb.set_trace()
 
     log.info('Stacking everything took: {:.2f} sec'.format(time.time()-tall))

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -98,8 +98,11 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
             outdir = os.path.dirname(logfile)
             if not os.path.isdir(outdir):
                 os.makedirs(outdir, exist_ok=True)
-            with open(logfile, 'w') as mylog:
-                err = subprocess.call(cmd.split(), stdout=mylog, stderr=mylog)
+            if args.nolog:
+                err = subprocess.call(cmd.split())
+            else:
+                with open(logfile, 'w') as mylog:
+                    err = subprocess.call(cmd.split(), stdout=mylog, stderr=mylog)
             dt1 = time.time() - t1
             if err == 0:
                 log.info('  rank {} done in {:.2f} sec'.format(rank, dt1))
@@ -156,6 +159,7 @@ def main():
     parser.add_argument('--overwrite', action='store_true', help='Overwrite any existing output files.')
     parser.add_argument('--plan', action='store_true', help='Plan how many nodes to use and how to distribute the targets.')
     parser.add_argument('--nompi', action='store_true', help='Do not use MPI parallelism.')
+    parser.add_argument('--nolog', action='store_true', help='Do not write to the log file.')
     parser.add_argument('--dry-run', action='store_true', help='Generate but do not run commands')
 
     specprod_dir = None

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -97,7 +97,7 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
             # memory leak?  Try making system call instead
             outdir = os.path.dirname(logfile)
             if not os.path.isdir(outdir):
-                os.makedirs(outdir)
+                os.makedirs(outdir, exist_ok=True)
             with open(logfile, 'w') as mylog:
                 err = subprocess.call(cmd.split(), stdout=mylog, stderr=mylog)
             dt1 = time.time() - t1

--- a/bin/mpi-fastspecfit.sh
+++ b/bin/mpi-fastspecfit.sh
@@ -42,9 +42,9 @@ export MPICH_GNI_FORK_MODE=FULLCOPY
 if [ $stage = "test" ]; then
     time python /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit --help
 elif [ $stage = "fastspec" ]; then
-    time python /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit --mp $mp --specprod $specprod --coadd-type $coadd_type --tile 80607 80608 80613
+    time python /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit --mp $mp --specprod $specprod --coadd-type $coadd_type
 elif [ $stage = "fastphot" ]; then
-    time python /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit --fastphot --mp $mp --specprod $specprod --coadd-type $coadd_type --tile 80607 80608 80613
+    time python /global/homes/i/ioannis/repos/desihub/fastspecfit/bin/mpi-fastspecfit --fastphot --mp $mp --specprod $specprod --coadd-type $coadd_type
 else
     echo "Unrecognized stage "$stage
 fi

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,11 @@ FastSpecFit Change Log
 0.0.3 (unreleased)
 -------------------
 
-* First set of updates for denali data release [`PR #16`_].
+* Additional updates needed to finish fitting all of Denali [`PR #18`_].
+* First set of updates for Denali data release [`PR #16`_].
 
 .. _`PR #16`: https://github.com/desihub/fastspecfit/pull/16
+.. _`PR #18`: https://github.com/desihub/fastspecfit/pull/18
 
 
 0.0.2 (2021-04-10)

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -295,6 +295,12 @@ class ContinuumTools(object):
         if ivarmaggies is None:
             ivarmaggies = np.zeros_like(maggies)
 
+        ## Gaia-only targets all have grz=-99 fluxes (we now cut these out in
+        ## io.DESISpectra.find_specfiles)
+        #if np.all(maggies==-99):
+        #    log.warning('Gaia-only targets not supported.')
+        #    raise ValueError
+
         phot['lambda_eff'] = lambda_eff.astype('f4')
         if nanomaggies:
             phot['nanomaggies'] = maggies.astype('f4')
@@ -1026,7 +1032,10 @@ class ContinuumFit(ContinuumTools):
         objflam = data['phot']['flam'].data * self.fluxnorm
         objflamivar = data['phot']['flam_ivar'].data / self.fluxnorm**2
         zsspflam_dustvdisp = zsspphot_dustvdisp['flam'].data * self.fluxnorm * self.massnorm # [nband,nage*nAV]
-        assert(np.all(objflamivar >= 0))
+        try:
+            assert(np.all(objflamivar >= 0))
+        except:
+            pdb.set_trace()
 
         inodust = np.asscalar(np.where(self.AV == 0)[0]) # should always be index 0
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1275,7 +1275,7 @@ class ContinuumFit(ContinuumTools):
         result['D4000_MODEL'][0] = d4000_model
 
         for icam, cam in enumerate(data['cameras']):
-            nonzero = continuummodel[icam] != 0
+            nonzero = np.abs(continuummodel[icam]) > 1e-5
             if np.sum(nonzero) > 0:
                 corr = np.mean(smooth_continuum[icam][nonzero] / continuummodel[icam][nonzero])
                 result['CONTINUUM_SMOOTHCORR_{}'.format(cam.upper())] = corr

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -636,7 +636,7 @@ class ContinuumTools(object):
 
         if percamera:
             smooth_continuum = []
-            for icam in [0, 1, 2]: # iterate over cameras        
+            for icam in np.arange(len(specflux)): # iterate over cameras        
                 residuals = specflux[icam] - continuummodel[icam]
                 if False:
                     smooth1 = robust_median(specwave[icam], residuals, specivar[icam], binwave)
@@ -1236,7 +1236,7 @@ class ContinuumFit(ContinuumTools):
         # Unpack the continuum into individual cameras.
         continuummodel = []
         smooth_continuum = []
-        for icam in [0, 1, 2]: # iterate over cameras
+        for icam in np.arange(len(data['cameras'])): # iterate over cameras
             ipix = np.sum(npixpercam[:icam+1])
             jpix = np.sum(npixpercam[:icam+2])
             continuummodel.append(bestfit[ipix:jpix])
@@ -1250,11 +1250,11 @@ class ContinuumFit(ContinuumTools):
         if False:
             import matplotlib.pyplot as plt
             fig, ax = plt.subplots(2, 1)
-            for icam in [0, 1, 2]: # iterate over cameras
+            for icam in np.arange(len(data['cameras'])): # iterate over cameras
                 resid = data['flux'][icam]-continuummodel[icam]
                 ax[0].plot(data['wave'][icam], resid)
                 ax[1].plot(data['wave'][icam], resid-smooth_continuum[icam])
-            for icam in [0, 1, 2]: # iterate over cameras
+            for icam in np.arange(len(data['cameras'])): # iterate over cameras
                 resid = data['flux'][icam]-continuummodel[icam]
                 pix_emlines = np.logical_not(data['linemask'][icam]) # affected by line = True
                 ax[0].scatter(data['wave'][icam][pix_emlines], resid[pix_emlines], s=30, color='red')

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -925,7 +925,7 @@ class EMLineFit(ContinuumTools):
             result['{}_CONT_IVAR'.format(linename)] = civar
 
             ew, ewivar, fluxlimit, ewlimit = 0.0, 0.0, 0.0, 0.0
-            if result['{}_CONT_IVAR'.format(linename)] != 0.0:
+            if result['{}_CONT'.format(linename)] != 0.0 and result['{}_CONT_IVAR'.format(linename)] != 0.0:
                 #if result['{}_CONT'.format(linename)] == 0:
                 #    pdb.set_trace()
                 factor = (1 + redshift) / result['{}_CONT'.format(linename)] # --> rest frame

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -905,10 +905,12 @@ class EMLineFit(ContinuumTools):
 
             # get the continuum, the inverse variance in the line-amplitude, and the EW
             indxlo = np.where((emlinewave > (linezwave - 10*linesigma * linezwave / C_LIGHT)) *
-                              (emlinewave < (linezwave - 3.*linesigma * linezwave / C_LIGHT)))[0]# *
+                              (emlinewave < (linezwave - 3.*linesigma * linezwave / C_LIGHT)) *
+                              (emlineivar > 0))[0]
                               #(emlinemodel == 0))[0]
             indxhi = np.where((emlinewave < (linezwave + 10*linesigma * linezwave / C_LIGHT)) *
-                              (emlinewave > (linezwave + 3.*linesigma * linezwave / C_LIGHT)))[0]# *
+                              (emlinewave > (linezwave + 3.*linesigma * linezwave / C_LIGHT)) *
+                              (emlineivar > 0))[0]
                               #(emlinemodel == 0))[0]
             indx = np.hstack((indxlo, indxhi))
 
@@ -916,11 +918,15 @@ class EMLineFit(ContinuumTools):
             if len(indx) > 10: # require at least XX pixels to get the continuum level
                 #_, cmed, csig = sigma_clipped_stats(specflux_nolines[indx], sigma=3.0)
                 clipflux, _, _ = sigmaclip(specflux_nolines[indx], low=3, high=3)
-                cmed, csig = np.median(clipflux), np.std(clipflux)
+                # corner case: if a portion of a camera is masked
+                if len(clipflux) > 0:
+                    cmed, csig = np.median(clipflux), np.std(clipflux)
                 if csig > 0:
                     civar = (np.sqrt(len(indx)) / csig)**2
                     #result['{}_AMP_IVAR'.format(linename)] = 1 / csig**2
-                
+
+            #if '3726' in linename:
+            #    pdb.set_trace()
             result['{}_CONT'.format(linename)] = cmed
             result['{}_CONT_IVAR'.format(linename)] = civar
 

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -409,6 +409,9 @@ class EMLineModel(Fittable1DModel):
             ipix = np.sum(self.npixpercamera[:ii+1]) # all pixels!
             jpix = np.sum(self.npixpercamera[:ii+2])
             #_emlinemodel = resample_flux(emlinewave[ipix:jpix], 10**self.log10wave, log10model)
+            if ipix == jpix:
+                pdb.set_trace()
+        
             _emlinemodel = trapz_rebin(10**self.log10wave, log10model, emlinewave[ipix:jpix])
 
             if self.emlineR is not None:
@@ -670,7 +673,7 @@ class EMLineFit(ContinuumTools):
         emlinebad = np.logical_not(emlinegood)
         if np.count_nonzero(emlinebad) > 0:
             weights[emlinebad] = 10*np.max(weights[emlinegood]) # 1e16 # ???
-        
+
         t0 = time.time()
         bestfit_init = self.fitter(self.EMLineModel, emlinewave, emlineflux, weights=weights, maxiter=1000)
         #bestfit_init = self.fitter(self.EMLineModel, emlinewave[emlinegood], emlineflux[emlinegood],

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -56,8 +56,9 @@ class DESISpectra(object):
         # fastspec /global/cfs/cdirs/desi/spectro/redux/blanc/tiles/80605/20201222/zbest-6-80605-20201222.fits -o /global/cfs/cdirs/desi/spectro/fastspecfit/blanc/tiles/80605/20201222/fastspec-6-80605-20201222.fits --mp 32
         fahdr = fits.getheader(fiberfile, ext=0)
         targetdirs = [fahdr['TARG']]
-        if 'TARG2' in fahdr:
-            targetdirs += [fahdr['TARG2']]
+        for moretarg in ['TARG2', 'TARG3', 'TARG4']:
+            if moretarg in fahdr:
+                targetdirs += [fahdr[moretarg]]
         if 'SCND' in fahdr:
             if fahdr['SCND'].strip() != '-':
                 targetdirs += [fahdr['SCND']]
@@ -265,6 +266,10 @@ class DESISpectra(object):
                         targets.append(alltargets)
                         
         targets = Table(np.hstack(targets))
+
+        # targets table can include duplicates from secondary programs...
+        _, uindx = np.unique(targets['TARGETID'], return_index=True) 
+        targets = targets[uindx]
         if len(targets) != len(meta):
             log.warning('Missing targeting info for {} objects!'.format(len(meta) - len(targets)))
             raise ValueError

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -177,8 +177,9 @@ class DESISpectra(object):
                 # Are we reading individual exposures or coadds?
                 meta = fitsio.read(specfile, 'FIBERMAP', columns=fmcols)
                 assert(np.all(zb['TARGETID'] == meta['TARGETID']))
-                fitindx = np.where((zb['Z'] > 0) * (zb['ZWARN'] == 0) * #(zb['SPECTYPE'] == 'GALAXY') * 
-                     (meta['OBJTYPE'] == 'TGT') * (meta['FIBERSTATUS'] == 0))[0]
+                fitindx = np.where((zb['Z'] > 0) * (zb['ZWARN'] == 0) * #(zb['SPECTYPE'] == 'GALAXY') *
+                                   (meta['PHOTSYS'] != 'G') *
+                                   (meta['OBJTYPE'] == 'TGT') * (meta['FIBERSTATUS'] == 0))[0]
             else:
                 # We already know we like the input targetids, so no selection
                 # needed.

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -59,7 +59,8 @@ class DESISpectra(object):
         if 'TARG2' in fahdr:
             targetdirs += [fahdr['TARG2']]
         if 'SCND' in fahdr:
-            targetdirs += [fahdr['SCND']]
+            if fahdr['SCND'].strip() != '-':
+                targetdirs += [fahdr['SCND']]
             
         for ii, targetdir in enumerate(targetdirs):
             targetdir = os.path.join(os.getenv('DESI_ROOT'), targetdir.replace('DESIROOT/', ''))

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -270,8 +270,8 @@ class DESISpectra(object):
         # targets table can include duplicates from secondary programs...
         _, uindx = np.unique(targets['TARGETID'], return_index=True) 
         targets = targets[uindx]
-        if len(targets) != len(meta):
-            log.warning('Missing targeting info for {} objects!'.format(len(meta) - len(targets)))
+        if len(targets) != len(info):
+            log.warning('Missing targeting info for {} objects!'.format(len(info) - len(targets)))
             raise ValueError
 
         metas = []

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -79,7 +79,7 @@ def group_zbestfiles(specfiles, maxnodes=256, comm=None, makeqa=False):
             _, I, _ = np.intersect1d(fm['TARGETID'], zb['TARGETID'], return_indices=True)
             fm = fm[I]
             assert(np.all(zb['TARGETID'] == fm['TARGETID']))
-            J = ((zb['Z'] > 0) * #(zb['ZWARN'] == 0) * #(zb['SPECTYPE'] == 'GALAXY') * 
+            J = ((zb['Z'] > 0) * (zb['ZWARN'] == 0) * #(zb['SPECTYPE'] == 'GALAXY') * 
                  (fm['OBJTYPE'] == 'TGT') * (fm['FIBERSTATUS'] == 0))
             ntargets[i] = np.count_nonzero(J)
 
@@ -169,7 +169,12 @@ def plan(args, comm=None, merge=False, makeqa=False, fastphot=False,
             args.tile = alltiles[ireduced]
             tileinfo = tileinfo[ireduced]
             #print(args.tile)
-            print(tileinfo)
+
+            #if True:
+            #    tileinfo = tileinfo[['lrg' in program or 'elg' in program for program in tileinfo['FAPRGRM']]]
+            #    args.tile = np.array(list(set(tileinfo['TILEID'])))
+            #print(tileinfo)
+            #pdb.set_trace()
 
         outdir = os.path.join(os.getenv('FASTSPECFIT_DATA'), args.specprod, 'tiles')
         htmldir = os.path.join(os.getenv('FASTSPECFIT_HTML'), args.specprod, 'tiles')
@@ -354,7 +359,7 @@ def merge_fastspecfit(args, fastphot=False, specprod_dir=None):
 
     mergedir = os.path.join(outdir, 'merged')
     if not os.path.isdir(mergedir):
-        os.makedirs(mergedir)
+        os.makedirs(mergedir, exist_ok=True)
 
     #if args.coadd_type == 'deep-coadds':
     #    mergeprefix = 'deep'

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -161,13 +161,14 @@ def plan(args, comm=None, merge=False, makeqa=False, fastphot=False,
             #tileinfo = tileinfo[tileinfo['PROGRAM'] == 'SV1']
             #log.info('Retrieved a list of {} SV1 tiles from {}'.format(len(tileinfo), tilefile))
 
-            alltiles = np.array(list(set(tileinfo['TILEID'])))
-            ireduced = [os.path.isdir(os.path.join(specprod_dir, args.coadd_type, str(tile1))) for tile1 in alltiles]
-            log.info('In specprod={}, {}/{} of these tiles have been reduced.'.format(
-                args.specprod, np.sum(ireduced), len(alltiles)))
+            #alltiles = np.array(list(set(tileinfo['TILEID'])))
+            #ireduced = [os.path.isdir(os.path.join(specprod_dir, args.coadd_type, str(tile1))) for tile1 in alltiles]
+            #log.info('In specprod={}, {}/{} of these tiles have been reduced.'.format(
+            #    args.specprod, np.sum(ireduced), len(alltiles)))
+            #args.tile = alltiles[ireduced]
+            #tileinfo = tileinfo[ireduced]
 
-            args.tile = alltiles[ireduced]
-            tileinfo = tileinfo[ireduced]
+            args.tile = np.array(list(set(tileinfo['TILEID'])))
             #print(args.tile)
 
             #if True:

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -148,9 +148,9 @@ def plan(args, comm=None, merge=False, makeqa=False, fastphot=False,
             tileinfo = alltileinfo[['sv' in survey for survey in alltileinfo['SURVEY']]]
             #tileinfo = tileinfo[['sv' in survey or 'cmx' in survey for survey in tileinfo['SURVEY']]]
 
-            log.info('Add tiles 80605-80610 which are incorrectly identified as cmx tiles.')
-            tileinfo = vstack((tileinfo, alltileinfo[np.where((alltileinfo['TILEID'] >= 80605) * (alltileinfo['TILEID'] <= 80610))[0]]))
-            tileinfo = tileinfo[np.argsort(tileinfo['TILEID'])]
+            #log.info('Add tiles 80605-80610 which are incorrectly identified as cmx tiles.')
+            #tileinfo = vstack((tileinfo, alltileinfo[np.where((alltileinfo['TILEID'] >= 80605) * (alltileinfo['TILEID'] <= 80610))[0]]))
+            #tileinfo = tileinfo[np.argsort(tileinfo['TILEID'])]
 
             log.info('Retrieved a list of {} {} tiles from {}'.format(
                 len(tileinfo), ','.join(sorted(set(tileinfo['SURVEY']))), tilefile))
@@ -174,7 +174,6 @@ def plan(args, comm=None, merge=False, makeqa=False, fastphot=False,
             #    tileinfo = tileinfo[['lrg' in program or 'elg' in program for program in tileinfo['FAPRGRM']]]
             #    args.tile = np.array(list(set(tileinfo['TILEID'])))
             #print(tileinfo)
-            #pdb.set_trace()
 
         outdir = os.path.join(os.getenv('FASTSPECFIT_DATA'), args.specprod, 'tiles')
         htmldir = os.path.join(os.getenv('FASTSPECFIT_HTML'), args.specprod, 'tiles')

--- a/py/fastspecfit/scripts/fastspec.py
+++ b/py/fastspecfit/scripts/fastspec.py
@@ -53,7 +53,7 @@ def fastspec_one(iobj, data, out, meta, CFit, EMFit, solve_vdisp=False):
     #    meta['FLUX_{}'.format(band.upper())] = data['phot']['nanomaggies'][iband]
     #    meta['FLUX_IVAR_{}'.format(band.upper())] = data['phot']['nanomaggies_ivar'][iband]
         
-    log.info('Continuum-fitting object {} (targetid {}) took {:.2f} sec'.format(
+    log.info('Continuum-fitting object {} [targetid {}] took {:.2f} sec'.format(
         iobj, meta['TARGETID'], time.time()-t0))
     
     # Fit the emission-line spectrum.

--- a/sandbox/find-nans
+++ b/sandbox/find-nans
@@ -10,11 +10,10 @@ from astropy.table import Table
 topdir = '/global/cfs/cdirs/desi/spectro/fastspecfit/denali/tiles/'
 #topdir = '/Users/ioannis/work/desi/spectro/fastspecfit/denali/tiles/'
 
-#tt = Table(fitsio.read(topdir+'merged/fastphot-denali-cumulative.fits', 'FASTPHOT'))
-#mm = Table(fitsio.read(topdir+'merged/fastphot-denali-cumulative.fits', 'METADATA'))
-
-tt = Table(fitsio.read(topdir+'merged/fastspec-denali-cumulative.fits', 'FASTSPEC'))
-mm = Table(fitsio.read(topdir+'merged/fastspec-denali-cumulative.fits', 'METADATA'))
+tt = Table(fitsio.read(topdir+'merged/fastphot-denali-cumulative.fits', 'FASTPHOT'))
+mm = Table(fitsio.read(topdir+'merged/fastphot-denali-cumulative.fits', 'METADATA'))
+#tt = Table(fitsio.read(topdir+'merged/fastspec-denali-cumulative.fits', 'FASTSPEC'))
+#mm = Table(fitsio.read(topdir+'merged/fastspec-denali-cumulative.fits', 'METADATA'))
 
 zbest = []
 
@@ -41,17 +40,43 @@ for col in tt.colnames:
             zbest.append('{}/{}/zbest-{}-{}-thru{}.fits'.format(
                 str(tile), str(night), str(petal), str(tile), str(night)))
 
-zbest = np.unique(np.hstack(zbest))
-print(len(zbest))
+if len(zbest) > 0:
+    zbest = np.unique(np.hstack(zbest))
+    print(len(zbest))
+else:
+    print('No NaNs!')
+
+if True:
+    with open('/global/u2/i/ioannis/junk', 'w') as ff:
+        for zb in zbest:
+            outfile = topdir+'cumulative/{}'.format(zb.replace('zbest-', 'fastphot-'))
+            #zbestfile = topdir.replace('fastspecfit/', 'redux/')+'cumulative/{}'.formaat(zb)
+            #ff.write('fastspec {} -o {} --mp 32 \n'.format(zbestfile, outfile))
+            ff.write('\\rm {}\n'.format(outfile))
 
 pdb.set_trace()
 
-with open('/global/u2/i/ioannis/junk', 'w') as ff:
-    for zb in zbest:
-        outfile = topdir+'cumulative/{}'.format(zb.replace('zbest-', 'fastspec-'))
-        #zbestfile = topdir.replace('fastspecfit/', 'redux/')+'cumulative/{}'.formaat(zb)
-        #ff.write('fastspec {} -o {} --mp 32 \n'.format(zbestfile, outfile))
-        ff.write('\\rm {}\n'.format(outfile))
+#from fastspecfit.io import write_fastspecfit
+#fastfiles = np.array([zb.replace('zbest-', 'fastphot-') for zb in zbest])
+#for fastfile in fastfiles:
+#    ff = topdir+'cumulative/{}'.format(fastfile)
+#    data = Table.read(ff, 'FASTPHOT')
+#    meta = Table.read(ff, 'METADATA')
+#
+#    keep = np.where(np.logical_or(meta['PHOTSYS'] == 'N', meta['PHOTSYS'] == 'S'))[0]
+#    if len(keep) == len(data): # already did tit
+#        continue
+#    
+#    print('Keeping {}/{} objects'.format(len(keep), len(meta)))
+#    if len(keep) == 0:
+#        print('All targets dropped for {}'.format(ff))
+#        continue
+#
+#    data = data[keep]
+#    meta = meta[keep]
+#    write_fastspecfit(data, meta, outfile=ff, specprod='denali', coadd_type='cumulative', fastphot=True)
+
+pdb.set_trace()
 
 pdb.set_trace()
 

--- a/sandbox/find-nans
+++ b/sandbox/find-nans
@@ -6,7 +6,6 @@ import os, pdb
 import fitsio
 import numpy as np
 from astropy.table import Table
-from fastspecfit.io import write_fastspecfit
 
 topdir = '/global/cfs/cdirs/desi/spectro/fastspecfit/denali/tiles/'
 #topdir = '/Users/ioannis/work/desi/spectro/fastspecfit/denali/tiles/'
@@ -19,7 +18,6 @@ mm = Table(fitsio.read(topdir+'merged/fastspec-denali-cumulative.fits', 'METADAT
 
 zbest = []
 
-
 ifix = np.where(np.logical_or(mm['PHOTSYS'] == 'G', mm['PHOTSYS'] == ''))[0]
 if len(ifix) > 0:
     tiles = mm['TILEID'][ifix]
@@ -28,32 +26,6 @@ if len(ifix) > 0:
     for tile, petal, night in zip(tiles, petals, nights):
         zbest.append('{}/{}/zbest-{}-{}-thru{}.fits'.format(
             str(tile), str(night), str(petal), str(tile), str(night)))
-
-zbest = np.unique(np.hstack(zbest))
-print(len(zbest))
-#print(set(zbest))
-
-fastfiles = np.array([zb.replace('zbest-', 'fastspec-') for zb in zbest])
-for fastfile in fastfiles:
-    #print('Working on {}'.format(fastfile))
-    ff = topdir+'cumulative/{}'.format(fastfile)
-    data = Table.read(ff, 'FASTSPEC')
-    meta = Table.read(ff, 'METADATA')
-
-    keep = np.where(np.logical_or(meta['PHOTSYS'] == 'N', meta['PHOTSYS'] == 'S'))[0]
-    if len(keep) == len(data): # already did tit
-        continue
-    
-    print('Keeping {}/{} objects'.format(len(keep), len(meta)))
-    if len(keep) == 0:
-        print('All targets dropped for {}'.format(ff))
-        continue
-
-    data = data[keep]
-    meta = meta[keep]
-    write_fastspecfit(data, meta, outfile=ff, specprod='denali', coadd_type='cumulative', fastphot=False)
-    
-pdb.set_trace()
 
 for col in tt.colnames:
     if tt[col].dtype.char == 'U':
@@ -69,8 +41,38 @@ for col in tt.colnames:
             zbest.append('{}/{}/zbest-{}-{}-thru{}.fits'.format(
                 str(tile), str(night), str(petal), str(tile), str(night)))
 
-print(len(np.unique(np.hstack(zbest))))
+zbest = np.unique(np.hstack(zbest))
+print(len(zbest))
 
+pdb.set_trace()
 
+with open('/global/u2/i/ioannis/junk', 'w') as ff:
+    for zb in zbest:
+        outfile = topdir+'cumulative/{}'.format(zb.replace('zbest-', 'fastspec-'))
+        #zbestfile = topdir.replace('fastspecfit/', 'redux/')+'cumulative/{}'.formaat(zb)
+        #ff.write('fastspec {} -o {} --mp 32 \n'.format(zbestfile, outfile))
+        ff.write('\\rm {}\n'.format(outfile))
 
+pdb.set_trace()
 
+#from fastspecfit.io import write_fastspecfit
+#fastfiles = np.array([zb.replace('zbest-', 'fastspec-') for zb in zbest])
+#for fastfile in fastfiles:
+#    #print('Working on {}'.format(fastfile))
+#    ff = topdir+'cumulative/{}'.format(fastfile)
+#    data = Table.read(ff, 'FASTSPEC')
+#    meta = Table.read(ff, 'METADATA')
+#
+#    keep = np.where(np.logical_or(meta['PHOTSYS'] == 'N', meta['PHOTSYS'] == 'S'))[0]
+#    if len(keep) == len(data): # already did tit
+#        continue
+#    
+#    print('Keeping {}/{} objects'.format(len(keep), len(meta)))
+#    if len(keep) == 0:
+#        print('All targets dropped for {}'.format(ff))
+#        continue
+#
+#    data = data[keep]
+#    meta = meta[keep]
+#    write_fastspecfit(data, meta, outfile=ff, specprod='denali', coadd_type='cumulative', fastphot=False)
+    

--- a/sandbox/find-nans
+++ b/sandbox/find-nans
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 # /global/cfs/cdirs/desi/spectro/redux/denali/tiles/cumulative/80609/20201217/zbest-2-80609-thru20201217.fits
 
 import os, pdb
@@ -40,19 +39,19 @@ for col in tt.colnames:
             zbest.append('{}/{}/zbest-{}-{}-thru{}.fits'.format(
                 str(tile), str(night), str(petal), str(tile), str(night)))
 
-if len(zbest) > 0:
+if len(zbest) == 0:
+    print('No NaNs!')
+else:
     zbest = np.unique(np.hstack(zbest))
     print(len(zbest))
-else:
-    print('No NaNs!')
 
-if True:
-    with open('/global/u2/i/ioannis/junk', 'w') as ff:
-        for zb in zbest:
-            outfile = topdir+'cumulative/{}'.format(zb.replace('zbest-', 'fastphot-'))
-            #zbestfile = topdir.replace('fastspecfit/', 'redux/')+'cumulative/{}'.formaat(zb)
-            #ff.write('fastspec {} -o {} --mp 32 \n'.format(zbestfile, outfile))
-            ff.write('\\rm {}\n'.format(outfile))
+    if False:
+        with open('/global/u2/i/ioannis/junk', 'w') as ff:
+            for zb in zbest:
+                outfile = topdir+'cumulative/{}'.format(zb.replace('zbest-', 'fastphot-'))
+                #zbestfile = topdir.replace('fastspecfit/', 'redux/')+'cumulative/{}'.formaat(zb)
+                #ff.write('fastspec {} -o {} --mp 32 \n'.format(zbestfile, outfile))
+                ff.write('\\rm {}\n'.format(outfile))
 
 pdb.set_trace()
 
@@ -75,10 +74,6 @@ pdb.set_trace()
 #    data = data[keep]
 #    meta = meta[keep]
 #    write_fastspecfit(data, meta, outfile=ff, specprod='denali', coadd_type='cumulative', fastphot=True)
-
-pdb.set_trace()
-
-pdb.set_trace()
 
 #from fastspecfit.io import write_fastspecfit
 #fastfiles = np.array([zb.replace('zbest-', 'fastspec-') for zb in zbest])

--- a/sandbox/find-nans
+++ b/sandbox/find-nans
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# /global/cfs/cdirs/desi/spectro/redux/denali/tiles/cumulative/80609/20201217/zbest-2-80609-thru20201217.fits
+
+import os, pdb
+import fitsio
+import numpy as np
+from astropy.table import Table
+
+topdir = '/Users/ioannis/work/desi/spectro/fastspecfit/denali/tiles/'
+
+#tt = Table(fitsio.read(topdir+'merged/fastphot-denali-cumulative.fits', 'FASTPHOT'))
+#mm = Table(fitsio.read(topdir+'merged/fastphot-denali-cumulative.fits', 'METADATA'))
+
+tt = Table(fitsio.read(topdir+'merged/fastspec-denali-cumulative.fits', 'FASTSPEC'))
+mm = Table(fitsio.read(topdir+'merged/fastspec-denali-cumulative.fits', 'METADATA'))
+
+zbest = []
+
+
+ifix = np.where(np.logical_or(mm['PHOTSYS'] == 'G', mm['PHOTSYS'] == ''))[0]
+if len(ifix) > 0:
+    tiles = mm['TILEID'][ifix]
+    petals = mm['FIBER'][ifix] // 500
+    nights = mm['THRUNIGHT'][ifix]
+    for tile, petal, night in zip(tiles, petals, nights):
+        zbest.append('{}/{}/zbest-{}-{}-thru{}.fits'.format(
+            str(tile), str(night), str(petal), str(tile), str(night)))
+
+zbest = np.unique(np.hstack(zbest))
+print(len(zbest))
+#print(set(zbest))
+
+fastfiles = np.array([zb.replace('zbest-', 'fastspec-') for zb in zbest])
+for fastfile in fastfiles:
+    print('Working on {}'.format(fastfile))
+    ff = topdir+'cumulative/{}'.format(fastfile)
+    data = Table.read(ff, 'FASTSPEC')
+    meta = Table.read(ff, 'METADATA')
+
+    keep = np.where(np.logical_or(meta['PHOTSYS'] == 'N', meta['PHOTSYS'] == 'S'))[0]
+    print('Keeping {}/{} objects'.format(len(keep), len(meta)))
+
+    data = data[keep]
+    meta = meta[keep]
+    
+    pdb.set_trace()
+
+
+for col in tt.colnames:
+    if tt[col].dtype.char == 'U':
+        continue
+    ifix = np.where(np.isnan(tt[col]))[0]
+    if len(ifix) > 0:
+        print('{}: {} NaNs'.format(col, len(ifix)))
+
+        tiles = mm['TILEID'][ifix]
+        petals = mm['FIBER'][ifix] // 500
+        nights = mm['THRUNIGHT'][ifix]
+        for tile, petal, night in zip(tiles, petals, nights):
+            zbest.append('{}/{}/zbest-{}-{}-thru{}.fits'.format(
+                str(tile), str(night), str(petal), str(tile), str(night)))
+
+print(len(np.unique(np.hstack(zbest))))
+
+
+
+

--- a/sandbox/find-nans
+++ b/sandbox/find-nans
@@ -6,8 +6,10 @@ import os, pdb
 import fitsio
 import numpy as np
 from astropy.table import Table
+from fastspecfit.io import write_fastspecfit
 
-topdir = '/Users/ioannis/work/desi/spectro/fastspecfit/denali/tiles/'
+topdir = '/global/cfs/cdirs/desi/spectro/fastspecfit/denali/tiles/'
+#topdir = '/Users/ioannis/work/desi/spectro/fastspecfit/denali/tiles/'
 
 #tt = Table(fitsio.read(topdir+'merged/fastphot-denali-cumulative.fits', 'FASTPHOT'))
 #mm = Table(fitsio.read(topdir+'merged/fastphot-denali-cumulative.fits', 'METADATA'))
@@ -33,19 +35,25 @@ print(len(zbest))
 
 fastfiles = np.array([zb.replace('zbest-', 'fastspec-') for zb in zbest])
 for fastfile in fastfiles:
-    print('Working on {}'.format(fastfile))
+    #print('Working on {}'.format(fastfile))
     ff = topdir+'cumulative/{}'.format(fastfile)
     data = Table.read(ff, 'FASTSPEC')
     meta = Table.read(ff, 'METADATA')
 
     keep = np.where(np.logical_or(meta['PHOTSYS'] == 'N', meta['PHOTSYS'] == 'S'))[0]
+    if len(keep) == len(data): # already did tit
+        continue
+    
     print('Keeping {}/{} objects'.format(len(keep), len(meta)))
+    if len(keep) == 0:
+        print('All targets dropped for {}'.format(ff))
+        continue
 
     data = data[keep]
     meta = meta[keep]
+    write_fastspecfit(data, meta, outfile=ff, specprod='denali', coadd_type='cumulative', fastphot=False)
     
-    pdb.set_trace()
-
+pdb.set_trace()
 
 for col in tt.colnames:
     if tt[col].dtype.char == 'U':

--- a/sandbox/stackit
+++ b/sandbox/stackit
@@ -1,0 +1,230 @@
+#!/usr/bin/env python
+"""fastspecfit stacking code
+
+fastspecfit-stack --specfitfile /global/cfs/cdirs/desi/users/ioannis/fastspecfit/blanc/tiles/specfit-80607-80613-20201214-20201223.fits --outdir /global/cfs/cdirs/desi/users/ioannis/fastspecfit/blanc/tiles/qa/stacks --tile 80608 --mp 32 --ntargets 5
+
+"""
+import pdb # for debugging
+import os, sys, time
+import numpy as np
+
+from desiutil.log import get_logger
+log = get_logger()
+
+# ridiculousness!
+import tempfile
+os.environ['MPLCONFIGDIR'] = tempfile.mkdtemp()
+
+def parse(options=None):
+    """Parse input arguments.
+
+    """
+    import sys, argparse
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument('--tile', default=None, type=str, nargs='*', help='Generate QA for all objects on this tile.')
+    parser.add_argument('--night', default=None, type=str, nargs='*', help='Generate QA for all objects observed on this night.')
+    parser.add_argument('--targetids', type=str, default=None, help='Comma-separated list of target IDs to process.')
+    parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
+    parser.add_argument('--firsttarget', type=int, default=0, help='Index of first object to to process in each file (0-indexed).')
+    parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
+
+    parser.add_argument('--suffix', default=None, type=str, help='Optional suffix for output filename.')
+    parser.add_argument('-o', '--outdir', default=None, type=str, help='Full path to desired output directory.')
+    
+    parser.add_argument('--specfitfile', default=None, type=str, help='Full path to specfit fitting results.')
+    
+    if options is None:
+        args = parser.parse_args()
+        log.info(' '.join(sys.argv))
+    else:
+        args = parser.parse_args(options)
+        log.info('fastspecfit-stack {}'.format(' '.join(options)))
+
+    return args
+
+def main(args=None, comm=None):
+    """Main module.
+
+    """
+    import fitsio
+    from astropy.table import Table
+    from astropy.io import fits
+
+    from desispec.interpolation import resample_flux
+    from desitarget.sv1.sv1_targetmask import desi_mask
+
+    from fastspecfit.continuum import ContinuumFit
+    from fastspecfit.emlines import EMLineFit
+    from fastspecfit.external.desi import DESISpectra
+
+    if isinstance(args, (list, tuple, type(None))):
+        args = parse(args)
+
+    # Read the fitting results.
+    if args.specfitfile is None:
+        log.warning('Must provide --specfitfile.')
+        return
+
+    def _check_and_read(filename):
+        if os.path.isfile(filename):
+            fastfit, hdr = fitsio.read(filename, header=True, ext='RESULTS')
+            specprod = hdr['SPECPROD']
+            fastfit = Table(fastfit)
+            log.info('Read {} objects from {}'.format(len(fastfit), filename))
+            return fastfit, specprod
+        else:
+            log.warning('File {} not found.'.format(filename))
+            raise IOError
+
+    specfit, specprod = _check_and_read(args.specfitfile)
+
+    # parse the targetids optional input
+    if args.targetids:
+        targetids = [int(x) for x in args.targetids.split(',')]
+    else:
+        targetids = args.targetids
+
+    # optionally trim to a particular tile and/or night
+    def _select_tiles_nights_targets(fastfit, tiles=None, nights=None, targetids=None):
+        if fastfit and (tiles or nights or targetids):
+            keep = np.ones(len(fastfit), bool)
+            if targetids:
+                targetkeep = np.zeros(len(fastfit), bool)
+                for targetid in targetids:
+                    targetkeep = np.logical_or(targetkeep, fastfit['TARGETID'] == targetid)
+                keep = np.logical_and(keep, targetkeep)
+            if tiles:
+                tilekeep = np.zeros(len(fastfit), bool)
+                for tile in tiles:
+                    tilekeep = np.logical_or(tilekeep, fastfit['TILEID'].astype(str) == tile)
+                keep = np.logical_and(keep, tilekeep)
+            if nights:
+                nightkeep = np.zeros(len(fastfit), bool)
+                for night in nights:
+                    nightkeep = np.logical_or(nightkeep, fastfit['NIGHT'].astype(str) == night)
+                keep = np.logical_and(keep, nightkeep)
+            fastfit = fastfit[keep]
+            #log.info('Keeping {} spectra from tile {} on night {}.'.format(len(fastfit), tile, night))
+        return fastfit
+
+    specfit = _select_tiles_nights_targets(specfit, tiles=args.tile, nights=args.night, targetids=targetids)
+
+    # Initialize the continuum- and emission-line fitting classes.
+    t0 = time.time()
+    CFit = ContinuumFit()
+    EMFit = EMLineFit()
+    log.info('Initializing the classes took: {:.2f} sec'.format(time.time()-t0))
+
+    Spec = DESISpectra()
+
+    # select ELGs
+    ielg = np.where((specfit['SV1_DESI_TARGET'] & desi_mask.mask('ELG') != 0) *
+                    (specfit['OII_3726_FLUX'] > 0) *
+                    (specfit['OII_3729_FLUX'] > 0))[0]
+    specfit = specfit[ielg]
+
+    Spec.find_specfiles(fastfit=specfit, specprod=specprod, targetids=targetids,
+                        firsttarget=args.firsttarget, ntargets=args.ntargets)
+    if len(Spec.specfiles) == 0:
+        return
+    data = Spec.read_and_unpack(CFit, synthphot=True, remember_coadd=True)
+
+    # sort specfit so it matches 'data', 'Spec.fibermap', and 'Spec.zbest'
+    refindx = np.array(['{}-{}-{}'.format(night, tile, tid) for night, tile, tid in zip(Spec.fibermap['FIRST_NIGHT'], Spec.fibermap['FIRST_TILEID'], Spec.fibermap['TARGETID'])])
+    sindx = np.array(['{}-{}-{}'.format(night, tile, tid) for night, tile, tid in zip(specfit['NIGHT'], specfit['TILEID'], specfit['TARGETID'])])
+    specfit = specfit[np.hstack([np.where(rindx == sindx)[0] for rindx in refindx])]
+    
+    wave = np.arange(1200.0, 8000.0, 0.5)
+    npix = len(wave)
+
+    # Build the stacks!
+    ngal = len(specfit)
+    flux = np.zeros((ngal, npix))
+    ivar = np.zeros((ngal, npix))
+    keep = np.ones(ngal, bool)
+    t0 = time.time()
+    pad = 10.0
+    for igal, onegal in enumerate(data):
+        cwave = onegal['coadd_wave'] / (1 + onegal['zredrock'])
+        #I = np.where((wave > (cwave.min()+0)) * (wave < (cwave.max()-0)))[0]
+        I = np.where((wave > (cwave.min()+pad)) * (wave < (cwave.max()-pad)))[0]
+        #I = np.where((wave > (cwave.min()+5)) * (wave < (cwave.max()-5)) * (onegal['coadd_ivar'] > 0))[0]
+        if len(I) > 5:# and np.count_nonzero(onegal['coadd_ivar'] > 0) > 10:
+            try:
+                _flux, _ivar = resample_flux(wave[I], cwave, onegal['coadd_flux'], ivar=onegal['coadd_ivar'])
+                flux[igal, I] = _flux
+                ivar[igal, I] = _ivar
+            except:
+                log.info('Rejecting object {}'.format(igal))
+                pdb.set_trace()
+                keep[igal] = False
+        else:
+            log.info('Rejecting object {}'.format(igal))
+            keep[igal] = False
+        #_ivar = resample_flux(wave, onegal['coadd_wave'] / (1 + onegal['zredrock']),
+        #                      onegal['coadd_flux'], extrapolate=False)
+        #norm = np.median(_flux)
+        #if norm > 0:
+        #    _flux /= norm
+        #    _ivar *= norm**2
+#        _flux /= CFit.fluxnorm * onegal['synthphot']['flam'][1] # r-band flux
+    log.info('Done in {:.2f} sec'.format(time.time()-t0))
+
+    #INFO:fastspecfit-stack:159:main: Rejecting object 7944
+    #INFO:fastspecfit-stack:159:main: Rejecting object 14511
+    #INFO:fastspecfit-stack:159:main: Rejecting object 17092
+    #INFO:fastspecfit-stack:159:main: Rejecting object 18932
+    #INFO:fastspecfit-stack:159:main: Rejecting object 19148
+    reject = np.where(np.logical_not(keep))[0]
+    keep = np.where(keep)[0]
+    if len(reject) > 0:
+        pdb.set_trace()
+
+    try:
+        flux = flux[keep, :]
+        ivar = ivar[keep, :]
+        specfit = specfit[keep]
+        zbest = Spec.zbest[keep]
+        fibermap = Spec.fibermap[keep]
+
+        # write out
+        t0 = time.time()
+        if args.outdir is None:
+            args.outdir = '.'
+        if not os.path.isdir(args.outdir):
+            os.makedirs(args.outdir)
+
+        outfile = os.path.join(args.outdir, 'rest-elgs-{}.fits'.format(args.tile[0]))
+
+        hduflux = fits.PrimaryHDU(flux.astype('f4'))
+        hduflux.header['EXTNAME'] = 'FLUX'
+
+        hduivar = fits.ImageHDU(ivar.astype('f4'))
+        hduivar.header['EXTNAME'] = 'IVAR'
+
+        hduwave = fits.ImageHDU(wave.astype('f8'))
+        hduwave.header['EXTNAME'] = 'WAVE'
+        hduwave.header['BUNIT'] = 'Angstrom'
+        hduwave.header['AIRORVAC'] = ('vac', 'vacuum wavelengths')
+
+        hduspecfit = fits.convenience.table_to_hdu(specfit)
+        hduspecfit.header['EXTNAME'] = 'SPECFIT'
+
+        hduzbest = fits.convenience.table_to_hdu(zbest)
+        hduzbest.header['EXTNAME'] = 'ZBEST'
+
+        hdufmap = fits.convenience.table_to_hdu(fibermap)
+        hdufmap.header['EXTNAME'] = 'FIBERMAP'
+
+        hx = fits.HDUList([hduflux, hduwave, hduspecfit, hduzbest, hdufmap])
+
+        print('Writing {}'.format(outfile))
+        hx.writeto(outfile, overwrite=True)
+        log.info('Time to write is {:.2f} sec'.format(time.time()-t0))
+    except:
+        pdb.set_trace()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Additional updates needed to finish fitting all of Denali, mostly catching corner cases which lead to infinity or NaN. Biggest change is that `PHOTSYS` must be either `N` or `S` (i.e., Gaia-only targets or secondary targets for which the photometric system is not defined are not fitted).

There's also now a functional code which deredshifts the data for ease of stacking and template-building.

All outputs are in `/global/cfs/cdirs/desi/spectro/fastspecfit/denali/tiles`.