### PR TITLE
refactor fitting engine to not use fnnls or astropy.modeling

### DIFF
--- a/bin/fastphot
+++ b/bin/fastphot
@@ -5,5 +5,6 @@ Example call:
   fastphot /global/cfs/cdirs/desi/spectro/redux/daily/tiles/80608/20201215/zbest-9-80608-20201215.fits -o fastphot.fits --ntargets 2 --mp 1
 
 """
-from fastspecfit.fastspecfit import fastphot
-fastphot(comm=None)
+if __name__ == '__main__':
+    from fastspecfit.fastspecfit import fastphot
+    fastphot(comm=None)

--- a/bin/fastspec
+++ b/bin/fastspec
@@ -5,5 +5,6 @@ Example call:
   fastspec /global/cfs/cdirs/desi/spectro/redux/daily/tiles/80608/20201215/zbest-9-80608-20201215.fits -o fastspec.fits --ntargets 2 --mp 1
 
 """
-from fastspecfit.fastspecfit import fastspec
-fastspec(comm=None)
+if __name__ == '__main__':
+    from fastspecfit.fastspecfit import fastspec
+    fastspec(comm=None)

--- a/bin/fastspecfit-qa
+++ b/bin/fastspecfit-qa
@@ -33,6 +33,9 @@ def parse(options=None):
     parser.add_argument('--redrockfile-prefix', type=str, default='redrock-', help='Prefix of the input Redrock file name(s).')
     parser.add_argument('--specfile-prefix', type=str, default='coadd-', help='Prefix of the spectral file(s).')
     parser.add_argument('--qnfile-prefix', type=str, default='qso_qn-', help='Prefix of the QuasarNet afterburner file(s).')
+    parser.add_argument('--mapdir', type=str, default=None, help='Optional directory name for the dust maps.')
+    parser.add_argument('--dr9dir', type=str, default=None, help='Optional directory name for the DR9 photometry.')
+
     parser.add_argument('--targetids', type=str, default=None, help='Comma-separated list of target IDs to process.')
     parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
     parser.add_argument('--firsttarget', type=int, default=0, help='Index of first object to to process in each file (0-indexed).')
@@ -104,9 +107,9 @@ def main(args=None, comm=None):
 
     # Initialize the continuum- and emission-line fitting classes.
     t0 = time.time()
-    CFit = ContinuumFit(nolegend=args.nolegend)
-    EMFit = EMLineFit(nolegend=args.nolegend)
-    Spec = DESISpectra(redux_dir=args.redux_dir)
+    CFit = ContinuumFit(nolegend=args.nolegend, mapdir=args.mapdir)
+    EMFit = EMLineFit(nolegend=args.nolegend, mapdir=args.mapdir)
+    Spec = DESISpectra(redux_dir=args.redux_dir, dr9dir=args.dr9dir)
     log.info('Initializing the classes took: {:.2f} sec'.format(time.time()-t0))
 
     if args.outdir:

--- a/bin/fastspecfit-qa
+++ b/bin/fastspecfit-qa
@@ -96,7 +96,7 @@ def main(args=None, comm=None):
             errmsg = '--webqa fastphot file {} not found.'.format(fastphotfile)
             log.critical(errmsg)
             raise IOError(errmsg)
-        
+
         webphot, _, _, _ = read_fastspecfit(fastphotfile)
         if not np.all(fastfit['TARGETID'] == webphot['TARGETID']):
             errmsg = 'Mismatch in fastspec and fastphot TARGETIDs'

--- a/bin/fastspecfit-qa
+++ b/bin/fastspecfit-qa
@@ -124,7 +124,7 @@ def main(args=None, comm=None):
                     redrockfile_prefix=args.redrockfile_prefix,
                     specfile_prefix=args.specfile_prefix,
                     qnfile_prefix=args.qnfile_prefix)
-        data = Spec.read_and_unpack(CFit, fastphot=fastphot, synthphot=True, remember_coadd=True)
+        data = Spec.read_and_unpack(CFit, fastphot=fastphot, synthphot=True)
         qaargs = [(CFit, EMFit, data[igal], fastfit[indx[igal]], metadata[indx[igal]],
                    coadd_type, fastphot, args.outdir, args.outprefix) for igal in np.arange(len(indx))]                
 

--- a/bin/fastspecfit-qa
+++ b/bin/fastspecfit-qa
@@ -82,21 +82,39 @@ def main(args=None, comm=None):
         log.warning('File {} not found.'.format(args.fastfitfile[0]))
         return
 
-    fastfit, metadata, coadd_type, isfastphot = read_fastspecfit(args.fastfitfile[0])
+    fastfit, metadata, coadd_type, fastphot = read_fastspecfit(args.fastfitfile[0])
     if args.webqa:
         # This is not great coding, but when building the webqa, assume that a
         # companion fastphot- file exists and, if not, quit.
+        if 'fastspec-' not in args.fastfitfile[0]:
+            errmsg = 'For --webqa, input fastfitfile must be have the prefix "fastspec-"'
+            log.critical(errmsg)
+            raise IOError(errmsg)
+        
         fastphotfile = args.fastfitfile[0].replace('fastspec-', 'fastphot-').replace('.gz', '')
         if not os.path.isfile(fastphotfile):
             errmsg = '--webqa fastphot file {} not found.'.format(fastphotfile)
             log.critical(errmsg)
             raise IOError(errmsg)
         
-        fastphot, _, _, _ = read_fastspecfit(fastphotfile)
-        if not np.all(fastfit['TARGETID'] == fastphot['TARGETID']):
+        webphot, _, _, _ = read_fastspecfit(fastphotfile)
+        if not np.all(fastfit['TARGETID'] == webphot['TARGETID']):
             errmsg = 'Mismatch in fastspec and fastphot TARGETIDs'
             log.critical(errmsg)
             raise Valuerror(errmsg)
+
+        # merge the results
+        from astropy.table import hstack        
+        
+        joinkeys = ['SURVEY', 'PROGRAM', 'TARGETID']
+        if coadd_type == 'healpix':
+            joinkeys += ['HEALPIX']
+        else:
+            joinkeys += ['NIGHT', 'FIBER', 'TILEID']
+        assert(np.all(fastfit[joinkeys] == webphot[joinkeys]))
+
+        webphot.remove_columns(joinkeys)
+        fastfit = hstack((fastfit, webphot), table_names=['SPEC', 'PHOT'])
         
     # parse the targetids optional input
     if args.targetids:
@@ -108,7 +126,7 @@ def main(args=None, comm=None):
         fastfit = fastfit[keep]
         metadata = metadata[keep]
         if args.webqa:
-            fastphot = fastphot[keep]
+            webphot = webphot[keep]
         
     if args.ntargets is not None:
         keep = np.arange(args.ntargets) + args.firsttarget
@@ -116,14 +134,14 @@ def main(args=None, comm=None):
         fastfit = fastfit[keep]
         metadata = metadata[keep]
         if args.webqa:
-            fastphot = fastphot[keep]
+            webphot = webphot[keep]
 
     if args.webqa:
         keep = select(fastfit, metadata, coadd_type, healpixels=args.healpix,
                       tiles=args.tile, nights=args.night, return_index=True)
         fastfit = fastfit[keep]
         metadata = metadata[keep]
-        fastphot = fastphot[keep]
+        webphot = webphot[keep]
     else:
         fastfit, metadata = select(fastfit, metadata, coadd_type, healpixels=args.healpix,
                                    tiles=args.tile, nights=args.night)
@@ -147,25 +165,24 @@ def main(args=None, comm=None):
     def _wrap_qa(redrockfile, indx=None):
         if indx is None:
             indx = np.arange(len(fastfit))
+
         targetids = fastfit['TARGETID'][indx]
         Spec.select(redrockfiles=redrockfile, targetids=targetids,
                     redrockfile_prefix=args.redrockfile_prefix,
                     specfile_prefix=args.specfile_prefix,
                     qnfile_prefix=args.qnfile_prefix)
-        data = Spec.read_and_unpack(CFit, fastphot=isfastphot, synthphot=True)
+        data = Spec.read_and_unpack(CFit, fastphot=fastphot, synthphot=True)
 
-        pdb.set_trace()
-        
         qaargs = [(CFit, EMFit, data[igal], fastfit[indx[igal]], metadata[indx[igal]],
-                   coadd_type, isfastphot, args.outdir, args.outprefix) for igal in np.arange(len(indx))]                
-
+                   coadd_type, fastphot, args.outdir, args.outprefix, args.webqa)
+                   for igal in np.arange(len(indx))]                
         if args.mp > 1:
             import multiprocessing
             with multiprocessing.Pool(args.mp) as P:
                 P.map(_desiqa_one, qaargs)
         else:
             [desiqa_one(*_qaargs) for _qaargs in qaargs]
-
+            
     t0 = time.time()
     if coadd_type == 'healpix':
         allspecprods = metadata['SPECPROD'].data

--- a/bin/fastspecfit-qa
+++ b/bin/fastspecfit-qa
@@ -41,6 +41,7 @@ def parse(options=None):
     parser.add_argument('--firsttarget', type=int, default=0, help='Index of first object to to process in each file (0-indexed).')
     parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
     parser.add_argument('--nolegend', action='store_true', help='Exclude legends from QA.')
+    parser.add_argument('--webqa', action='store_true', help='Build QA for the web-app.')
     parser.add_argument('--outprefix', default=None, type=str, help='Optional prefix for output filename.')
     parser.add_argument('-o', '--outdir', default='.', type=str, help='Full path to desired output directory.')
     
@@ -80,8 +81,23 @@ def main(args=None, comm=None):
     if not os.path.isfile(args.fastfitfile[0]):
         log.warning('File {} not found.'.format(args.fastfitfile[0]))
         return
-    fastfit, metadata, coadd_type, fastphot = read_fastspecfit(args.fastfitfile[0])
 
+    fastfit, metadata, coadd_type, isfastphot = read_fastspecfit(args.fastfitfile[0])
+    if args.webqa:
+        # This is not great coding, but when building the webqa, assume that a
+        # companion fastphot- file exists and, if not, quit.
+        fastphotfile = args.fastfitfile[0].replace('fastspec-', 'fastphot-').replace('.gz', '')
+        if not os.path.isfile(fastphotfile):
+            errmsg = '--webqa fastphot file {} not found.'.format(fastphotfile)
+            log.critical(errmsg)
+            raise IOError(errmsg)
+        
+        fastphot, _, _, _ = read_fastspecfit(fastphotfile)
+        if not np.all(fastfit['TARGETID'] == fastphot['TARGETID']):
+            errmsg = 'Mismatch in fastspec and fastphot TARGETIDs'
+            log.critical(errmsg)
+            raise Valuerror(errmsg)
+        
     # parse the targetids optional input
     if args.targetids:
         targetids = [int(x) for x in args.targetids.split(',')]
@@ -91,15 +107,27 @@ def main(args=None, comm=None):
             return
         fastfit = fastfit[keep]
         metadata = metadata[keep]
-
+        if args.webqa:
+            fastphot = fastphot[keep]
+        
     if args.ntargets is not None:
         keep = np.arange(args.ntargets) + args.firsttarget
         log.info('Keeping {} targets.'.format(args.ntargets))
         fastfit = fastfit[keep]
         metadata = metadata[keep]
-    
-    fastfit, metadata = select(fastfit, metadata, coadd_type, healpixels=args.healpix,
-                               tiles=args.tile, nights=args.night)
+        if args.webqa:
+            fastphot = fastphot[keep]
+
+    if args.webqa:
+        keep = select(fastfit, metadata, coadd_type, healpixels=args.healpix,
+                      tiles=args.tile, nights=args.night, return_index=True)
+        fastfit = fastfit[keep]
+        metadata = metadata[keep]
+        fastphot = fastphot[keep]
+    else:
+        fastfit, metadata = select(fastfit, metadata, coadd_type, healpixels=args.healpix,
+                                   tiles=args.tile, nights=args.night)
+        
     if coadd_type == 'custom' and args.redrockfiles is None:
         errmsg = 'redrockfiles input is required if coadd_type==custom'
         log.critical(errmsg)
@@ -124,9 +152,12 @@ def main(args=None, comm=None):
                     redrockfile_prefix=args.redrockfile_prefix,
                     specfile_prefix=args.specfile_prefix,
                     qnfile_prefix=args.qnfile_prefix)
-        data = Spec.read_and_unpack(CFit, fastphot=fastphot, synthphot=True)
+        data = Spec.read_and_unpack(CFit, fastphot=isfastphot, synthphot=True)
+
+        pdb.set_trace()
+        
         qaargs = [(CFit, EMFit, data[igal], fastfit[indx[igal]], metadata[indx[igal]],
-                   coadd_type, fastphot, args.outdir, args.outprefix) for igal in np.arange(len(indx))]                
+                   coadd_type, isfastphot, args.outdir, args.outprefix) for igal in np.arange(len(indx))]                
 
         if args.mp > 1:
             import multiprocessing

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -177,9 +177,9 @@ def main():
     parser.add_argument('--nolog', action='store_true', help='Do not write to the log file.')
     parser.add_argument('--dry-run', action='store_true', help='Generate but do not run commands.')
 
-    parser.add_argument('--outdir-html', default='/global/cfs/cdirs/desi/users/ioannis/fastspecfit',
+    parser.add_argument('--outdir-html', default='/global/cfs/cdirs/desi/users/ioannis/fastspecfit-dev',
                         type=str, help='Base output HTML directory.')
-    parser.add_argument('--outdir-data', default='/global/cfs/cdirs/desi/spectro/fastspecfit',
+    parser.add_argument('--outdir-data', default='/global/cfs/cdirs/desi/spectro/fastspecfit-dev',
                         type=str, help='Base output data directory.')
     
     specprod_dir = None

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -14,6 +14,8 @@ mpi-fastspecfit --merge --specprod fuji --fastphot
 mpi-fastspecfit --mp 32 --makeqa --specprod fuji --dry-run
 mpi-fastspecfit --mp 32 --makeqa --specprod fuji --fastphot --dry-run
 
+mpi-fastspecfit --mp 32 --webqa
+
 """
 import pdb # for debugging
 
@@ -24,7 +26,7 @@ from desiutil.log import get_logger
 log = get_logger()
 
 def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None,
-                    makeqa=False, outdir_data='.', outdir_html='.'):
+                    makeqa=False, webqa=False, outdir_data='.', outdir_html='.'):
 
     import sys, subprocess
     from fastspecfit.mpi import backup_logs, plan
@@ -41,6 +43,7 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None,
             comm=comm, specprod=args.specprod, specprod_dir=specprod_dir,
             coadd_type=args.coadd_type, survey=args.survey, program=args.program,
             healpix=args.healpix, tile=args.tile, night=args.night,
+            makeqa=args.makeqa, webqa=args.webqa, 
             fastphot=fastphot, outdir_data=outdir_data, outdir_html=outdir_html,
             overwrite=args.overwrite)
         log.info('Planning took {:.2f} sec'.format(time.time() - t0))
@@ -55,7 +58,6 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None,
 
     #if comm:
     #    comm.barrier()
-
     sys.stdout.flush()
     
     # all done
@@ -70,13 +72,15 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None,
         log.debug('Rank {} started at {}'.format(rank, time.asctime()))
         sys.stdout.flush()
 
-        if args.makeqa:
-            # hack--the desired output directories are in the 'zbestfiles' variable!
-            # note: by default don't render the legend
-            if fastphot:
-                cmd = 'fastspecfit-qa --fastphotfile {} --nolegend -o {} --mp {}'.format(outfiles[ii], zbestfiles[ii], args.mp)
-            else:
-                cmd = 'fastspecfit-qa --fastspecfile {} --nolegend -o {} --mp {}'.format(outfiles[ii], zbestfiles[ii], args.mp)
+        # With --webqa and --makeqa the desired output directories are in the
+        # 'zbestfiles' variable.
+        if args.webqa or args.makeqa:
+            cmd = 'fastspecfit-qa {} -o {} --mp {}'.format(outfiles[ii], zbestfiles[ii], args.mp)
+            if args.webqa:
+                cmd += ' --webqa'
+            ## Note: by default don't render the legend.
+            #if args.makeqa:
+            #    cmd += ' --nolegend'            
             if args.ntargets:
                 cmd += ' --ntargets {}'.format(args.ntargets)
         else:
@@ -170,6 +174,7 @@ def main():
     parser.add_argument('--merge', action='store_true', help='Merge all individual catalogs (for a given survey and program) into one large file.')
     parser.add_argument('--mergeall', action='store_true', help='Merge all the individual merged catalogs into a single merged catalog.')
     parser.add_argument('--makeqa', action='store_true', help='Build QA in parallel.')
+    parser.add_argument('--webqa', action='store_true', help='Build QA for the web-app.')
     
     parser.add_argument('--overwrite', action='store_true', help='Overwrite any existing output files.')
     parser.add_argument('--plan', action='store_true', help='Plan how many nodes to use and how to distribute the targets.')
@@ -207,7 +212,7 @@ def main():
                           overwrite=args.overwrite, fastphot=args.fastphot, supermerge=args.mergeall,
                           mp=args.mp)
         return
-        
+
     if args.plan:
         if comm is None:
             rank = 0
@@ -217,11 +222,12 @@ def main():
             plan(comm=comm, specprod=args.specprod, specprod_dir=specprod_dir,
                  coadd_type=args.coadd_type, survey=args.survey, program=args.program,
                  healpix=args.healpix, tile=args.tile, night=args.night,
+                 makeqa=args.makeqa, webqa=args.webqa, 
                  fastphot=args.fastphot, outdir_data=args.outdir_data,
                  outdir_html=args.outdir_html, overwrite=args.overwrite)
     else:
         run_fastspecfit(args, comm=comm, fastphot=args.fastphot, specprod_dir=specprod_dir,
-                        makeqa=args.makeqa, outdir_data=args.outdir_data,
+                        makeqa=args.makeqa, webqa=args.webqa, outdir_data=args.outdir_data,
                         outdir_html=args.outdir_html)
 
 if __name__ == '__main__':

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -94,7 +94,12 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None,
             if args.ntargets:
                 cmd += ' --ntargets {}'.format(args.ntargets)
 
-        logfile = outfiles[ii].replace('.gz', '').replace('.fits', '.log')
+        if args.webqa or args.makeqa:
+            logfile = zbestfiles[ii].replace('.gz', '').replace('.fits', '.log')
+            if args.webqa:
+                logfile = logfile.replace('fastspec-', 'fastfit-')
+        else:
+            logfile = outfiles[ii].replace('.gz', '').replace('.fits', '.log')
         assert(logfile != outfiles[ii])
 
         log.info('Rank {}, ntargets={}: {}'.format(rank, ntargets[ii], cmd))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,13 +2,15 @@
 FastSpecFit Change Log
 ======================
 
-1.1.0 (not released yet)
+2.0.0 (not released yet)
 ------------------------
 
 * Support custom coadds, update laboratory line-wavelengths, and fix major EW
   bug [`PR #87`_].
+* Refactor fitting engine to not use fnnls or astropy.modeling #92 [`PR #92`_]. 
 
 .. _`PR #87`: https://github.com/desihub/fastspecfit/pull/87
+.. _`PR #92`: https://github.com/desihub/fastspecfit/pull/92
 
 1.0.1 (2022-08-11)
 ------------------

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -2282,9 +2282,9 @@ class ContinuumFit(ContinuumTools):
 
         # Unpack the continuum into individual cameras.
         continuummodel, smooth_continuum = [], []
-        for ipix, jpix in zip(data['ipix'], data['jpix']):
-            continuummodel.append(bestfit[ipix:jpix])
-            smooth_continuum.append(_smooth_continuum[ipix:jpix])
+        for camerapix in data['camerapix']:
+            continuummodel.append(bestfit[camerapix[0]:camerapix[1]])
+            smooth_continuum.append(_smooth_continuum[camerapix[0]:camerapix[1]])
 
         ## Like above, but with per-camera smoothing.
         #smooth_continuum = self.smooth_residuals(

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1587,8 +1587,9 @@ class ContinuumFit(ContinuumTools):
                     # if we use synthesized photometry then ivarabsmag is zero
                     # (which should never happen?)
                     absmag[jj] = -2.5 * np.log10(synth_outmaggies_rest[jj]) - dmod
-                    
-                self.log.debug(absmag[jj], -2.5*np.log10(synth_outmaggies_rest[jj]) - dmod)
+
+                check = absmag[jj], -2.5*np.log10(synth_outmaggies_rest[jj]) - dmod
+                self.log.debug(check)
 
             return kcorr, absmag, ivarabsmag
 
@@ -2255,23 +2256,23 @@ class ContinuumFit(ContinuumTools):
             outprefix = 'fastphot'
 
         if coadd_type == 'healpix':
-            title = 'Survey/Program/HealPix: {}/{}/{}, TargetID: {}'.format(
+            title = 'Survey/Program/HealPix: {}/{}/{}, TARGETID: {}'.format(
                     metadata['SURVEY'], metadata['PROGRAM'], metadata['HEALPIX'], metadata['TARGETID'])
             pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(
                     outprefix, metadata['SURVEY'], metadata['PROGRAM'], metadata['HEALPIX'], metadata['TARGETID']))
         elif coadd_type == 'cumulative':
-            title = 'Tile/ThruNight: {}/{}, TargetID/Fiber: {}/{}'.format(
+            title = 'Tile/ThruNight: {}/{}, TARGETID/Fiber: {}/{}'.format(
                     metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID'], metadata['FIBER'])
             pngfile = os.path.join(outdir, '{}-{}-{}-{}.png'.format(
                     outprefix, metadata['TILEID'], coadd_type, metadata['TARGETID']))
         elif coadd_type == 'pernight':
-            title = 'Tile/Night: {}/{}, TargetID/Fiber: {}/{}'.format(
+            title = 'Tile/Night: {}/{}, TARGETID/Fiber: {}/{}'.format(
                     metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID'],
                     metadata['FIBER'])
             pngfile = os.path.join(outdir, '{}-{}-{}-{}.png'.format(
                     outprefix, metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID']))
         elif coadd_type == 'perexp':
-            title = 'Tile/Night/Expid: {}/{}/{}, TargetID/Fiber: {}/{}'.format(
+            title = 'Tile/Night/Expid: {}/{}/{}, TARGETID/Fiber: {}/{}'.format(
                     metadata['TILEID'], metadata['NIGHT'], metadata['EXPID'],
                     metadata['TARGETID'], metadata['FIBER'])
             pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1955,43 +1955,6 @@ class ContinuumFit(ContinuumTools):
         for icam, cam in enumerate(data['cameras']):
             result['CONTINUUM_SNR_{}'.format(cam.upper())] = data['snr'][icam]
 
-        coadd_linemask_dict = self.build_linemask(data['coadd_wave'], data['coadd_flux'], data['coadd_ivar'], redshift=redshift)
-        data['coadd_linename'] = coadd_linemask_dict['linename']
-        data['coadd_linepix'] = [np.where(lpix)[0] for lpix in coadd_linemask_dict['linepix']]
-        data['coadd_contpix'] = [np.where(cpix)[0] for cpix in coadd_linemask_dict['contpix']]
-        
-        data['linesigma_narrow'] = coadd_linemask_dict['linesigma_narrow']
-        data['linesigma_balmer'] = coadd_linemask_dict['linesigma_balmer']
-        data['linesigma_uv'] = coadd_linemask_dict['linesigma_uv']
-        
-        data['linesigma_narrow_snr'] = coadd_linemask_dict['linesigma_narrow_snr']
-        data['linesigma_balmer_snr'] = coadd_linemask_dict['linesigma_balmer_snr']
-        data['linesigma_uv_snr'] = coadd_linemask_dict['linesigma_uv_snr']
-
-        # Map the pixels belonging to individual emission lines and
-        # their local continuum back onto the original per-camera
-        # spectra. These lists of arrays are used in
-        # continuum.ContinnuumTools.smooth_continuum.
-        for icam in np.arange(len(data['cameras'])):
-            data['linemask'].append(np.interp(data['wave'][icam], data['coadd_wave'], coadd_linemask_dict['linemask']*1) > 0)
-            data['linemask_all'].append(np.interp(data['wave'][icam], data['coadd_wave'], coadd_linemask_dict['linemask_all']*1) > 0)
-            _linename, _linenpix, _contpix = [], [], []
-            for ipix in np.arange(len(coadd_linemask_dict['linepix'])):
-                I = np.interp(data['wave'][icam], data['coadd_wave'], coadd_linemask_dict['linepix'][ipix]*1) > 0
-                J = np.interp(data['wave'][icam], data['coadd_wave'], coadd_linemask_dict['contpix'][ipix]*1) > 0
-                #if '4686' in coadd_linemask_dict['linename'][ipix]:
-                #    pdb.set_trace()
-                if np.sum(I) > 3 and np.sum(J) > 3:
-                    _linename.append(coadd_linemask_dict['linename'][ipix])
-                    _linenpix.append(np.where(I)[0])
-                    _contpix.append(np.where(J)[0])
-            data['linename'].append(_linename)
-            data['linepix'].append(_linenpix)
-            data['contpix'].append(_contpix)
-
-            data.update({'coadd_linemask': coadd_linemask_dict['linemask'],
-                         'coadd_linemask_all': coadd_linemask_dict['linemask_all']})
-
         # Combine all three cameras; we will unpack them to build the
         # best-fitting model (per-camera) below.
         specwave = np.hstack(data['wave'])

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -2023,11 +2023,45 @@ class ContinuumFit(ContinuumTools):
         for icam, cam in enumerate(data['cameras']):
             result['CONTINUUM_SNR_{}'.format(cam.upper())] = data['snr'][icam]
 
+        coadd_linemask_dict = self.build_linemask(data['coadd_wave'], data['coadd_flux'], data['coadd_ivar'], redshift=redshift)
+        data['coadd_linename'] = coadd_linemask_dict['linename']
+        data['coadd_linepix'] = [np.where(lpix)[0] for lpix in coadd_linemask_dict['linepix']]
+        data['coadd_contpix'] = [np.where(cpix)[0] for cpix in coadd_linemask_dict['contpix']]
+        
+        data['linesigma_narrow'] = coadd_linemask_dict['linesigma_narrow']
+        data['linesigma_balmer'] = coadd_linemask_dict['linesigma_balmer']
+        data['linesigma_uv'] = coadd_linemask_dict['linesigma_uv']
+        
+        data['linesigma_narrow_snr'] = coadd_linemask_dict['linesigma_narrow_snr']
+        data['linesigma_balmer_snr'] = coadd_linemask_dict['linesigma_balmer_snr']
+        data['linesigma_uv_snr'] = coadd_linemask_dict['linesigma_uv_snr']
+
+        # Map the pixels belonging to individual emission lines and
+        # their local continuum back onto the original per-camera
+        # spectra. These lists of arrays are used in
+        # continuum.ContinnuumTools.smooth_continuum.
+        for icam in np.arange(len(data['cameras'])):
+            data['linemask'].append(np.interp(data['wave'][icam], data['coadd_wave'], coadd_linemask_dict['linemask']*1) > 0)
+            data['linemask_all'].append(np.interp(data['wave'][icam], data['coadd_wave'], coadd_linemask_dict['linemask_all']*1) > 0)
+            _linename, _linenpix, _contpix = [], [], []
+            for ipix in np.arange(len(coadd_linemask_dict['linepix'])):
+                I = np.interp(data['wave'][icam], data['coadd_wave'], coadd_linemask_dict['linepix'][ipix]*1) > 0
+                J = np.interp(data['wave'][icam], data['coadd_wave'], coadd_linemask_dict['contpix'][ipix]*1) > 0
+                #if '4686' in coadd_linemask_dict['linename'][ipix]:
+                #    pdb.set_trace()
+                if np.sum(I) > 3 and np.sum(J) > 3:
+                    _linename.append(coadd_linemask_dict['linename'][ipix])
+                    _linenpix.append(np.where(I)[0])
+                    _contpix.append(np.where(J)[0])
+            data['linename'].append(_linename)
+            data['linepix'].append(_linenpix)
+            data['contpix'].append(_contpix)
+
+            data.update({'coadd_linemask': coadd_linemask_dict['linemask'],
+                         'coadd_linemask_all': coadd_linemask_dict['linemask_all']})
+
         # Combine all three cameras; we will unpack them to build the
         # best-fitting model (per-camera) below.
-        npixpercamera = [len(gw) for gw in data['wave']]
-        npixpercam = np.hstack([0, npixpercamera])
-        
         specwave = np.hstack(data['wave'])
         specflux = np.hstack(data['flux'])
         specivar = np.hstack(data['ivar']) * np.logical_not(np.hstack(data['linemask'])) # mask emission lines
@@ -2037,7 +2071,7 @@ class ContinuumFit(ContinuumTools):
                 errmsg = 'All pixels are masked or some inverse variances are negative!'
                 log.critical(errmsg)
                 raise ValueError(errmsg)
-        
+
         # Prepare the reddened and unreddened SSP templates by redshifting and
         # normalizing. Note that we ignore templates which are older than the
         # age of the universe at the redshift of the object.
@@ -2247,11 +2281,8 @@ class ContinuumFit(ContinuumTools):
                                                          redshift, linemask=linemask, png=png)
 
         # Unpack the continuum into individual cameras.
-        continuummodel = []
-        smooth_continuum = []
-        for icam in np.arange(len(data['cameras'])): # iterate over cameras
-            ipix = np.sum(npixpercam[:icam+1])
-            jpix = np.sum(npixpercam[:icam+2])
+        continuummodel, smooth_continuum = [], []
+        for ipix, jpix in zip(data['ipix'], data['jpix']):
             continuummodel.append(bestfit[ipix:jpix])
             smooth_continuum.append(_smooth_continuum[ipix:jpix])
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -16,6 +16,59 @@ from fastspecfit.util import C_LIGHT
 from desiutil.log import get_logger, DEBUG
 log = get_logger()#DEBUG)
 
+def nnls(A, b, maxiter=None, eps=1e-7, v=False):
+    # https://en.wikipedia.org/wiki/Non-negative_least_squares#Algorithms
+    # not sure what eps should be set to
+    m, n = A.shape
+    if b.shape[0] != m:
+        raise ValueError(f"Shape mismatch: {A.shape} {b.shape}. Expected: (m, n) (m) ")
+    if maxiter is None:
+        # this is what scipy does when maxiter is not specified
+        maxiter = 3 * n
+    # init
+    P = np.zeros(n).astype(bool)
+    R = np.ones(n).astype(bool)
+    x = np.zeros(n)
+    s = np.zeros(n)
+    # compute these once ahead of time
+    ATA = A.T.dot(A)
+    ATb = A.T.dot(b)
+    # main loop
+    w = ATb - ATA.dot(x)
+    j = np.argmax(R * w)
+    c = 0 # iteration count
+    # while R != {} and max(w[R]) > eps
+    while np.any(R) and w[j] > eps:
+        if v: print(f"{c=}", f"{P=}\n {R=}\n {w=}\n {j=}")
+        # add j to P, remove j from R
+        P[j], R[j] = True, False
+        s[P] = np.linalg.inv(ATA[P][:, P]).dot(ATb[P])
+        s[R] = 0
+        d = 0 # inner loop iteration count, for debugging
+        if v: print(f"{c=}", f"{P=}\n {R=}\n {s=}")
+        # while P != {} and min(s[P]) < eps
+        # make sure P is not empty before checking min s[P]
+        while np.any(P) and np.min(s[P]) < eps:
+            i = P & (s < eps)
+            if v: print(f" {d=}", f"  {P=}\n  {i=}\n  {s=}\n  {x=}")
+            a = np.min(x[i] / (x[i] - s[i]))
+            x = x + a * (s - x)
+            j = P & (x < eps)
+            R[j], P[j] = True, False
+            s[P] = np.linalg.inv(ATA[P][:, P]).dot(ATb[P])
+            s[R] = 0
+            d += 1
+        x[:] = s
+        # w = A.T.dot(b - A.dot(x))
+        w = ATb - ATA.dot(x)
+        j = np.argmax(R * w)
+        if v: print(f"{c=}", f"{P=}\n {R=}\n {w=}\n {j=}")
+        c += 1
+        if c >= maxiter:
+            break
+    res = np.linalg.norm(A.dot(x) - b)
+    return x, res
+
 def _fnnls_continuum(myargs):
     """Multiprocessing wrapper for fnnls_continuum."""
     return fnnls_continuum(*myargs)

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -260,8 +260,7 @@ class ContinuumTools(object):
 
         self.min_uncertainty = np.array([0.02, 0.02, 0.02, 0.05, 0.05, 0.05, 0.05]) # mag
 
-    @staticmethod
-    def get_dn4000(wave, flam, flam_ivar=None, redshift=None, rest=True):
+    def get_dn4000(self, wave, flam, flam_ivar=None, redshift=None, rest=True):
         """Compute DN(4000) and, optionally, the inverse variance.
 
         Parameters

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -91,6 +91,7 @@ def _objective_function(free_parameters, emlinewave, emlineflux, weights, redshi
     #    if value > bnd[1]:
     #        free_parameters[I] = bnd[1]
 
+    print(free_parameters)
     parameters[Ifree] = free_parameters
 
     if len(Itied) > 0:
@@ -814,30 +815,30 @@ class EMLineFit(ContinuumTools):
         # being fitted):
         # --negative amplitude or sigma
         # --parameter at its default value (fit failed, right??)
-        # --parameter outside its bounds
+        # --parameter outside its bounds [should never be needed if method='trf']
         lineamps, linevshifts, linesigmas = np.array_split(parameters, 3) # 3 parameters per line
 
-        if False:
-            drop1 = np.hstack((lineamps < 0, np.zeros(len(linevshifts), bool), linesigmas < 0))
-            
-            drop2 = np.zeros(len(parameters), bool)
-            drop2[Ifree] = parameters[Ifree] == linemodel['value'][Ifree] # want 'value' here not 'initial'
-            
-            drop3 = np.zeros(len(parameters), bool)
-            drop3[Ifree] = np.logical_or(parameters[Ifree] < linemodel['bounds'][Ifree, 0], 
-                                         parameters[Ifree] > linemodel['bounds'][Ifree, 1])
-            
-            self.log.debug('Dropping {} negative amplitudes or line-widths.'.format(np.sum(drop1)))
-            self.log.debug('Dropping {} parameters which were not optimized.'.format(np.sum(drop2)))
-            self.log.debug('Dropping {} parameters which are out-of-bounds.'.format(np.sum(drop3)))
-            Idrop = np.where(np.logical_or.reduce((drop1, drop2, drop3)))[0]
+        drop1 = np.hstack((lineamps < 0, np.zeros(len(linevshifts), bool), linesigmas <= 0))
+        
+        drop2 = np.zeros(len(parameters), bool)
+        drop2[Ifree] = parameters[Ifree] == linemodel['value'][Ifree] # want 'value' here not 'initial'
+        
+        drop3 = np.zeros(len(parameters), bool)
+        drop3[Ifree] = np.logical_or(parameters[Ifree] < linemodel['bounds'][Ifree, 0], 
+                                     parameters[Ifree] > linemodel['bounds'][Ifree, 1])
+        
+        self.log.debug('Dropping {} negative amplitudes or line-widths.'.format(np.sum(drop1)))
+        self.log.debug('Dropping {} parameters which were not optimized.'.format(np.sum(drop2)))
+        self.log.debug('Dropping {} parameters which are out-of-bounds.'.format(np.sum(drop3)))
+        Idrop = np.where(np.logical_or.reduce((drop1, drop2, drop3)))[0]
 
-            if debug:
-                pass
-    
-            if len(Idrop) > 0:
-                self.log.debug('  Dropping {} unique parameters.'.format(len(Idrop)))
-                parameters[Idrop] = 0.0
+        pdb.set_trace()
+        if debug:
+            pass
+
+        if len(Idrop) > 0:
+            self.log.debug('  Dropping {} unique parameters.'.format(len(Idrop)))
+            parameters[Idrop] = 0.0
 
         # apply tied constraints
         if len(Itied) > 0:
@@ -1116,8 +1117,6 @@ class EMLineFit(ContinuumTools):
         # Now fill the output table.
         self._populate_emtable(result, finalfit, finalmodel, emlinewave, emlineflux,
                                emlineivar, oemlineivar, specflux_nolines, redshift)
-
-        pdb.set_trace()
 
         # Build the model spectra.
         emmodel = np.hstack(self.emlinemodel_bestfit(data['wave'], data['res'], result, redshift=redshift))

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -821,7 +821,7 @@ class EMLineFit(ContinuumTools):
         Idrop = np.where(np.logical_or.reduce((drop1, drop2, drop3)))[0]
 
         if debug:
-            pdb.set_trace()
+            pass
 
         if len(Idrop) > 0:
             log.debug('  Dropping {} unique parameters.'.format(len(Idrop)))
@@ -1074,7 +1074,7 @@ class EMLineFit(ContinuumTools):
                     log.critical(errmsg)
                     raise ValueError(errmsg)
 
-        B = np.where(['ne' in param for param in self.param_names])[0]
+        #B = np.where(['ne' in param for param in self.param_names])[0]
 
         t0 = time.time()
         finalfit = self._optimize(linemodel, emlinewave, emlineflux, weights, 

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -15,9 +15,6 @@ import astropy.units as u
 from astropy.modeling import Fittable1DModel
 #from astropy.modeling.fitting import LevMarLSQFitter
 
-import operator
-from functools import reduce, wraps
-
 from desispec.interpolation import resample_flux
 from fastspecfit.util import trapz_rebin, C_LIGHT
 from fastspecfit.continuum import ContinuumTools
@@ -1110,7 +1107,7 @@ class EMLineFit(ContinuumTools):
         self.chi2_default = chi2_default
         self.nolegend = nolegend
 
-        self.emwave_pixkms = 10.0 # pixel size for internal wavelength array [km/s]
+        self.emwave_pixkms = 5.0 # pixel size for internal wavelength array [km/s]
         self.dlogwave = pixkms / C_LIGHT / np.log(10) # pixel size [log-lambda]
         self.log10wave = np.arange(np.log10(minwave), np.log10(maxwave), self.dlogwave)
         #self.log10wave = np.arange(np.log10(emlinewave.min()), np.log10(emlinewave.max()), dlogwave)

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1563,34 +1563,34 @@ class EMLineFit(ContinuumTools):
             outprefix = 'fastspec'
 
         if coadd_type == 'healpix':
-            title = 'Survey/Program/HealPix: {}/{}/{}, TargetID: {}'.format(
+            title = 'Survey/Program/HealPix: {}/{}/{}, TARGETID: {}'.format(
                     metadata['SURVEY'], metadata['PROGRAM'], metadata['HEALPIX'], metadata['TARGETID'])
             pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(
                     outprefix, metadata['SURVEY'], metadata['PROGRAM'], metadata['HEALPIX'], metadata['TARGETID']))
         elif coadd_type == 'cumulative':
-            title = 'Tile/ThruNight: {}/{}, TargetID/Fiber: {}/{}'.format(
+            title = 'Tile/ThruNight: {}/{}, TARGETID/Fiber: {}/{}'.format(
                     metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID'], metadata['FIBER'])
             pngfile = os.path.join(outdir, '{}-{}-{}-{}.png'.format(
                     outprefix, metadata['TILEID'], coadd_type, metadata['TARGETID']))
         elif coadd_type == 'pernight':
-            title = 'Tile/Night: {}/{}, TargetID/Fiber: {}/{}'.format(
+            title = 'Tile/Night: {}/{}, TARGETID/Fiber: {}/{}'.format(
                     metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID'],
                     metadata['FIBER'])
             pngfile = os.path.join(outdir, '{}-{}-{}-{}.png'.format(
                     outprefix, metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID']))
         elif coadd_type == 'perexp':
-            title = 'Tile/Night/Expid: {}/{}/{}, TargetID/Fiber: {}/{}'.format(
+            title = 'Tile/Night/Expid: {}/{}/{}, TARGETID/Fiber: {}/{}'.format(
                     metadata['TILEID'], metadata['NIGHT'], metadata['EXPID'],
                     metadata['TARGETID'], metadata['FIBER'])
             pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(
                     outprefix, metadata['TILEID'], metadata['NIGHT'],
                     metadata['EXPID'], metadata['TARGETID']))
         elif coadd_type == 'custom':
-            title = 'Survey/Program/HealPix: {}/{}/{}, TargetID: {}'.format(
+            title = 'Survey/Program/HealPix: {}/{}/{}, TARGETID: {}'.format(
                     metadata['SURVEY'], metadata['PROGRAM'], metadata['HEALPIX'], metadata['TARGETID'])
             pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(
                     outprefix, metadata['SURVEY'], metadata['PROGRAM'], metadata['HEALPIX'], metadata['TARGETID']))
-            #title = 'Tile: {}, TargetID/Fiber: {}/{}'.format(
+            #title = 'Tile: {}, TARGETID/Fiber: {}/{}'.format(
             #        metadata['TILEID'], metadata['TARGETID'], metadata['FIBER'])
             #pngfile = os.path.join(outdir, '{}-{}-{}.png'.format(
             #        outprefix, metadata['TILEID'], metadata['TARGETID']))
@@ -1665,12 +1665,12 @@ class EMLineFit(ContinuumTools):
 
         leg = {
             'zredrock': '$z_{{\\rm redrock}}$={:.6f}'.format(redshift),
-            'dv_balmer': '$\\Delta v_{{\\rm narrow}}$={:.2f} km/s'.format(C_LIGHT*(fastspec['NARROW_Z']-redshift)),
-            'dv_forbid': '$\\Delta v_{{\\rm broad}}$={:.2f} km/s'.format(C_LIGHT*(fastspec['BROAD_Z']-redshift)),
-            'dv_broad': '$\\Delta v_{{\\rm UV}}$={:.2f} km/s'.format(C_LIGHT*(fastspec['UV_Z']-redshift)),
-            'sigma_balmer': '$\\sigma_{{\\rm narrow}}$={:.1f} km/s'.format(fastspec['NARROW_SIGMA']),
-            'sigma_forbid': '$\\sigma_{{\\rm broad}}$={:.1f} km/s'.format(fastspec['BROAD_SIGMA']),
-            'sigma_broad': '$\\sigma_{{\\rm UV}}$={:.1f} km/s'.format(fastspec['UV_SIGMA']),
+            'dv_narrow': '$\\Delta v_{{\\rm narrow}}$={:.2f} km/s'.format(C_LIGHT*(fastspec['NARROW_Z']-redshift)),
+            'dv_broad': '$\\Delta v_{{\\rm broad}}$={:.2f} km/s'.format(C_LIGHT*(fastspec['BROAD_Z']-redshift)),
+            'dv_uv': '$\\Delta v_{{\\rm UV}}$={:.2f} km/s'.format(C_LIGHT*(fastspec['UV_Z']-redshift)),
+            'sigma_narrow': '$\\sigma_{{\\rm narrow}}$={:.1f} km/s'.format(fastspec['NARROW_SIGMA']),
+            'sigma_broad': '$\\sigma_{{\\rm broad}}$={:.1f} km/s'.format(fastspec['BROAD_SIGMA']),
+            'sigma_uv': '$\\sigma_{{\\rm UV}}$={:.1f} km/s'.format(fastspec['UV_SIGMA']),
             #'targetid': '{} {}'.format(metadata['TARGETID'], metadata['FIBER']),
             #'targetid': 'targetid={} fiber={}'.format(metadata['TARGETID'], metadata['FIBER']),
             'chi2': '$\\chi^{{2}}_{{\\nu}}$={:.3f}'.format(fastspec['CONTINUUM_RCHI2']),
@@ -1810,9 +1810,9 @@ class EMLineFit(ContinuumTools):
         if not self.nolegend:
             txt = '\n'.join((
                 r'{} {}'.format(leg['rchi2'], leg['deltarchi2']),
-                r'{} {}'.format(leg['dv_balmer'], leg['sigma_balmer']),
-                r'{} {}'.format(leg['dv_forbid'], leg['sigma_forbid']),
+                r'{} {}'.format(leg['dv_narrow'], leg['sigma_narrow']),
                 r'{} {}'.format(leg['dv_broad'], leg['sigma_broad']),
+                r'{} {}'.format(leg['dv_uv'], leg['sigma_uv']),
                 ))
             bigax2.text(legxpos, legypos, txt, ha='right', va='top',
                         transform=bigax2.transAxes, fontsize=legfntsz,

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1117,6 +1117,8 @@ class EMLineFit(ContinuumTools):
         self._populate_emtable(result, finalfit, finalmodel, emlinewave, emlineflux,
                                emlineivar, oemlineivar, specflux_nolines, redshift)
 
+        pdb.set_trace()
+
         # Build the model spectra.
         emmodel = np.hstack(self.emlinemodel_bestfit(data['wave'], data['res'], result, redshift=redshift))
 
@@ -1177,12 +1179,10 @@ class EMLineFit(ContinuumTools):
             modelflux = modelcontinuum[0, :] + modelsmoothcontinuum[0, :] + modelemspectrum[0, :]
             self._synthphot_spectrum(data, result, modelwave, modelflux)
 
-        pdb.set_trace()
-
         return result, modelspectra
 
-    def _populate_emtable(self, result, finalfit, finalmodel, emlinewave, emlineflux, emlineivar,
-                          oemlineivar, specflux_nolines, redshift):
+    def _populate_emtable(self, result, finalfit, finalmodel, emlinewave, emlineflux,
+                          emlineivar, oemlineivar, specflux_nolines, redshift):
         """Populate the output table with the emission-line measurements.
 
         """
@@ -1377,7 +1377,8 @@ class EMLineFit(ContinuumTools):
                     self.log.debug('{} {}: {:.4f}'.format(linename, col, result['{}_{}'.format(linename, col)][0]))
                 for col in ('FLUX', 'BOXFLUX', 'FLUX_IVAR', 'BOXFLUX_IVAR', 'CONT', 'CONT_IVAR', 'EW', 'EW_IVAR', 'FLUX_LIMIT', 'EW_LIMIT'):
                     self.log.debug('{} {}: {:.4f}'.format(linename, col, result['{}_{}'.format(linename, col)][0]))
-                self.log.debug(' ')
+                print()
+                #self.log.debug(' ')
     
             ## simple QA
             #if 'alpha' in linename and False:
@@ -1402,28 +1403,32 @@ class EMLineFit(ContinuumTools):
         #    result[param.upper()] = factor * result[param.upper()]
         #    parameters[I] = parameters[indx] * factor
 
-        ## Clean up the doublets (v1.0.1); This should not be necessary as of PR92.
-        #if result['OIII_5007_AMP'] == 0 and result['OIII_5007_NPIX'] > 0:
-        #    result['OIII_4959_AMP'] = 0.0
-        #    result['OIII_4959_FLUX'] = 0.0
-        #    result['OIII_4959_EW'] = 0.0
-        #if result['NII_6584_AMP'] == 0 and result['NII_6584_NPIX'] > 0:
-        #    result['NII_6548_AMP'] = 0.0
-        #    result['NII_6548_FLUX'] = 0.0
-        #    result['NII_6548_EW'] = 0.0
-        ##if result['OII_3729_AMP'] == 0 and result['OII_3729_NPIX'] > 0:
-        ##    result['OII_3726_AMP'] = 0.0
-        ##    result['OII_3726_FLUX'] = 0.0
-        ##    result['OII_3726_EW'] = 0.0
-        #if result['OII_7320_AMP'] == 0 and result['OII_7320_NPIX'] > 0:
-        #    result['OII_7330_AMP'] = 0.0
-        #    result['OII_7330_FLUX'] = 0.0
-        #    result['OII_7330_EW'] = 0.0
+        # Clean up the doublets whose amplitudes were tied in the fitting since
+        # they may have been zeroed out in the clean-up, above.
+        if result['OIII_5007_AMP'] == 0.0 and result['OIII_5007_NPIX'] > 0:
+            result['OIII_4959_AMP'] = 0.0
+            result['OIII_4959_FLUX'] = 0.0
+            result['OIII_4959_EW'] = 0.0
+        if result['NII_6584_AMP'] == 0.0 and result['NII_6584_NPIX'] > 0:
+            result['NII_6548_AMP'] = 0.0
+            result['NII_6548_FLUX'] = 0.0
+            result['NII_6548_EW'] = 0.0
+        if result['OII_7320_AMP'] == 0.0 and result['OII_7320_NPIX'] > 0:
+            result['OII_7330_AMP'] = 0.0
+            result['OII_7330_FLUX'] = 0.0
+            result['OII_7330_EW'] = 0.0
+        if result['MGII_2796_AMP'] == 0.0 and result['MGII_2803_AMP'] == 0.0:
+            result['MGII_DOUBLET_RATIO'] = 0.0
+        if result['OII_3726_AMP'] == 0.0 and result['OII_3729_AMP'] == 0.0:
+            result['OII_DOUBLET_RATIO'] = 0.0
+        if result['SII_6716_AMP'] == 0.0 and result['SII_6731_AMP'] == 0.0:
+            result['SII_DOUBLET_RATIO'] = 0.0
 
         if 'debug' in self.log.name:
             for col in ('MGII_DOUBLET_RATIO', 'OII_DOUBLET_RATIO', 'SII_DOUBLET_RATIO'):
                 self.log.debug('{}: {:.4f}'.format(col, result[col][0]))
-            self.log.debug(' ')
+            #self.log.debug(' ')
+            print()
 
         # get the average emission-line redshifts and velocity widths
         if len(narrow_redshifts) > 0:

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -9,15 +9,13 @@ import pdb # for debugging
 
 import os, time
 import numpy as np
-import multiprocessing
 import numba
 
-import astropy.units as u
 from astropy.table import Table, Column
 
-from desispec.interpolation import resample_flux
 from fastspecfit.util import trapz_rebin, C_LIGHT
 from fastspecfit.continuum import ContinuumTools
+
 from desiutil.log import get_logger, DEBUG
 log = get_logger(DEBUG)
 

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1280,8 +1280,8 @@ class EMLineFit(ContinuumTools):
 
             # Are the pixels based on the original inverse spectrum fully
             # masked? If so, set everything to zero and move onto the next line.
-            lineindx = np.where((emlinewave >= (linezwave - 2.*linesigma_ang)) *
-                                (emlinewave <= (linezwave + 2.*linesigma_ang)))[0]
+            lineindx = np.where((emlinewave >= (linezwave - 3.0*linesigma_ang)) *
+                                (emlinewave <= (linezwave + 3.0*linesigma_ang)))[0]
             
             if len(lineindx) > 0 and np.sum(oemlineivar[lineindx] == 0) / len(lineindx) > 0.3: # use original ivar
                 result['{}_AMP'.format(linename)] = 0.0
@@ -1289,8 +1289,8 @@ class EMLineFit(ContinuumTools):
                 result['{}_SIGMA'.format(linename)] = 0.0
             else:
                 # number of pixels, chi2, and boxcar integration
-                lineindx = np.where((emlinewave >= (linezwave - 2.*linesigma_ang)) *
-                                    (emlinewave <= (linezwave + 2.*linesigma_ang)) *
+                lineindx = np.where((emlinewave >= (linezwave - 3.0*linesigma_ang)) *
+                                    (emlinewave <= (linezwave + 3.0*linesigma_ang)) *
                                     (emlineivar > 0))[0]
     
                 # can happen if sigma is very small (depending on the wavelength)
@@ -1322,7 +1322,7 @@ class EMLineFit(ContinuumTools):
                         self.log.critical(errmsg)
                         raise ValueError(errmsg)
                         
-                    # boxcar integration of the flux
+                    # boxcar integration of the flux; should we weight by the line-profile???
                     boxflux = np.sum(emlineflux[lineindx])                
                     boxflux_ivar = 1 / np.sum(1 / emlineivar[lineindx])
     
@@ -1432,41 +1432,33 @@ class EMLineFit(ContinuumTools):
                 print()
                 #self.log.debug(' ')
     
-            # simple QA
-            if linename == 'OII_3726':
-                import matplotlib.pyplot as plt
-                _indx = np.arange(indx[-1]-indx[0])+indx[0]
-                # continuum bandpasses and statistics
-                plt.clf()
-                plt.plot(emlinewave[_indx], specflux_nolines[_indx], color='gray')
-                plt.scatter(emlinewave[indx], specflux_nolines[indx], color='red')
-                plt.axhline(y=cmed, color='k')
-                plt.axhline(y=cmed+1/np.sqrt(civar), color='k', ls='--')
-                plt.axhline(y=cmed-1/np.sqrt(civar), color='k', ls='--')
-                plt.savefig('desi-users/ioannis/tmp/junk.png')
-
-                # emission-line integration
-                plt.clf()
-                plt.plot(emlinewave[_indx], emlineflux[_indx], color='gray')
-                plt.plot(emlinewave[_indx], finalmodel[_indx], color='red')
-                plt.axvline(x=emlinewave[lineindx[0]], color='blue')
-                plt.axvline(x=emlinewave[lineindx[-1]], color='blue')
-                plt.axhline(y=0, color='k', ls='--')
-                plt.axhline(y=amp_sigma, color='k', ls='--')
-                plt.axhline(y=2*amp_sigma, color='k', ls='--')
-                plt.axhline(y=3*amp_sigma, color='k', ls='--')
-                plt.axhline(y=result['{}_AMP'.format(linename)], color='k', ls='-')
-                plt.savefig('desi-users/ioannis/tmp/junk2.png')
-                pdb.set_trace()
-
-        ## Reset all the doublets and tied parameters, since they can be zerod
-        ## out, above, if there are insufficient pixels in the spectrum.
-        #Itied = np.where((finalfit['tiedtoparam'] != -1) * (finalfit['fixed'] == False))[0]
-        #for param, tiedparam, factor in zip(finalfit['param_name'][Itied], finalfit[finalfit['tiedtoparam'][Itied]]['param_name'], finalfit['tiedfactor'][Itied]):
-        #    val = result[param.upper()][0]
-        #    pdb.set_trace()
-        #    result[param.upper()] = factor * result[param.upper()]
-        #    parameters[I] = parameters[indx] * factor
+            ## simple QA
+            #if linename == 'OIII_5007':
+            #    import matplotlib.pyplot as plt
+            #    _indx = np.arange(indx[-1]-indx[0])+indx[0]
+            #    # continuum bandpasses and statistics
+            #    plt.clf()
+            #    plt.plot(emlinewave[_indx], specflux_nolines[_indx], color='gray')
+            #    plt.scatter(emlinewave[indx], specflux_nolines[indx], color='red')
+            #    plt.axhline(y=cmed, color='k')
+            #    plt.axhline(y=cmed+1/np.sqrt(civar), color='k', ls='--')
+            #    plt.axhline(y=cmed-1/np.sqrt(civar), color='k', ls='--')
+            #    plt.savefig('desi-users/ioannis/tmp/junk.png')
+            #
+            #    # emission-line integration
+            #    plt.clf()
+            #    plt.plot(emlinewave[_indx], emlineflux[_indx], color='gray')
+            #    plt.plot(emlinewave[_indx], finalmodel[_indx], color='red')
+            #    #plt.plot(emlinewave[_indx], specflux_nolines[_indx], color='orange', alpha=0.5)
+            #    plt.axvline(x=emlinewave[lineindx[0]], color='blue')
+            #    plt.axvline(x=emlinewave[lineindx[-1]], color='blue')
+            #    plt.axhline(y=0, color='k', ls='--')
+            #    plt.axhline(y=amp_sigma, color='k', ls='--')
+            #    plt.axhline(y=2*amp_sigma, color='k', ls='--')
+            #    plt.axhline(y=3*amp_sigma, color='k', ls='--')
+            #    plt.axhline(y=result['{}_AMP'.format(linename)], color='k', ls='-')
+            #    plt.savefig('desi-users/ioannis/tmp/junk2.png')
+            #    pdb.set_trace()
 
         # Clean up the doublets whose amplitudes were tied in the fitting since
         # they may have been zeroed out in the clean-up, above.

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -231,125 +231,199 @@ def _tie_lines(model):
 #            
 #    return model
 
-# TODO: These utility functions are really particular to handling
-# bounds/tied/fixed constraints for scipy.optimize optimizers that do not
-# support them inherently; this needs to be reworked to be clear about this
-# distinction (and the fact that these are not necessarily applicable to any
-# arbitrary fitter--as evidenced for example by the fact that JointFitter has
-# its own versions of these)
-# TODO: Most of this code should be entirely rewritten; it should not be as
-# inefficient as it is.
-def fitter_to_model_params(model, fps, use_min_max_bounds=True):
-    """
-    Constructs the full list of model parameters from the fitted and
-    constrained parameters.
+def emline_spectrum(emlinewave, *lineargs):
+                    #mgii_doublet_ratio,
+                    #oii_doublet_ratio,
+                    #sii_doublet_ratio,
+                    #mgii_2803_amp,
+                    #oii_3729_amp,
+                    #sii_6716_amp,
+                    #oi_1304_amp,
+                    #siliv_1396_amp,
+                    #civ_1549_amp,
+                    #siliii_1892_amp,
+                    #ciii_1908_amp,
+                    #nev_3346_amp,
+                    #nev_3426_amp,
+                    #neiii_3869_amp,
+                    #h6_amp,
+                    #h6_broad_amp,
+                    #hepsilon_amp,
+                    #hepsilon_broad_amp,
+                    #hdelta_amp,
+                    #hdelta_broad_amp,
+                    #hgamma_amp,
+                    #hgamma_broad_amp,
+                    #oiii_4363_amp,
+                    #hei_4471_amp,
+                    #hei_broad_4471_amp,
+                    #heii_4686_amp,
+                    #heii_broad_4686_amp,
+                    #hbeta_amp,
+                    #hbeta_broad_amp,
+                    #oiii_4959_amp,
+                    #oiii_5007_amp,
+                    #nii_5755_amp,
+                    #hei_5876_amp,
+                    #hei_broad_5876_amp,
+                    #oi_6300_amp,
+                    #siii_6312_amp,
+                    #nii_6548_amp,
+                    #halpha_amp,
+                    #halpha_broad_amp,
+                    #nii_6584_amp,
+                    #oii_7320_amp,
+                    #oii_7330_amp,
+                    #siii_9069_amp,
+                    #siii_9532_amp,
+                    #mgii_2796_vshift,
+                    #oii_3726_vshift,
+                    #sii_6731_vshift,
+                    #mgii_2803_vshift,
+                    #oii_3729_vshift,
+                    #sii_6716_vshift,
+                    #oi_1304_vshift,
+                    #siliv_1396_vshift,
+                    #civ_1549_vshift,
+                    #siliii_1892_vshift,
+                    #ciii_1908_vshift,
+                    #nev_3346_vshift,
+                    #nev_3426_vshift,
+                    #neiii_3869_vshift,
+                    #h6_vshift,
+                    #h6_broad_vshift,
+                    #hepsilon_vshift,
+                    #hepsilon_broad_vshift,
+                    #hdelta_vshift,
+                    #hdelta_broad_vshift,
+                    #hgamma_vshift,
+                    #hgamma_broad_vshift,
+                    #oiii_4363_vshift,
+                    #hei_4471_vshift,
+                    #hei_broad_4471_vshift,
+                    #heii_4686_vshift,
+                    #heii_broad_4686_vshift,
+                    #hbeta_vshift,
+                    #hbeta_broad_vshift,
+                    #oiii_4959_vshift,
+                    #oiii_5007_vshift,
+                    #nii_5755_vshift,
+                    #hei_5876_vshift,
+                    #hei_broad_5876_vshift,
+                    #oi_6300_vshift,
+                    #siii_6312_vshift,
+                    #nii_6548_vshift,
+                    #halpha_vshift,
+                    #halpha_broad_vshift,
+                    #nii_6584_vshift,
+                    #oii_7320_vshift,
+                    #oii_7330_vshift,
+                    #siii_9069_vshift,
+                    #siii_9532_vshift,
+                    #mgii_2796_sigma,
+                    #oii_3726_sigma,
+                    #sii_6731_sigma,
+                    #mgii_2803_sigma,
+                    #oii_3729_sigma,
+                    #sii_6716_sigma,
+                    #oi_1304_sigma,
+                    #siliv_1396_sigma,
+                    #civ_1549_sigma,
+                    #siliii_1892_sigma,
+                    #ciii_1908_sigma,
+                    #nev_3346_sigma,
+                    #nev_3426_sigma,
+                    #neiii_3869_sigma,
+                    #h6_sigma,
+                    #h6_broad_sigma,
+                    #hepsilon_sigma,
+                    #hepsilon_broad_sigma,
+                    #hdelta_sigma,
+                    #hdelta_broad_sigma,
+                    #hgamma_sigma,
+                    #hgamma_broad_sigma,
+                    #oiii_4363_sigma,
+                    #hei_4471_sigma,
+                    #hei_broad_4471_sigma,
+                    #heii_4686_sigma,
+                    #heii_broad_4686_sigma,
+                    #hbeta_sigma,
+                    #hbeta_broad_sigma,
+                    #oiii_4959_sigma,
+                    #oiii_5007_sigma,
+                    #nii_5755_sigma,
+                    #hei_5876_sigma,
+                    #hei_broad_5876_sigma,
+                    #oi_6300_sigma,
+                    #siii_6312_sigma,
+                    #nii_6548_sigma,
+                    #halpha_sigma,
+                    #halpha_broad_sigma,
+                    #nii_6584_sigma,
+                    #oii_7320_sigma,
+                    #oii_7330_sigma,
+                    #siii_9069_sigma,
+                    #siii_9532_sigma):
+    """The model we want to optimize is a pure emission-line spectrum in erg/s/cm2/A
+    in the observed frame.
 
-    Parameters
-    ----------
-    model :
-        The model being fit
-    fps :
-        The fit parameter values to be assigned
-    use_min_max_bounds: bool
-        If the set parameter bounds for model will be enforced on each
-        parameter with bounds.
-        Default: True
-    """
+    """ 
+    EMLine = lineargs[0][1]
+    lineargs = lineargs[0][0]
 
-    _, fit_param_indices, _ = model_to_fit_params(model)
+    # build the emission-line model [erg/s/cm2/A, observed frame]
+    log10model = np.zeros_like(EMLine.log10wave)
 
-    has_tied = any(model.tied.values())
-    has_fixed = any(model.fixed.values())
-    has_bound = any(b != (None, None) for b in model.bounds.values())
-    parameters = model.parameters
+    # carefull parse the parameters (order matters!)
+    linesplit = np.array_split(lineargs, 3) # 3 parameters per line
+    linevshifts = np.hstack(linesplit[1])
+    linesigmas = np.hstack(linesplit[2])
 
-    if not (has_tied or has_fixed or has_bound):
-        # We can just assign directly
-        model.parameters = fps
-        return
+    # stupidly hard-coded
+    _lineamps = np.hstack(linesplit[0])
+    doublet_ratios = _lineamps[:EMLine.ndoublet]
+    doublet_amps = _lineamps[EMLine.ndoublet:2*EMLine.ndoublet] * doublet_ratios
+    lineamps = np.hstack((doublet_amps, _lineamps[EMLine.ndoublet:]))
+    #print(doublet_ratios)
 
-    fit_param_indices = set(fit_param_indices)
-    offset = 0
-    param_metrics = model._param_metrics
-    for idx, name in enumerate(model.param_names):
-        if idx not in fit_param_indices:
-            continue
+    # cut to lines in range and non-zero
+    I = EMLine.inrange * (lineamps > 0)
+    if np.count_nonzero(I) > 0:
+        linevshifts = linevshifts[I]
+        linesigmas = linesigmas[I]
+        lineamps = lineamps[I]
 
-        slice_ = param_metrics[name]['slice']
-        shape = param_metrics[name]['shape']
-        # This is determining which range of fps (the fitted parameters) maps
-        # to parameters of the model
-        size = reduce(operator.mul, shape, 1)
+        # line-width [log-10 Angstrom] and redshifted wavelength [log-10 Angstrom]
+        log10sigmas = linesigmas / C_LIGHT / np.log(10) 
+        linezwaves = np.log10(EMLine.restlinewaves[I] * (1.0 + EMLine.redshift + linevshifts / C_LIGHT)) 
 
-        values = fps[offset:offset + size]
+        for lineamp, linezwave, log10sigma in zip(lineamps, linezwaves, log10sigmas):
+            ww = np.abs(EMLine.log10wave - linezwave) < (10 * log10sigma)
+            if np.sum(ww) > 0:
+                #log.info(linename, 10**linezwave, 10**_emlinewave[ww].min(), 10**_emlinewave[ww].max())
+                log10model[ww] += lineamp * np.exp(-0.5 * (EMLine.log10wave[ww]-linezwave)**2 / log10sigma**2)
 
-        # Check bounds constraints
-        if model.bounds[name] != (None, None) and use_min_max_bounds:
-            _min, _max = model.bounds[name]
-            if _min is not None:
-                values = np.fmax(values, _min)
-            if _max is not None:
-                values = np.fmin(values, _max)
+    # optionally split into cameras, resample, and convolve with the instrumental
+    # resolution
+    emlinemodel = []
+    for ii in np.arange(len(EMLine.npixpercamera)-1): # iterate over cameras
+        ipix = np.sum(EMLine.npixpercamera[:ii+1]) # all pixels!
+        jpix = np.sum(EMLine.npixpercamera[:ii+2])
+        try:
+            _emlinemodel = trapz_rebin(10**EMLine.log10wave, log10model, emlinewave[ipix:jpix])
+        except:
+            _emlinemodel = resample_flux(emlinewave[ipix:jpix], 10**EMLine.log10wave, log10model)
 
-        parameters[slice_] = values
-        offset += size
+        if EMLine.emlineR is not None:
+            _emlinemomdel = EMLine.emlineR[ii].dot(_emlinemodel)
+        
+        #plt.plot(10**_emlinewave, _emlinemodel)
+        #plt.plot(10**_emlinewave, self.emlineR[ii].dot(_emlinemodel))
+        #plt.xlim(3870, 3920) ; plt.show()
+        emlinemodel.append(_emlinemodel)
+        
+    return np.hstack(emlinemodel)
 
-    # Update model parameters before calling ``tied`` constraints.
-    model._array_to_parameters()
-
-    # This has to be done in a separate loop due to how tied parameters are
-    # currently evaluated (the fitted parameters need to actually be *set* on
-    # the model first, for use in evaluating the "tied" expression--it might be
-    # better to change this at some point
-    if has_tied:
-        for idx, name in enumerate(model.param_names):
-            if model.tied[name]:
-                value = model.tied[name](model)
-                slice_ = param_metrics[name]['slice']
-
-                # To handle multiple tied constraints, model parameters
-                # need to be updated after each iteration.
-                parameters[slice_] = value
-                model._array_to_parameters()
-
-def model_to_fit_params(model):
-    """
-    Convert a model instance's parameter array to an array that can be used
-    with a fitter that doesn't natively support fixed or tied parameters.
-    In particular, it removes fixed/tied parameters from the parameter
-    array.
-    These may be a subset of the model parameters, if some of them are held
-    constant or tied.
-    """
-
-    fitparam_indices = list(range(len(model.param_names)))
-    model_params = model.parameters
-    model_bounds = list(model.bounds.values())
-    if any(model.fixed.values()) or any(model.tied.values()):
-        params = list(model_params)
-        param_metrics = model._param_metrics
-        for idx, name in list(enumerate(model.param_names))[::-1]:
-            if model.fixed[name] or model.tied[name]:
-                slice_ = param_metrics[name]['slice']
-                del params[slice_]
-                del model_bounds[slice_]
-                del fitparam_indices[idx]
-        model_params = np.array(params)
-
-    for idx, bound in enumerate(model_bounds):
-        if bound[0] is None:
-            lower = -np.inf
-        else:
-            lower = bound[0]
-
-        if bound[1] is None:
-            upper = np.inf
-        else:
-            upper = bound[1]
-
-        model_bounds[idx] = (lower, upper)
-    model_bounds = tuple(zip(*model_bounds))
-    return model_params, fitparam_indices, model_bounds
 
 class FastLevMarLSQFitter(object):
     """
@@ -407,8 +481,7 @@ class FastLevMarLSQFitter(object):
         self.has_fixed = any(model.fixed.values())
         self.has_bound = any(b != (None, None) for b in model.bounds.values())
 
-        #_, fit_param_indices = self.model_to_fit_params(model)
-        _, fit_param_indices, _ = model_to_fit_params(model)
+        _, fit_param_indices, _ = self.model_to_fit_params(model)
 
         self._fit_param_names = [model.param_names[iparam] for iparam in np.unique(fit_param_indices)]
 
@@ -450,11 +523,16 @@ class FastLevMarLSQFitter(object):
         else:
             self.fit_info['param_cov'] = None
 
-    def fitter_to_model_params(self, model, fps):
+    def fitter_to_model_params(self, model, fps, use_min_max_bounds=True):
         """Constructs the full list of model parameters from the fitted and constrained
         parameters.
 
         """
+        _, fit_param_indices, _ = self.model_to_fit_params(model)
+
+        has_tied = any(model.tied.values())
+        has_fixed = any(model.fixed.values())
+        has_bound = any(b != (None, None) for b in model.bounds.values())
         parameters = model.parameters
 
         if not (self.has_tied or self.has_fixed or self.has_bound):
@@ -462,38 +540,50 @@ class FastLevMarLSQFitter(object):
             model.parameters = fps
             return
 
-        for name, istart, iend, islice, (ibounds, imin, imax) in zip(
-                        self._fit_param_names, self._fit_istart, self._fit_iend,
-                        self._fit_slice, self._fit_ibounds):
-            values = fps[istart:iend]
-
+        fit_param_indices = set(fit_param_indices)
+        offset = 0
+        param_metrics = model._param_metrics
+        for idx, name in enumerate(model.param_names):
+            if idx not in fit_param_indices:
+                continue
+    
+            slice_ = param_metrics[name]['slice']
+            shape = param_metrics[name]['shape']
+            # This is determining which range of fps (the fitted parameters) maps
+            # to parameters of the model
+            size = reduce(operator.mul, shape, 1)
+    
+            values = fps[offset:offset + size]
+    
             # Check bounds constraints
-            if ibounds:
-                if imin is not None:
-                    values = np.fmax(values, imin)
-                if imax is not None:
-                    values = np.fmin(values, imax)
-                    
-            #parameters[islice] = values
-            setattr(model, name, values)
-
+            if model.bounds[name] != (None, None) and use_min_max_bounds:
+                _min, _max = model.bounds[name]
+                if _min is not None:
+                    values = np.fmax(values, _min)
+                if _max is not None:
+                    values = np.fmin(values, _max)
+    
+            parameters[slice_] = values
+            offset += size
+    
         # Update model parameters before calling ``tied`` constraints.
-
+        model._array_to_parameters()
+    
         # This has to be done in a separate loop due to how tied parameters are
         # currently evaluated (the fitted parameters need to actually be *set* on
         # the model first, for use in evaluating the "tied" expression--it might be
         # better to change this at some point
-        if self.has_tied:
-            for name, islice, func in zip(
-                    self._tied_param_names, self._tied_slice,
-                    self._tied_func):
-                #value = model.tied[name](model)
+        if has_tied:
+            for idx, name in enumerate(model.param_names):
+                if model.tied[name]:
+                    value = model.tied[name](model)
+                    slice_ = param_metrics[name]['slice']
+    
+                    # To handle multiple tied constraints, model parameters
+                    # need to be updated after each iteration.
+                    parameters[slice_] = value
+                    model._array_to_parameters()
 
-                # To handle multiple tied constraints, model parameters
-                # need to be updated after each iteration.
-                value = func(model)
-                #parameters[islice] = value
-                setattr(model, name, value)
                 
     def model_to_fit_params(self, model):
         """Convert a model instance's parameter array to an array that can be used with
@@ -504,16 +594,32 @@ class FastLevMarLSQFitter(object):
 
         """
         fitparam_indices = list(range(len(model.param_names)))
+        model_params = model.parameters
+        model_bounds = list(model.bounds.values())
+
         if self.has_fixed or self.has_tied:
-            params = list(model.parameters)
+            params = list(model_params)
             param_metrics = model._param_metrics
             for idx, name in list(enumerate(model.param_names))[::-1]:
                 if model.fixed[name] or model.tied[name]:
                     slice_ = param_metrics[name]['slice']
                     del params[slice_]
+                    del model_bounds[slice_]
                     del fitparam_indices[idx]
-            return (np.array(params), fitparam_indices)
-        return (model.parameters, fitparam_indices)
+            model_params = np.array(params)
+
+        for idx, bound in enumerate(model_bounds):
+            if bound[0] is None:
+                lower = -np.inf
+            else:
+                lower = bound[0]
+            if bound[1] is None:
+                upper = np.inf
+            else:
+                upper = bound[1]
+            model_bounds[idx] = (lower, upper)
+        model_bounds = tuple(zip(*model_bounds))
+        return model_params, fitparam_indices, model_bounds
 
     def __call__(self, model, x, y, z=None, weights=None,
                  maxiter=100, acc=1e-7, epsilon=np.sqrt(np.finfo(float).eps)):
@@ -581,7 +687,7 @@ class FastLevMarLSQFitter(object):
 
         model = args[0]
         weights = args[1]
-        fitter_to_model_params(model, fps, self._use_min_max_bounds)
+        self.fitter_to_model_params(model, fps, self._use_min_max_bounds)
         meas = args[-1]
 
         if weights is None:
@@ -600,8 +706,8 @@ class FastLevMarLSQFitter(object):
 
         from scipy import optimize
 
-        init_values, _, _ = model_to_fit_params(model)
-        #init_values, _, _ = self.model_to_fit_params(model)
+        #init_values, _, _ = model_to_fit_params(model)
+        init_values, _, _ = self.model_to_fit_params(model)
 
         fitparams, cov_x, dinfo, mess, ierr = optimize.leastsq(
             self.objective_function, init_values, args=farg, 
@@ -1270,126 +1376,85 @@ class EMLineFit(ContinuumTools):
             emlinemodel.append(_emlinemodel[ipix:jpix])
 
         return emlinemodel
-    
-    def fit(self, data, continuummodel, smooth_continuum, synthphot=True,
-            maxiter=5000, accuracy=1e-2, verbose=False, broadlinefit=True):
-        """Perform the fit minimization / chi2 minimization.
-        
-        EMLineModel object
-        FC - ContinuumFit object
 
-        ToDo: need to take into account the instrumental velocity width when
-        computing integrated fluxes...
+    def _clean_linefit(self, bestfit, init_amplitudes, init_sigmas):
+        """Clean up line-fitting results."""
+        
+        # If the amplitude is still at its default (or its upper or lower
+        # bound!), it means the line wasn't fit or the fit failed (right??), so
+        # set it to zero. Important: need to loop over *all* lines (not just
+        # those in range).
+        initkeys = init_amplitudes.keys()
+
+        for linename in self.linetable['name'].data:
+            if not hasattr(bestfit, '{}_amp'.format(linename)): # skip the physical doubleta
+                continue
+            amp = getattr(bestfit, '{}_amp'.format(linename))
+            if amp.fixed: # line is either out of range or a suppressed line--skip it here
+                continue
+            sigma = getattr(bestfit, '{}_sigma'.format(linename))
+            vshift = getattr(bestfit, '{}_vshift'.format(linename))
+
+            # drop the line if:
+            #  sigma = 0, amp = default or amp = max bound (not optimized!) or amp =< 0
+            if ((amp.value == amp.default) or
+                (amp.bounds[1] is not None and amp.value >= amp.bounds[1]) or
+                #(amp.value <= amp.bounds[0]) or
+                (amp.value <= 0) or
+                (linename in initkeys and init_amplitudes[linename] == amp.value) or 
+                (sigma.value == sigma.default)
+                #(sigma.value <= sigma.bounds[0]) or (sigma.value >= sigma.bounds[1])
+                ):
+                log.debug('Dropping {} (amp={:.3f}, sigma={:.3f}, vshift={:.3f})'.format(
+                    linename, amp.value, sigma.value, vshift.value))
+
+                setattr(bestfit, '{}_amp'.format(linename), 0.0)
+                setattr(bestfit, '{}_sigma'.format(linename), 0.0) # sigma.default)
+                setattr(bestfit, '{}_vshift'.format(linename), 0.0) #vshift.default)
+
+        # Now loop back through and drop Broad balmer lines that:
+        #   (1) are narrower than their narrow-line counterparts;
+        #   (2) have a narrow line whose amplitude is smaller than that of the broad line
+        #      --> Deprecated! main-dark-32303-39628176678192981 is an example
+        #          of an object where there's a broad H-alpha line but no other
+        #          forbidden lines!
+        
+        IB = self.linetable['isbalmer'] * self.linetable['isbroad']
+        for linename in self.linetable['name'][IB]:
+            amp_broad = getattr(bestfit, '{}_amp'.format(linename))
+            if amp_broad.fixed: # line is either out of range or a suppressed line--skip it here
+                continue
+            amp = getattr(bestfit, '{}_amp'.format(linename.replace('_broad', ''))) # fragile
+            sigma = getattr(bestfit, '{}_sigma'.format(linename.replace('_broad', ''))) # fragile
+            sigma_broad = getattr(bestfit, '{}_sigma'.format(linename))
+            
+            if sigma_broad <= sigma:
+                log.debug('Dropping {} (sigma_broad={:.2f}, sigma_narrow={:.2f})'.format(
+                    linename, sigma_broad.value, sigma.value))
+                #vshift = getattr(bestfit, '{}_vshift'.format(linename))
+                setattr(bestfit, '{}_amp'.format(linename), 0.0)
+                setattr(bestfit, '{}_sigma'.format(linename), 0.0) # sigma_broad.default)
+                setattr(bestfit, '{}_vshift'.format(linename), 0.0) # vshift.default)
+
+            # Deprecated! -- See note above.
+            #if (amp <= 0) or (amp_broad <= 0) and ((amp+amp_broad) < amp_broad):
+            #    #vshift = getattr(bestfit, '{}_vshift'.format(linename))
+            #    setattr(bestfit, '{}_amp'.format(linename), 0.0)
+            #    setattr(bestfit, '{}_sigma'.format(linename), 0.0) # sigma_broad.default)
+            #    setattr(bestfit, '{}_vshift'.format(linename), 0.0) # vshift.default)
+
+        return bestfit
+
+    def _init_guesses(self, data, emlinewave, emlineflux):
+        """For all lines in range, do a fast update of the initial line-amplitudes
+        which especially helps with cases like 39633354915582193 (tile 80613,
+        petal 05), which has strong narrow lines.
 
         """
-        from astropy.table import Table, Column
-        from scipy.stats import sigmaclip
-        from fastspecfit.util import ivar2var
-            
-        def _clean_linefit(bestfit, init_amplitudes, init_sigmas):
-            """Clean up line-fitting results."""
-            
-            # If the amplitude is still at its default (or its upper or lower
-            # bound!), it means the line wasn't fit or the fit failed (right??), so
-            # set it to zero. Important: need to loop over *all* lines (not just
-            # those in range).
-            initkeys = init_amplitudes.keys()
+        init_amplitudes, init_sigmas = {}, {}
 
-            for linename in self.linetable['name'].data:
-                if not hasattr(bestfit, '{}_amp'.format(linename)): # skip the physical doubleta
-                    continue
-                amp = getattr(bestfit, '{}_amp'.format(linename))
-                if amp.fixed: # line is either out of range or a suppressed line--skip it here
-                    continue
-                sigma = getattr(bestfit, '{}_sigma'.format(linename))
-                vshift = getattr(bestfit, '{}_vshift'.format(linename))
-    
-                # drop the line if:
-                #  sigma = 0, amp = default or amp = max bound (not optimized!) or amp =< 0
-                if ((amp.value == amp.default) or
-                    (amp.bounds[1] is not None and amp.value >= amp.bounds[1]) or
-                    #(amp.value <= amp.bounds[0]) or
-                    (amp.value <= 0) or
-                    (linename in initkeys and init_amplitudes[linename] == amp.value) or 
-                    (sigma.value == sigma.default)
-                    #(sigma.value <= sigma.bounds[0]) or (sigma.value >= sigma.bounds[1])
-                    ):
-                    log.debug('Dropping {} (amp={:.3f}, sigma={:.3f}, vshift={:.3f})'.format(
-                        linename, amp.value, sigma.value, vshift.value))
-
-                    setattr(bestfit, '{}_amp'.format(linename), 0.0)
-                    setattr(bestfit, '{}_sigma'.format(linename), 0.0) # sigma.default)
-                    setattr(bestfit, '{}_vshift'.format(linename), 0.0) #vshift.default)
-
-            # Now loop back through and drop Broad balmer lines that:
-            #   (1) are narrower than their narrow-line counterparts;
-            #   (2) have a narrow line whose amplitude is smaller than that of the broad line
-            #      --> Deprecated! main-dark-32303-39628176678192981 is an example
-            #          of an object where there's a broad H-alpha line but no other
-            #          forbidden lines!
-            
-            IB = self.linetable['isbalmer'] * self.linetable['isbroad']
-            for linename in self.linetable['name'][IB]:
-                amp_broad = getattr(bestfit, '{}_amp'.format(linename))
-                if amp_broad.fixed: # line is either out of range or a suppressed line--skip it here
-                    continue
-                amp = getattr(bestfit, '{}_amp'.format(linename.replace('_broad', ''))) # fragile
-                sigma = getattr(bestfit, '{}_sigma'.format(linename.replace('_broad', ''))) # fragile
-                sigma_broad = getattr(bestfit, '{}_sigma'.format(linename))
-                
-                if sigma_broad <= sigma:
-                    log.debug('Dropping {} (sigma_broad={:.2f}, sigma_narrow={:.2f})'.format(
-                        linename, sigma_broad.value, sigma.value))
-                    #vshift = getattr(bestfit, '{}_vshift'.format(linename))
-                    setattr(bestfit, '{}_amp'.format(linename), 0.0)
-                    setattr(bestfit, '{}_sigma'.format(linename), 0.0) # sigma_broad.default)
-                    setattr(bestfit, '{}_vshift'.format(linename), 0.0) # vshift.default)
-    
-                # Deprecated! -- See note above.
-                #if (amp <= 0) or (amp_broad <= 0) and ((amp+amp_broad) < amp_broad):
-                #    #vshift = getattr(bestfit, '{}_vshift'.format(linename))
-                #    setattr(bestfit, '{}_amp'.format(linename), 0.0)
-                #    setattr(bestfit, '{}_sigma'.format(linename), 0.0) # sigma_broad.default)
-                #    setattr(bestfit, '{}_vshift'.format(linename), 0.0) # vshift.default)
-
-            return bestfit
-
-        # Combine all three cameras; we will unpack them to build the
-        # best-fitting model (per-camera) below.
-        redshift = data['zredrock']
-        emlinewave = np.hstack(data['wave'])
-        oemlineivar = np.hstack(data['ivar'])
-        specflux = np.hstack(data['flux'])
-
-        continuummodelflux = np.hstack(continuummodel)
-        smoothcontinuummodelflux = np.hstack(smooth_continuum)
-        emlineflux = specflux - continuummodelflux - smoothcontinuummodelflux
-
-        npixpercamera = [len(gw) for gw in data['wave']] # all pixels
-        npixpercam = np.hstack([0, npixpercamera])
-
-        emlineivar = np.copy(oemlineivar)
-        emlinevar, emlinegood = ivar2var(emlineivar, clip=1e-3)
-        emlinebad = np.logical_not(emlinegood)
-        if np.sum(emlinebad) > 0:
-            emlineivar[emlinebad] = np.interp(emlinewave[emlinebad], emlinewave[emlinegood], emlineivar[emlinegood])
-            emlineflux[emlinebad] = np.interp(emlinewave[emlinebad], emlinewave[emlinegood], emlineflux[emlinegood]) # ???
-        weights = np.sqrt(emlineivar)
-
-        wavelims = (np.min(emlinewave)+5, np.max(emlinewave)-5)
-
-        self.EMLineModel = EMLineModel(redshift=redshift,
-                                       wavelims=wavelims,
-                                       emlineR=data['res'],
-                                       npixpercamera=npixpercamera,
-                                       log10wave=self.log10wave)
-
-        # For all lines in range, do a fast update of the initial
-        # line-amplitudes which especially helps with cases like
-        # 39633354915582193 (tile 80613, petal 05), which has strong narrow
-        # lines.
-        init_amplitudes = {}
         coadd_emlineflux = np.interp(data['coadd_wave'], emlinewave, emlineflux)
+
         for linename, linepix in zip(data['coadd_linename'], data['coadd_linepix']):
             # skip the physical doublets
             if not hasattr(self.EMLineModel, '{}_amp'.format(linename)):
@@ -1432,7 +1497,6 @@ class EMLineFit(ContinuumTools):
         # (not just those in range). E.g., if H-alpha is out of range we need to
         # set its initial value correctly since other lines are tied to it
         # (e.g., main-bright-32406-39628257196245904).
-        init_sigmas = {}
         for iline in self.linetable:
             linename = iline['name']
             # If sigma is zero here, it was set in _tie_lines because the line
@@ -1463,7 +1527,57 @@ class EMLineFit(ContinuumTools):
                 #    getattr(self.EMLineModel, '{}_sigma'.format(linename)).default = data['linesigma_balmer']
                 #    init_sigmas[linename] = data['linesigma_balmer']
 
-        #print('HACK!!!!!!!!!!!')
+        return init_amplitudes, init_sigmas
+
+    
+    def fit(self, data, continuummodel, smooth_continuum, synthphot=True,
+            maxiter=5000, accuracy=1e-2, verbose=False, broadlinefit=True):
+        """Perform the fit minimization / chi2 minimization.
+        
+        EMLineModel object
+        FC - ContinuumFit object
+
+        ToDo: need to take into account the instrumental velocity width when
+        computing integrated fluxes...
+
+        """
+        from astropy.table import Table, Column
+        from scipy.stats import sigmaclip
+        from fastspecfit.util import ivar2var
+            
+        # Combine all three cameras; we will unpack them to build the
+        # best-fitting model (per-camera) below.
+        redshift = data['zredrock']
+        emlinewave = np.hstack(data['wave'])
+        oemlineivar = np.hstack(data['ivar'])
+        specflux = np.hstack(data['flux'])
+
+        continuummodelflux = np.hstack(continuummodel)
+        smoothcontinuummodelflux = np.hstack(smooth_continuum)
+        emlineflux = specflux - continuummodelflux - smoothcontinuummodelflux
+
+        npixpercamera = [len(gw) for gw in data['wave']] # all pixels
+        npixpercam = np.hstack([0, npixpercamera])
+
+        emlineivar = np.copy(oemlineivar)
+        emlinevar, emlinegood = ivar2var(emlineivar, clip=1e-3)
+        emlinebad = np.logical_not(emlinegood)
+        if np.sum(emlinebad) > 0:
+            emlineivar[emlinebad] = np.interp(emlinewave[emlinebad], emlinewave[emlinegood], emlineivar[emlinegood])
+            emlineflux[emlinebad] = np.interp(emlinewave[emlinebad], emlinewave[emlinegood], emlineflux[emlinegood]) # ???
+        weights = np.sqrt(emlineivar)
+
+        wavelims = (np.min(emlinewave)+5, np.max(emlinewave)-5)
+
+        # Initialize the emission-line model with good first guesses.
+        self.EMLineModel = EMLineModel(redshift=redshift,
+                                       wavelims=wavelims,
+                                       emlineR=data['res'],
+                                       npixpercamera=npixpercamera,
+                                       log10wave=self.log10wave)
+
+        init_amplitudes, init_sigmas = self._init_guesses(data, emlinewave, emlineflux)
+
         #self.EMLineModel.halpha_sigma.tied = False
         #self.EMLineModel.nii_6584_sigma.tied = False
         #self.EMLineModel.nii_6548_sigma.tied = False
@@ -1492,10 +1606,45 @@ class EMLineFit(ContinuumTools):
         #for pp in self.EMLineModel.param_names:
         #    print(getattr(self.EMLineModel, pp))
 
+        ## --------------------------------------------------
+        #Ifree, Itied, Ifixed, model_bounds = [], [], [], []
+        #for pp in self.EMLineModel.param_names:
+        #    Ifree.append(self.EMLineModel.tied[pp] is False and self.EMLineModel.fixed[pp] is False)
+        #    Itied.append(self.EMLineModel.tied[pp] is not False)
+        #    Ifixed.append(self.EMLineModel.fixed[pp] is not False)
+        #    if self.EMLineModel.bounds[pp][0] is None:
+        #        lower = -np.inf
+        #    else:
+        #        lower = self.EMLineModel.bounds[pp][0]
+        #    if self.EMLineModel.bounds[pp][1] is None:
+        #        upper = +np.inf
+        #    else:
+        #        upper = self.EMLineModel.bounds[pp][1]
+        #    model_bounds.append((lower, upper))
+        #model_bounds = tuple(zip(*model_bounds))
+        #
+        #Ifree = np.where(Ifree)[0]
+        #Itied = np.where(Itied)[0]
+        #Ifixed = np.where(Ifixed)[0]
+        #
+        #
+        #
+        #fit_info = optimize.least_squares(
+        #    self.objective_function, init_values, args=farg, 
+        #    max_nfev=maxiter, xtol=accuracy, method='lm')#, bounds=bounds)
+        #
+        #pdb.set_trace()
+        #
+        #emline_spectrum(emlinewave, [self.EMLineModel.parameters, self.EMLineModel])
+        ##emline_spectrum(emlinewave, *self.EMLineModel.parameters.tolist())
+        #
+        #pdb.set_trace()
+        ## --------------------------------------------------
+
         fitter = FastLevMarLSQFitter(self.EMLineModel)
         initfit = fitter(self.EMLineModel, emlinewave, emlineflux, weights=weights,
                          maxiter=maxiter, acc=accuracy)
-        initfit = _clean_linefit(initfit, init_amplitudes, init_sigmas)
+        initfit = self._clean_linefit(initfit, init_amplitudes, init_sigmas)
         initchi2 = self.chi2(initfit, emlinewave, emlineflux, emlineivar)
         log.info('Initial line-fitting with {} free parameters took {:.2f} sec (niter={}) with chi2={:.3f}'.format(
             nfree, time.time()-t0, fitter.fit_info['nfev'], initchi2))
@@ -1539,7 +1688,7 @@ class EMLineFit(ContinuumTools):
             broadfit = fitter(self.EMLineModel, emlinewave, emlineflux, weights=weights,
                               maxiter=maxiter, acc=accuracy)
 
-            broadfit = _clean_linefit(broadfit, init_amplitudes, init_sigmas)
+            broadfit = self._clean_linefit(broadfit, init_amplitudes, init_sigmas)
             broadchi2 = self.chi2(broadfit, emlinewave, emlineflux, emlineivar)
             log.info('Second (broad) line-fitting with {} free parameters took {:.2f} sec (niter={}) with chi2={:.3f}'.format(
                 nfree, time.time()-t0, fitter.fit_info['nfev'], broadchi2))
@@ -1589,7 +1738,7 @@ class EMLineFit(ContinuumTools):
             fitter = FastLevMarLSQFitter(bestfit)
             finalfit = fitter(bestfit, emlinewave, emlineflux, weights=weights,
                               maxiter=maxiter, acc=accuracy)
-            finalfit = _clean_linefit(finalfit, init_amplitudes)
+            finalfit = self._clean_linefit(finalfit, init_amplitudes)
             chi2 = self.chi2(finalfit, emlinewave, emlineflux, emlineivar)
             log.info('Final line-fitting took {:.2f} sec (niter={}) with chi2={:.3f}'.format(
                 time.time()-t0, fitter.fit_info['nfev'], chi2))

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1527,10 +1527,9 @@ class EMLineFit(ContinuumTools):
         if np.all(fastspec['CONTINUUM_COEFF'] == 0):
             _smooth_continuum = np.zeros_like(stackwave)
         else:
-            print('HACK ON LINEMASK!!!')
             _smooth_continuum, _ = self.smooth_continuum(np.hstack(data['wave']), np.hstack(residuals),
                                                          np.hstack(data['ivar']), redshift=redshift,
-                                                         linemask=None)#np.hstack(data['linemask']))
+                                                         linemask=np.hstack(data['linemask']))
         smooth_continuum = []
         for campix in data['camerapix']:
             smooth_continuum.append(_smooth_continuum[campix[0]:campix[1]])

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -807,7 +807,10 @@ class EMLineFit(ContinuumTools):
 
         fit_info = least_squares(_objective_function, parameters[Ifree],
                                  args=farg, max_nfev=self.maxiter, 
-                                 xtol=self.accuracy, #method='lm')
+                                 xtol=self.accuracy, 
+                                 #method='lm')
+                                 #verbose=2,
+                                 tr_solver='lsmr', tr_options={'regularize': True},
                                  method='trf', bounds=tuple(zip(*bounds)))
         parameters[Ifree] = fit_info.x
 
@@ -1443,24 +1446,24 @@ class EMLineFit(ContinuumTools):
 
         # get the average emission-line redshifts and velocity widths
         if len(narrow_redshifts) > 0:
-            result['NARROW_Z'] = np.mean(narrow_redshifts)
-            result['NARROW_SIGMA'] = np.mean(narrow_sigmas) # * u.kilometer / u.second
+            result['NARROW_Z'] = np.median(narrow_redshifts)
+            result['NARROW_SIGMA'] = np.median(narrow_sigmas) # * u.kilometer / u.second
             #result['NARROW_Z_ERR'] = np.std(narrow_redshifts)
             #result['NARROW_SIGMA_ERR'] = np.std(narrow_sigmas)
         else:
             result['NARROW_Z'] = redshift
             
         if len(broad_redshifts) > 0:
-            result['BROAD_Z'] = np.mean(broad_redshifts)
-            result['BROAD_SIGMA'] = np.mean(broad_sigmas) # * u.kilometer / u.second
+            result['BROAD_Z'] = np.median(broad_redshifts)
+            result['BROAD_SIGMA'] = np.median(broad_sigmas) # * u.kilometer / u.second
             #result['BROAD_Z_ERR'] = np.std(broad_redshifts)
             #result['BROAD_SIGMA_ERR'] = np.std(broad_sigmas)
         else:
             result['BROAD_Z'] = redshift
             
         if len(uv_redshifts) > 0:
-            result['UV_Z'] = np.mean(uv_redshifts)
-            result['UV_SIGMA'] = np.mean(uv_sigmas) # * u.kilometer / u.second
+            result['UV_Z'] = np.median(uv_redshifts)
+            result['UV_SIGMA'] = np.median(uv_sigmas) # * u.kilometer / u.second
             #result['UV_Z_ERR'] = np.std(uv_redshifts)
             #result['UV_SIGMA_ERR'] = np.std(uv_sigmas)
         else:

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -773,7 +773,9 @@ class EMLineFit(ContinuumTools):
             else:
                 if linemodel['fixed'][iparam]:
                     linemodel['initial'][iparam] = 0.0
-
+                else:
+                    linemodel['initial'][iparam] = 1.0
+                    
         # Now loop back through and ensure that tied relationships are enforced.
         Itied = np.where((linemodel['tiedtoparam'] != -1) * (linemodel['fixed'] == False))[0]
         if len(Itied) > 0:
@@ -1016,7 +1018,7 @@ class EMLineFit(ContinuumTools):
                     #print(data['wave'][icam][linepix])
 
         # Require minimum XX pixels.
-        if broadlinefit and (len(broadlinepix) > 0 and len(np.hstack(broadlinepix)) > 10):
+        if broadlinefit and len(broadlinepix) > 0 and len(np.hstack(broadlinepix)) > 10:
             broadlinepix = np.hstack(broadlinepix)
 
             t0 = time.time()

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1061,18 +1061,26 @@ class EMLineFit(ContinuumTools):
 
         Ifree = np.where(linemodel['fixed'] == False)[0]
         for I in Ifree:
+            # copy initial values
             if bestfit['initial'][I] != 0:
                 linemodel['initial'][I] = bestfit['initial'][I]
+            # copy best-fit values
             if bestfit['value'][I] != 0:
                 linemodel['value'][I] = bestfit['value'][I]
             else:
                 if bestfit['tiedtoparam'][I] != -1:
                     linemodel['value'][I] = bestfit['value'][bestfit['tiedtoparam'][I]]
                 else:
-                    print(linemodel['param_name'][I])
-                    errmsg = 'Initial value should never be zero!'
-                    log.critical(errmsg)
-                    raise ValueError(errmsg)
+                    linemodel['value'][I] = linemodel['initial'][I]
+
+        # Tied parameters can have initial values of zero if they are fixed
+        # (e.g., broad emission lines).
+        I = (linemodel['value'][Ifree] == 0) * (linemodel['tiedtoparam'][Ifree] == -1)
+        if np.any(I):
+            errmsg = 'Initial values should never be zero!'
+            log.critical(errmsg)
+            pdb.set_trace()
+            #raise ValueError(errmsg)
 
         #B = np.where(['ne' in param for param in self.param_names])[0]
 

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -232,138 +232,6 @@ def _tie_lines(model):
 #    return model
 
 def emline_spectrum(emlinewave, *lineargs):
-                    #mgii_doublet_ratio,
-                    #oii_doublet_ratio,
-                    #sii_doublet_ratio,
-                    #mgii_2803_amp,
-                    #oii_3729_amp,
-                    #sii_6716_amp,
-                    #oi_1304_amp,
-                    #siliv_1396_amp,
-                    #civ_1549_amp,
-                    #siliii_1892_amp,
-                    #ciii_1908_amp,
-                    #nev_3346_amp,
-                    #nev_3426_amp,
-                    #neiii_3869_amp,
-                    #h6_amp,
-                    #h6_broad_amp,
-                    #hepsilon_amp,
-                    #hepsilon_broad_amp,
-                    #hdelta_amp,
-                    #hdelta_broad_amp,
-                    #hgamma_amp,
-                    #hgamma_broad_amp,
-                    #oiii_4363_amp,
-                    #hei_4471_amp,
-                    #hei_broad_4471_amp,
-                    #heii_4686_amp,
-                    #heii_broad_4686_amp,
-                    #hbeta_amp,
-                    #hbeta_broad_amp,
-                    #oiii_4959_amp,
-                    #oiii_5007_amp,
-                    #nii_5755_amp,
-                    #hei_5876_amp,
-                    #hei_broad_5876_amp,
-                    #oi_6300_amp,
-                    #siii_6312_amp,
-                    #nii_6548_amp,
-                    #halpha_amp,
-                    #halpha_broad_amp,
-                    #nii_6584_amp,
-                    #oii_7320_amp,
-                    #oii_7330_amp,
-                    #siii_9069_amp,
-                    #siii_9532_amp,
-                    #mgii_2796_vshift,
-                    #oii_3726_vshift,
-                    #sii_6731_vshift,
-                    #mgii_2803_vshift,
-                    #oii_3729_vshift,
-                    #sii_6716_vshift,
-                    #oi_1304_vshift,
-                    #siliv_1396_vshift,
-                    #civ_1549_vshift,
-                    #siliii_1892_vshift,
-                    #ciii_1908_vshift,
-                    #nev_3346_vshift,
-                    #nev_3426_vshift,
-                    #neiii_3869_vshift,
-                    #h6_vshift,
-                    #h6_broad_vshift,
-                    #hepsilon_vshift,
-                    #hepsilon_broad_vshift,
-                    #hdelta_vshift,
-                    #hdelta_broad_vshift,
-                    #hgamma_vshift,
-                    #hgamma_broad_vshift,
-                    #oiii_4363_vshift,
-                    #hei_4471_vshift,
-                    #hei_broad_4471_vshift,
-                    #heii_4686_vshift,
-                    #heii_broad_4686_vshift,
-                    #hbeta_vshift,
-                    #hbeta_broad_vshift,
-                    #oiii_4959_vshift,
-                    #oiii_5007_vshift,
-                    #nii_5755_vshift,
-                    #hei_5876_vshift,
-                    #hei_broad_5876_vshift,
-                    #oi_6300_vshift,
-                    #siii_6312_vshift,
-                    #nii_6548_vshift,
-                    #halpha_vshift,
-                    #halpha_broad_vshift,
-                    #nii_6584_vshift,
-                    #oii_7320_vshift,
-                    #oii_7330_vshift,
-                    #siii_9069_vshift,
-                    #siii_9532_vshift,
-                    #mgii_2796_sigma,
-                    #oii_3726_sigma,
-                    #sii_6731_sigma,
-                    #mgii_2803_sigma,
-                    #oii_3729_sigma,
-                    #sii_6716_sigma,
-                    #oi_1304_sigma,
-                    #siliv_1396_sigma,
-                    #civ_1549_sigma,
-                    #siliii_1892_sigma,
-                    #ciii_1908_sigma,
-                    #nev_3346_sigma,
-                    #nev_3426_sigma,
-                    #neiii_3869_sigma,
-                    #h6_sigma,
-                    #h6_broad_sigma,
-                    #hepsilon_sigma,
-                    #hepsilon_broad_sigma,
-                    #hdelta_sigma,
-                    #hdelta_broad_sigma,
-                    #hgamma_sigma,
-                    #hgamma_broad_sigma,
-                    #oiii_4363_sigma,
-                    #hei_4471_sigma,
-                    #hei_broad_4471_sigma,
-                    #heii_4686_sigma,
-                    #heii_broad_4686_sigma,
-                    #hbeta_sigma,
-                    #hbeta_broad_sigma,
-                    #oiii_4959_sigma,
-                    #oiii_5007_sigma,
-                    #nii_5755_sigma,
-                    #hei_5876_sigma,
-                    #hei_broad_5876_sigma,
-                    #oi_6300_sigma,
-                    #siii_6312_sigma,
-                    #nii_6548_sigma,
-                    #halpha_sigma,
-                    #halpha_broad_sigma,
-                    #nii_6584_sigma,
-                    #oii_7320_sigma,
-                    #oii_7330_sigma,
-                    #siii_9069_sigma,
-                    #siii_9532_sigma):
     """The model we want to optimize is a pure emission-line spectrum in erg/s/cm2/A
     in the observed frame.
 
@@ -1529,6 +1397,38 @@ class EMLineFit(ContinuumTools):
 
         return init_amplitudes, init_sigmas
 
+    def _lines_to_fit(self):
+        """Determine the free, tied, and fixed lines and also determine all the model
+        bounds.
+
+        """
+        Ifree, Itied, bounds = [], [], []
+        #Ifree, Itied, Ifixed, bounds = [], [], [], []
+
+        for pp in self.EMLineModel.param_names:
+            Ifree.append(self.EMLineModel.tied[pp] is False and self.EMLineModel.fixed[pp] is False)
+            Itied.append(self.EMLineModel.tied[pp] is not False)
+            #Ifixed.append(self.EMLineModel.fixed[pp] is not False)
+            if self.EMLineModel.bounds[pp][0] is None:
+                #lower = -np.inf # should never be infinity!
+                lower = -1e12
+            else:
+                lower = self.EMLineModel.bounds[pp][0]
+            if self.EMLineModel.bounds[pp][1] is None:
+                #upper = +np.inf
+                upper = +1e12
+            else:
+                upper = self.EMLineModel.bounds[pp][1]
+            bounds.append((lower, upper))
+        
+        Ifree = np.where(Ifree)[0]
+        Itied = np.where(Itied)[0]
+        #Ifixed = np.where(Ifixed)[0]
+        #bounds = tuple(zip(*bounds))
+        bounds = np.array(bounds)
+
+        return Ifree, Itied, bounds
+        #return Ifree, Itied, Ifixed, bounds
     
     def fit(self, data, continuummodel, smooth_continuum, synthphot=True,
             maxiter=5000, accuracy=1e-2, verbose=False, broadlinefit=True):
@@ -1606,40 +1506,81 @@ class EMLineFit(ContinuumTools):
         #for pp in self.EMLineModel.param_names:
         #    print(getattr(self.EMLineModel, pp))
 
-        ## --------------------------------------------------
-        #Ifree, Itied, Ifixed, model_bounds = [], [], [], []
-        #for pp in self.EMLineModel.param_names:
-        #    Ifree.append(self.EMLineModel.tied[pp] is False and self.EMLineModel.fixed[pp] is False)
-        #    Itied.append(self.EMLineModel.tied[pp] is not False)
-        #    Ifixed.append(self.EMLineModel.fixed[pp] is not False)
-        #    if self.EMLineModel.bounds[pp][0] is None:
-        #        lower = -np.inf
-        #    else:
-        #        lower = self.EMLineModel.bounds[pp][0]
-        #    if self.EMLineModel.bounds[pp][1] is None:
-        #        upper = +np.inf
-        #    else:
-        #        upper = self.EMLineModel.bounds[pp][1]
-        #    model_bounds.append((lower, upper))
-        #model_bounds = tuple(zip(*model_bounds))
-        #
-        #Ifree = np.where(Ifree)[0]
-        #Itied = np.where(Itied)[0]
-        #Ifixed = np.where(Ifixed)[0]
-        #
-        #
-        #
-        #fit_info = optimize.least_squares(
-        #    self.objective_function, init_values, args=farg, 
-        #    max_nfev=maxiter, xtol=accuracy, method='lm')#, bounds=bounds)
-        #
-        #pdb.set_trace()
-        #
-        #emline_spectrum(emlinewave, [self.EMLineModel.parameters, self.EMLineModel])
-        ##emline_spectrum(emlinewave, *self.EMLineModel.parameters.tolist())
-        #
-        #pdb.set_trace()
-        ## --------------------------------------------------
+        # --------------------------------------------------
+        if True:
+            from scipy import optimize
+    
+            def objective_function(free_parameters, *args):
+                """The parameters array should only contain free (not tied or fixed) parameters.
+    
+                """
+                EMLine = args[0]
+                wave = args[1]
+                flux = args[2]
+                weights = args[3]
+                Ifree = args[4]
+                Itied = args[5]
+                bounds = args[6]
+    
+                # Handle tied parameters and bounds. We need to set the model
+                # attributes before we evaluate the tied parameters.
+                param_names = np.array(EMLine.param_names)
+                for value, pp, bnd in zip(free_parameters, param_names[Ifree], bounds[Ifree]):
+                    if value < bnd[0]:
+                        value = bnd[0]
+                    if value > bnd[1]:
+                        value = bnd[1]
+                    setattr(EMLine, pp, value)
+    
+                if len(Itied) > 0:
+                    for I, pp in zip(Itied, param_names[Itied]):
+                    #for I, pp, bnd in zip(Itied, param_names[Itied], bounds[Itied]):
+                        value = EMLine.tied[pp](EMLine)
+                        # The tied parameter should *always* be determined by
+                        # the parameter it's tied to, even if it's outside the
+                        # bounds.
+                        #if value < bnd[0]:
+                        #    value = bnd[0]
+                        #if value > bnd[0]:
+                        #    value = bnd[1]
+                        setattr(EMLine, pp, value)
+    
+                parameters = EMLine.parameters
+                #print(parameters[30]/parameters[29])
+                lineargs = [parameters, EMLine]
+    
+                if weights is None:
+                    modelflux = emline_spectrum(wave, lineargs) - flux
+                else:
+                    modelflux = weights * (emline_spectrum(wave, lineargs) - flux)
+    
+                return modelflux
+    
+            Ifree, Itied, bounds = self._lines_to_fit()
+    
+            parameters0 = self.EMLineModel.parameters[Ifree]
+            farg = (self.EMLineModel, emlinewave, emlineflux, weights, Ifree, Itied, bounds)
+    
+            t0 = time.time()        
+            fit_info = optimize.least_squares(
+                objective_function, parameters0, args=farg,
+                max_nfev=maxiter, xtol=accuracy, method='lm')
+            log.info('Refactored line-fitting took {:.2f} sec (niter={})'.format(
+                time.time()-t0, fit_info.nfev))
+
+            self.EMLineModel.parameters[Ifree] = fit_info.x
+            modelflux = emline_spectrum(emlinewave, [self.EMLineModel.parameters, self.EMLineModel])
+    
+            import matplotlib.pyplot as plt
+            plt.clf()
+            plt.plot(emlinewave, emlineflux)
+            plt.plot(emlinewave, modelflux)
+            plt.xlim(6600, 6950)
+            plt.savefig('junk.png')
+            
+            pdb.set_trace()
+
+        # --------------------------------------------------
 
         fitter = FastLevMarLSQFitter(self.EMLineModel)
         initfit = fitter(self.EMLineModel, emlinewave, emlineflux, weights=weights,
@@ -1648,6 +1589,7 @@ class EMLineFit(ContinuumTools):
         initchi2 = self.chi2(initfit, emlinewave, emlineflux, emlineivar)
         log.info('Initial line-fitting with {} free parameters took {:.2f} sec (niter={}) with chi2={:.3f}'.format(
             nfree, time.time()-t0, fitter.fit_info['nfev'], initchi2))
+        pdb.set_trace()
 
         # Now try adding bround Balmer and helium lines and see if we improve
         # the chi2. First, do we have enough pixels around Halpha and Hbeta to

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -771,6 +771,8 @@ class EMLineFit(ContinuumTools):
 
         wavelims = (np.min(emlinewave)+5, np.max(emlinewave)-5)
 
+        pdb.set_trace()
+
         ###################################################
         if True:
             linemodel = build_linemodels(self.linetable, redshift, wavelims, verbose=True)
@@ -910,7 +912,7 @@ class EMLineFit(ContinuumTools):
         # do this test?
         broadlinepix = []
         for icam in np.arange(len(data['cameras'])):
-            pixoffset = int(np.sum(npixpercamera[:icam]))
+            pixoffset = int(np.sum(data['npixpercamera'][:icam]))
             for linename, linepix in zip(data['linename'][icam], data['linepix'][icam]):
                 if linename == 'halpha_broad' or linename == 'hbeta_broad' or linename == 'hgamma_broad':
                     broadlinepix.append(linepix + pixoffset)
@@ -1456,9 +1458,7 @@ class EMLineFit(ContinuumTools):
                                                          np.hstack(data['ivar']), redshift=redshift,
                                                          linemask=np.hstack(data['linemask']))
         smooth_continuum = []
-        for icam in np.arange(len(data['cameras'])): # iterate over cameras
-            ipix = np.sum(npixpercam[:icam+1])
-            jpix = np.sum(npixpercam[:icam+2])
+        for ipix, jpix in zip(data['ipix'], data['jpix']):
             smooth_continuum.append(_smooth_continuum[ipix:jpix])
 
         _emlinemodel = self.emlinemodel_bestfit(data['wave'], data['res'], fastspec)

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -709,7 +709,10 @@ class EMLineFit(ContinuumTools):
             linename = iline['name']
             if iline['isbroad']:
                 if iline['isbalmer']: # broad Balmer lines
-                    initial_guesses[linename+'_sigma'] = data['linesigma_balmer']
+                    if data['linesigma_balmer'] > data['linesigma_narrow']:
+                        initial_guesses[linename+'_sigma'] = data['linesigma_balmer']
+                    else:
+                        initial_guesses[linename+'_sigma'] = data['linesigma_narrow']
                 else: # broad UV/QSO lines
                     initial_guesses[linename+'_sigma'] = data['linesigma_uv']
             else:
@@ -1086,7 +1089,7 @@ class EMLineFit(ContinuumTools):
 
         # Finally, one more fitting loop with all the line-constraints relaxed
         # but starting from the previous best-fitting values.
-        if linechi2_broad > linechi2_init:
+        if linechi2_init < (linechi2_broad + 1):
             linemodel = final_linemodel_nobroad
         else:
             linemodel = final_linemodel

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -19,7 +19,7 @@ from desispec.interpolation import resample_flux
 from fastspecfit.util import trapz_rebin, C_LIGHT
 from fastspecfit.continuum import ContinuumTools
 from desiutil.log import get_logger, DEBUG
-log = get_logger(DEBUG)
+log = get_logger()#DEBUG)
 
 def read_emlines():
     """Read the set of emission lines of interest.

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1598,9 +1598,6 @@ class EMLineFit(ContinuumTools):
             pass
 
         redshift = fastspec['CONTINUUM_Z']
-        npixpercamera = [len(gw) for gw in data['wave']] # all pixels
-        npixpercam = np.hstack([0, npixpercamera])
-        
         stackwave = np.hstack(data['wave'])
 
         # rebuild the best-fitting spectroscopic and photometric models

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -322,8 +322,6 @@ class EMLineFit(ContinuumTools):
                             if verbose:
                                 print('Not fixing out-of-range parameter {}'.format(param_name))
                         else:
-                            #if linename == 'halpha_broad':
-                            #    pdb.set_trace()                
                             linemodel['fixed'][I] |= True
                 if verbose:
                     print('Number of fixed parameters = {}'.format(np.sum(linemodel['fixed'])))
@@ -856,7 +854,6 @@ class EMLineFit(ContinuumTools):
         Idrop = np.where(np.logical_or.reduce((drop1, drop2, drop3)))[0]
 
         if debug:
-            #pdb.set_trace()
             pass
 
         if len(Idrop) > 0:
@@ -1177,10 +1174,7 @@ class EMLineFit(ContinuumTools):
         # As a consistency check, make sure that the emission-line spectrum
         # rebuilt from the final table is not (very) different from the one
         # based on the best-fitting model parameters.
-        #try:
-        #    assert(np.all(np.isclose(emmodel, emlinemodel, rtol=1e-4)))
-        #except:
-        #    pdb.set_trace()
+        #assert(np.all(np.isclose(emmodel, emlinemodel, rtol=1e-4)))
             
         #import matplotlib.pyplot as plt
         #plt.clf()
@@ -1400,13 +1394,6 @@ class EMLineFit(ContinuumTools):
                     else:
                         cmed, civar = 0.0, 0.0
     
-                    #if np.abs(civar) > 1e10:
-                    #    import matplotlib.pyplot as plt
-                    #    plt.clf()
-                    #    plt.plot(emlinewave, emlineivar)
-                    #    plt.savefig('desi-users/ioannis/tmp/junk.png')
-                    #    pdb.set_trace()
-
                     result['{}_CONT'.format(linename)] = cmed # * u.erg/(u.second*u.cm**2*u.Angstrom)
                     result['{}_CONT_IVAR'.format(linename)] = civar # * u.second**2*u.cm**4*u.Angstrom**2/u.erg**2
     

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -46,7 +46,7 @@ def _assign_units_to_columns(fastfit, metadata, Spec, CFit, EMFit=None, fastphot
             metadata[col].unit = M[col].unit
 
     if EMFit is not None:
-        E = EMFit.init_output(EMFit.linetable, nobj=1)
+        E = EMFit.init_output(nobj=1)
         for col in E.colnames:
             if col in fastcols:
                 fastfit[col].unit = E[col].unit

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -358,24 +358,26 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
         allfilters = CFit.bassmzlswise
 
     if coadd_type == 'healpix':
-        title = 'Survey/Program/HealPix: {}/{}/{}, TargetID: {}'.format(
-            metadata['SURVEY'], metadata['PROGRAM'].capitalize(),
+        title = 'Survey/Program/Healpix: {}/{}/{}, TARGETID: {}'.format(
+            metadata['SURVEY'], metadata['PROGRAM'],
             metadata['HEALPIX'], metadata['TARGETID'])
         pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(
                 outprefix, metadata['SURVEY'], metadata['PROGRAM'], metadata['HEALPIX'], metadata['TARGETID']))
     elif coadd_type == 'cumulative':
-        title = '{}/{}: {} on Tile/Fiber={}/{}'.format(
-            metadata['SURVEY'].upper(), metadata['PROGRAM'], metadata['TARGETID'], metadata['TILEID'], metadata['FIBER'])
+        title = 'Survey/Program/Tile/Fiber: {}/{}/{}/{}, TARGETID: {}'.format(
+            metadata['SURVEY'].upper(), metadata['PROGRAM'], metadata['TILEID'], metadata['FIBER'], metadata['TARGETID'])
+        #title = '{}/{}: {} on Tile/Fiber: {}/{}'.format(
+        #    metadata['SURVEY'].upper(), metadata['PROGRAM'], metadata['TARGETID'], metadata['TILEID'], metadata['FIBER'])
         pngfile = os.path.join(outdir, '{}-{}-{}-{}.png'.format(
                 outprefix, metadata['TILEID'], coadd_type, metadata['TARGETID']))
     elif coadd_type == 'pernight':
-        title = 'Tile/Night: {}/{}, TargetID/Fiber: {}/{}'.format(
+        title = 'Tile/Night: {}/{}, TARGETID/Fiber: {}/{}'.format(
                 metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID'],
                 metadata['FIBER'])
         pngfile = os.path.join(outdir, '{}-{}-{}-{}.png'.format(
                 outprefix, metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID']))
     elif coadd_type == 'perexp':
-        title = 'Tile/Night/Expid: {}/{}/{}, TargetID/Fiber: {}/{}'.format(
+        title = 'Tile/Night/Expid: {}/{}/{}, TARGETID/Fiber: {}/{}'.format(
                 metadata['TILEID'], metadata['NIGHT'], metadata['EXPID'],
                 metadata['TARGETID'], metadata['FIBER'])
         pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(
@@ -383,7 +385,7 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
                 metadata['EXPID'], metadata['TARGETID']))
 
     redshift = fastfit['CONTINUUM_Z']
-    
+
     # rebuild the best-fitting broadband photometric model
     inodust = np.ndarray.item(np.where(CFit.AV == 0)[0]) # should always be index 0
     continuum_phot, synthmodelphot = CFit.SSP2data(
@@ -468,35 +470,6 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
             log.critical(errmsg)
             raise ValueError(errmsg)
 
-    #leg = {
-    #    'zredrock': '$z_{{\\rm redrock}}$={:.6f}'.format(redshift),
-    #    'dv_balmer': '$\\Delta v_{{\\rm narrow}}$={:.2f} km/s'.format(C_LIGHT*(fastfit['NARROW_Z']-redshift)),
-    #    'dv_forbid': '$\\Delta v_{{\\rm broad}}$={:.2f} km/s'.format(C_LIGHT*(fastfit['BROAD_Z']-redshift)),
-    #    'dv_broad': '$\\Delta v_{{\\rm UV}}$={:.2f} km/s'.format(C_LIGHT*(fastfit['UV_Z']-redshift)),
-    #    'sigma_balmer': '$\\sigma_{{\\rm narrow}}$={:.1f} km/s'.format(fastfit['NARROW_SIGMA']),
-    #    'sigma_forbid': '$\\sigma_{{\\rm broad}}$={:.1f} km/s'.format(fastfit['BROAD_SIGMA']),
-    #    'sigma_broad': '$\\sigma_{{\\rm UV}}$={:.1f} km/s'.format(fastfit['UV_SIGMA']),
-    #    'chi2': '$\\chi^{{2}}_{{\\nu}}$={:.3f}'.format(fastfit['CONTINUUM_RCHI2_SPEC']),
-    #    'rchi2': '$\\chi^{{2}}_{{\\nu}}$={:.3f}'.format(fastfit['RCHI2']),
-    #    'deltarchi2': '$\\Delta\\chi^{{2}}_{{\\nu,\\rm broad,narrow}}$={:.3f}'.format(fastfit['DELTA_LINERCHI2']),
-    #    'age': '<Age>={:.3f} Gyr'.format(fastfit['CONTINUUM_AGE_SPEC']),
-    #    }
-    #
-    #if fastfit['CONTINUUM_VDISP_IVAR'] == 0:
-    #    leg.update({'vdisp': '$\\sigma_{{\\rm star}}$={:.1f} km/s'.format(fastfit['CONTINUUM_VDISP'])})
-    #else:
-    #    leg.update({'vdisp': '$\\sigma_{{\\rm star}}$={:.1f}+/-{:.1f} km/s'.format(
-    #        fastfit['CONTINUUM_VDISP'], 1/np.sqrt(fastfit['CONTINUUM_VDISP_IVAR']))})
-    #    
-    #if fastfit['CONTINUUM_AV_IVAR_SPEC'] == 0:
-    #    leg.update({'AV': '$A(V)$={:.3f} mag'.format(fastfit['CONTINUUM_AV_SPEC'])})
-    #else:
-    #    leg.update({'AV': '$A(V)$={:.3f}+/-{:.3f} mag'.format(
-    #        fastfit['CONTINUUM_AV_SPEC'], 1/np.sqrt(fastfit['CONTINUUM_AV_IVAR_SPEC']))})
-    #
-    #legxpos, legypos, legfntsz = 0.98, 0.94, 20
-    #bbox = dict(boxstyle='round', facecolor='lightgray', alpha=0.25)
-
     # QA choices - everything in inches
     npanelrows = 7
     height_onepanel = 1.6
@@ -525,7 +498,9 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
         assert((ncutcols + nspeccols) == npanelcols)
         assert((nsedcols + nlinecols) == npanelcols)
     except:
-        pdb.set_trace()
+        errmsg = 'QA setup has gone awry.'
+        log.critical(errmsg)
+        raise ValueError(errmsg)
 
     #print(fullwidth, fullheight)
     #print(ncutcols, nspeccols, npanelcols)
@@ -547,6 +522,16 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
         cutax.imshow(im, interpolation='nearest')
         sz = im.size
 
+    if metadata['DEC'] > 0:
+        sgn = '+'
+    else:
+        sgn = ''
+        
+    bbox = dict(boxstyle='round', facecolor='lightgray', alpha=0.7)
+    cutax.text(0.04, 0.95, '$(\\alpha,\\delta)$=({:.7f}, {}{:.6f})'.format(metadata['RA'], sgn, metadata['DEC']),
+               ha='left', va='top', color='k', fontsize=11, bbox=bbox,
+               transform=cutax.transAxes)
+
     pixscale = 0.262
     cutax.add_artist(Circle((sz[0] / 2, sz[1] / 2), radius=1.5/2/pixscale, facecolor='none', # DESI fiber=1.5 arcsec diameter
                             edgecolor='red', ls='-', alpha=0.5))#, label='3" diameter'))
@@ -559,7 +544,7 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
     cutax.get_yaxis().set_visible(False)
     cutax.axis('off')
     cutax.autoscale(False)
-    cutax.legend(handles=handles, loc='lower left', fontsize=10)
+    cutax.legend(handles=handles, loc='lower left', fontsize=10, facecolor='lightgray')
 
     # full spectrum + best-fitting continuum model
     ymin_spec, ymax_spec = 1e6, -1e6
@@ -748,13 +733,14 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
 
         fastfit = Table(fastfit)
         fastfit['LYA_SIGMA'] = [plotsig_default_broad]
+        fastfit = fastfit[0] # stupid astropy Table/Row hack
 
     linetable = linetable[np.logical_and.reduce((
         linetable['name'] != 'hei_4471',
-        linetable['name'] != 'hei_5876',
+        #linetable['name'] != 'hei_5876',
         linetable['name'] != 'heii_4686',
         linetable['name'] != 'hei_broad_4471',
-        linetable['name'] != 'hei_broad_5876',
+        #linetable['name'] != 'hei_broad_5876',
         linetable['name'] != 'heii_broad_4686',
         ))]
 
@@ -767,11 +753,10 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
     linetable['plotgroup'][linetable['name'] == 'oiii_4363'] = 'oiii_4363'
     linetable['nicename'][linetable['name'] == 'oiii_4363'] = '[OIII]-$\lambda4363$'
 
-    linetable['plotgroup'][linetable['name'] == 'oiii_4959'] = 'oiii_4959'
-    linetable['nicename'][linetable['name'] == 'oiii_4959'] = '[OIII]-$\lambda4959$'
-
-    linetable['plotgroup'][linetable['name'] == 'oiii_5007'] = 'oiii_5007'
-    linetable['nicename'][linetable['name'] == 'oiii_5007'] = '[OIII]-$\lambda5007$'
+    #linetable['plotgroup'][linetable['name'] == 'oiii_4959'] = 'oiii_4959'
+    #linetable['nicename'][linetable['name'] == 'oiii_4959'] = '[OIII]-$\lambda4959$'
+    #linetable['plotgroup'][linetable['name'] == 'oiii_5007'] = 'oiii_5007'
+    #linetable['nicename'][linetable['name'] == 'oiii_5007'] = '[OIII]-$\lambda5007$'
 
     #linetable['linetype'] = 
 
@@ -814,7 +799,10 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
         'lya_1215', 'oi_1304', 'siliv_1396', 'civ_1549', 'siliii_1892_ciii_1908', 'mgii_2796_2803',
         # Balmer + nebular - 12
         'nev_3346', 'nev_3426', 'oii_3726_29', 'neiii_3869_h6', 'hepsilon', 'hdelta',
-        'hgamma', 'hbeta', 'oiii_4959', 'oiii_5007', 'halpha_nii_6548_48', 'sii_6716_31',
+        'hgamma', 'hbeta',
+        #'oiii_4959', 'oiii_5007',
+        'oiii_doublet', 'hei_5876',
+        'halpha_nii_6548_48', 'sii_6716_31',
         # auroral - 6
         'oiii_4363', 'nii_5755', 'oi_6300_siii_6312', 'oii_7320_30', 'siii_9069', 'siii_9532'
         ]
@@ -836,6 +824,8 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
         if meanwave > spec_wavelims[0] and meanwave < spec_wavelims[1]:
             if 'SiIII' in linename:
                 thislinename = '\n'+linename.replace('+', '+\n  ')
+            elif '4363' in linename:
+                thislinename = linename+'\n'
             else:
                 thislinename = linename
             specax.text(meanwave, ymax_spec, thislinename, ha='center', va='top',
@@ -913,7 +903,7 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
             if 'SiIII' in linename or '6312' in linename:
                 thislinename = '\n'+linename.replace('+', '+\n  ')
             elif '2803' in linename:
-                thislinename = '\n'+linename.replace(',2803', ',\n 2803')
+                thislinename = '\n'+linename.replace(',2803', ',\n           2803')
             else:
                 thislinename = linename
             xx.text(0.04, 0.89, thislinename, ha='left', va='center',
@@ -933,7 +923,209 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
         xx.axis('off')
 
     #plt.subplots_adjust(wspace=0.27, top=tp, bottom=bt, left=lf, right=rt, hspace=0.22)
-    plt.subplots_adjust(bottom=0.1, top=0.94, left=0.08, right=0.91)
+    plt.subplots_adjust(bottom=0.22, top=0.94, left=0.08, right=0.91)
+
+    # add some key results about the object at the bottom of the figure
+    leg = {
+        'radec': '$(\\alpha,\\delta)=({:.7f},{:.6f})$'.format(metadata['RA'], metadata['DEC']),
+        'z': '$z={:.7f}$'.format(redshift),
+        'zredrock': '$z_{{\\rm Redrock}}={:.7f}$'.format(metadata['Z_RR']),
+        #'zredrock': '$z_{{\\rm redrock}}={:.7f}$'.format(redshift),
+        'dn4000_spec': '$D_{{n}}(4000)_{{\\rm spec}}={:.3f}$'.format(fastfit['DN4000']),
+        'dn4000_modelspec': '$D_{{n}}(4000)_{{\\rm spec,model}}={:.3f}$'.format(fastfit['DN4000_MODEL_SPEC']),
+        'dn4000_modelphot': '$D_{{n}}(4000)_{{\\rm phot,model}}={:.3f}$'.format(fastfit['DN4000_MODEL_PHOT']),
+        'chi2': '$\\chi^{{2}}_{{\\nu}}={:.3f}$'.format(fastfit['CONTINUUM_RCHI2_SPEC']),
+        'rchi2': '$\\chi^{{2}}_{{\\nu}}={:.3f}$'.format(fastfit['RCHI2']),
+        'deltarchi2': '$\\Delta\\chi^{{2}}_{{\\nu,\\rm broad,narrow}}={:.3f}$'.format(fastfit['DELTA_LINERCHI2']),
+        'age_spec': '<Age>$_{{\\rm spec}}={:.3f}$ Gyr'.format(fastfit['CONTINUUM_AGE_SPEC']),
+        'age_phot': '<Age>$_{{\\rm phot}}={:.3f}$ Gyr'.format(fastfit['CONTINUUM_AGE_PHOT']),
+        'absmag_r': '$M_{{^{{0.1}}r}}={:.2f}$'.format(fastfit['ABSMAG_SDSS_R']),
+        'absmag_gr': '$^{{0.1}}(g-r)={:.3f}$'.format(fastfit['ABSMAG_SDSS_G']-fastfit['ABSMAG_SDSS_R']),
+        'absmag_rz': '$^{{0.1}}(r-z)={:.3f}$'.format(fastfit['ABSMAG_SDSS_R']-fastfit['ABSMAG_SDSS_Z']),       
+        }
+
+    if fastfit['NARROW_Z'] == redshift:
+        leg.update({'dv_narrow': '$\\Delta v_{{\\rm narrow}}=$...'})
+    else:
+        leg.update({'dv_narrow': '$\\Delta v_{{\\rm narrow}}={:.2f}$ km/s'.format(C_LIGHT*(fastfit['NARROW_Z']-redshift))})
+    if fastfit['BROAD_Z'] == redshift:
+        leg.update({'dv_broad': '$\\Delta v_{{\\rm broad}}=$...'})
+    else:
+        leg.update({'dv_broad': '$\\Delta v_{{\\rm broad}}={:.2f}$ km/s'.format(C_LIGHT*(fastfit['BROAD_Z']-redshift))})        
+    if fastfit['UV_Z'] == redshift:
+        leg.update({'dv_uv': '$\\Delta v_{{\\rm UV}}=$...'})
+    else:
+        leg.update({'dv_uv': '$\\Delta v_{{\\rm UV}}={:.2f}$ km/s'.format(C_LIGHT*(fastfit['UV_Z']-redshift))})
+
+    if fastfit['NARROW_SIGMA'] == 0.0:
+        leg.update({'sigma_narrow': '$\\sigma_{{\\rm narrow}}=$...'})
+    else:
+        leg.update({'sigma_narrow': '$\\sigma_{{\\rm narrow}}={:.1f}$ km/s'.format(fastfit['NARROW_SIGMA'])})
+    if fastfit['BROAD_SIGMA'] == 0.0:
+        leg.update({'sigma_broad': '$\\sigma_{{\\rm broad}}=$...'})
+    else:
+        leg.update({'sigma_broad': '$\\sigma_{{\\rm broad}}={:.1f}$ km/s'.format(fastfit['BROAD_SIGMA'])})
+    if fastfit['UV_SIGMA'] == 0.0:
+        leg.update({'sigma_uv': '$\\sigma_{{\\rm UV}}=$...'})
+    else:
+        leg.update({'sigma_uv': '$\\sigma_{{\\rm UV}}={:.1f}$ km/s'.format(fastfit['UV_SIGMA'])})
+        
+    if fastfit['CONTINUUM_VDISP_IVAR'] == 0:
+        leg.update({'vdisp': '$\\sigma_{{\\rm star}}={:.1f}$ km/s'.format(fastfit['CONTINUUM_VDISP'])})
+    else:
+        leg.update({'vdisp': '$\\sigma_{{\\rm star}}={:.1f}\\pm{:.1f}$ km/s'.format(
+            fastfit['CONTINUUM_VDISP'], 1/np.sqrt(fastfit['CONTINUUM_VDISP_IVAR']))})
+
+    if fastfit['LOGMSTAR'] > 0:
+        leg.update({'mstar': '$\\log_{{10}}\,(M_{{*}}/M_{{\odot}})={:.3f}$'.format(fastfit['LOGMSTAR'])})
+    else:
+        leg.update({'mstar': '$\\log_{{10}}\,(M_{{*}}/M_{{\odot}})=$...'})
+
+    if fastfit['CONTINUUM_AV_IVAR_SPEC'] == 0:
+        leg.update({'AV': '$A(V)={:.3f}$ mag'.format(fastfit['CONTINUUM_AV_SPEC'])})
+    else:
+        leg.update({'AV': '$A(V)={:.3f}\\pm{:.3f}$ mag'.format(
+            fastfit['CONTINUUM_AV_SPEC'], 1/np.sqrt(fastfit['CONTINUUM_AV_IVAR_SPEC']))})
+
+    # emission lines
+    if fastfit['CIV_1549_EW'] == 0:
+        leg.update({'ewciv': 'EW(CIV)$=$...'})
+    else:
+        leg.update({'ewciv': 'EW(CIV)$={:.3f}\ \\AA$'.format(fastfit['CIV_1549_EW'])})
+        
+    if fastfit['MGII_2796_EW'] == 0 and fastfit['MGII_2796_EW'] == 0:
+        leg.update({'ewmgii': 'EW(MgII)$=$...'})
+    else:
+        leg.update({'ewmgii': 'EW(MgII)$={:.3f}\ \\AA$'.format(fastfit['MGII_2796_EW']+fastfit['MGII_2796_EW'])})
+        
+    if fastfit['HALPHA_EW'] == 0:
+        leg.update({'ewha_narrow': 'EW(H$\\alpha)_{{\\rm narrow}}=$...'})
+    else:
+        leg.update({'ewha_narrow': 'EW(H$\\alpha)_{{\\rm narrow}}={:.2f}\ \\AA$'.format(fastfit['HALPHA_EW'])})
+        
+    if fastfit['HBETA_EW'] == 0:
+        leg.update({'ewhb_narrow': 'EW(H$\\beta)_{{\\rm narrow}}=$...'})
+    else:
+        leg.update({'ewhb_narrow': 'EW(H$\\beta)_{{\\rm narrow}}={:.2f}\ \\AA$'.format(fastfit['HBETA_EW'])})
+        
+    if fastfit['HGAMMA_EW'] == 0:
+        leg.update({'ewhg_narrow': 'EW(H$\\gamma)_{{\\rm narrow}}=$...'})
+    else:
+        leg.update({'ewhg_narrow': 'EW(H$\\gamma)_{{\\rm narrow}}={:.2f}\ \\AA$'.format(fastfit['HGAMMA_EW'])})
+        
+    if fastfit['HALPHA_BROAD_EW'] == 0:
+        leg.update({'ewha_broad': 'EW(H$\\alpha)_{{\\rm broad}}=$...'})
+    else:
+        leg.update({'ewha_broad': 'EW(H$\\alpha)_{{\\rm broad}}={:.2f}\ \\AA$'.format(fastfit['HALPHA_BROAD_EW'])})
+        
+    if fastfit['HBETA_BROAD_EW'] == 0:
+        leg.update({'ewhb_broad': 'EW(H$\\beta)_{{\\rm broad}}=$...'})
+    else:
+        leg.update({'ewhb_broad': 'EW(H$\\beta)_{{\\rm broad}}={:.2f}\ \\AA$'.format(fastfit['HBETA_BROAD_EW'])})
+        
+    if fastfit['HGAMMA_BROAD_EW'] == 0:
+        leg.update({'ewhg_broad': 'EW(H$\\gamma)_{{\\rm broad}}=$...'})
+    else:
+        leg.update({'ewhg_broad': 'EW(H$\\gamma)_{{\\rm broad}}={:.2f}\ \\AA$'.format(fastfit['HGAMMA_BROAD_EW'])})
+        
+    if fastfit['OII_3726_EW'] == 0 and fastfit['OII_3729_EW'] == 0:
+        leg.update({'ewoii': 'EW([OII])$=$...'})
+    else:
+        leg.update({'ewoii': 'EW([OII])$={:.2f}\ \\AA$'.format(fastfit['OII_3726_EW']+fastfit['OII_3729_EW'])})
+        
+    if fastfit['OIII_5007_EW'] == 0:
+        leg.update({'ewoiii': 'EW([OIII])$=$...'})
+    else:
+        leg.update({'ewoiii': 'EW([OIII])$={:.2f}\ \\AA$'.format(fastfit['OIII_5007_EW'])})
+        
+    if fastfit['NII_6584_EW'] == 0:
+        leg.update({'ewnii': 'EW([NII])$=$...'})
+    else:
+        leg.update({'ewnii': 'EW([NII])$={:.2f}\ \\AA$'.format(fastfit['NII_6584_EW'])})
+        
+    if fastfit['SII_6716_EW'] == 0 and fastfit['SII_6731_EW'] == 0:
+        leg.update({'ewsii': 'EW([SII])$=$...'})
+    else:
+        leg.update({'ewsii': 'EW([SII])$={:.2f}\ \\AA$'.format(fastfit['SII_6716_EW']+fastfit['SII_6731_EW'])})
+        
+    if fastfit['OII_DOUBLET_RATIO'] == 0:
+        #leg.update({'oii_doublet': '[OII] doublet ratio$=$...'})
+        leg.update({'oii_doublet': '[OII] $\lambda3726/\lambda3729=$...'})
+    else:
+        #leg.update({'oii_doublet': '[OII] doublet ratio$={:.3f}$'.format(fastfit['OII_DOUBLET_RATIO'])})
+        leg.update({'oii_doublet': '[OII] $\lambda3726/\lambda3729={:.3f}$'.format(fastfit['OII_DOUBLET_RATIO'])})
+
+    if fastfit['SII_DOUBLET_RATIO'] == 0:
+        #leg.update({'sii_doublet': '[SII] doublet ratio$=$...'})
+        leg.update({'sii_doublet': '[SII] $\lambda6731/\lambda6716=$...'})
+    else:
+        #leg.update({'sii_doublet': '[SII] doublet ratio$={:.3f}$'.format(fastfit['SII_DOUBLET_RATIO'])})
+        leg.update({'sii_doublet': '[SII] $\lambda6731/\lambda6716={:.3f}$'.format(fastfit['SII_DOUBLET_RATIO'])})
+
+    # parse the targeting bits
+    #from desitarget.targets import main_cmx_or_sv
+    #(desi_target, bgs_target, mws_target), mask, survey = main_cmx_or_sv(metadata)
+    
+    legfntsz, toppos, startpos, deltapos = 12, 0.125, 0.07, 0.13
+    txt = '\n'.join((
+        r'{}'.format(leg['mstar']),
+        r'{}'.format(leg['absmag_r']),
+        r'{}'.format(leg['absmag_gr']),
+        r'{}'.format(leg['absmag_rz']),
+        #r'{}'.format(leg['AV']),
+        ))
+    fig.text(startpos, toppos, txt, ha='left', va='top', fontsize=legfntsz)
+
+    txt = '\n'.join((
+        r'{}'.format(leg['z']),
+        r'{}'.format(leg['zredrock']),
+        r'{}'.format(leg['dv_narrow']),
+        r'{}'.format(leg['dv_broad']),
+        r'{}'.format(leg['dv_uv']),
+        ))
+    fig.text(startpos+deltapos*1, toppos, txt, ha='left', va='top', fontsize=legfntsz)
+
+    txt = '\n'.join((
+        r'{}'.format(leg['age_spec']),
+        r'{}'.format(leg['age_phot']),
+        #r'{}'.format(leg['dn4000_spec']),
+        r'{}'.format(leg['dn4000_modelspec']),
+        r'{}'.format(leg['dn4000_modelphot']),
+        ))
+    fig.text(startpos+deltapos*2, toppos, txt, ha='left', va='top', fontsize=legfntsz)
+
+    txt = '\n'.join((
+        r'{}'.format(leg['vdisp']),
+        r'{}'.format(leg['sigma_narrow']),
+        r'{}'.format(leg['sigma_broad']),
+        r'{}'.format(leg['sigma_uv']),
+        '',
+        r'{}'.format(leg['oii_doublet']),
+        r'{}'.format(leg['sii_doublet']),
+        ))
+    fig.text(startpos+deltapos*3.2, toppos+0.05, txt, ha='left', va='top', fontsize=legfntsz)
+
+    txt = '\n'.join((
+        r'{}'.format(leg['ewciv']),
+        r'{}'.format(leg['ewmgii']),
+        '',
+        r'{}'.format(leg['ewoii']),
+        r'{}'.format(leg['ewoiii']),
+        r'{}'.format(leg['ewnii']),
+        r'{}'.format(leg['ewsii']),
+        ))
+    fig.text(startpos+deltapos*3.2+1.2*deltapos, toppos+0.06, txt, ha='left', va='top', fontsize=legfntsz)
+
+    txt = '\n'.join((
+        r'{}'.format(leg['ewhg_narrow']),
+        r'{}'.format(leg['ewhb_narrow']),
+        r'{}'.format(leg['ewha_narrow']),
+        '',
+        r'{}'.format(leg['ewhg_broad']),
+        r'{}'.format(leg['ewhb_broad']),
+        r'{}'.format(leg['ewha_broad']),
+        ))
+    fig.text(startpos+deltapos*3.2+1.2*deltapos+1.1*deltapos, toppos+0.07, txt, ha='left', va='top', fontsize=legfntsz)
 
     # common axis labels
     ppos = specax.get_position()
@@ -943,7 +1135,8 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
              ha='center', va='center', 
              transform=fig.transFigure, rotation=270)#, fontsize=)
 
-    # draw a box around the three groups of lines
+    # draw a box around the three groups of lines -- note that this code has to
+    # come after the subplots_adjust!
     ax = np.array(ax).reshape(nlinerows, nlinecols)
 
     # UV/QSO
@@ -964,7 +1157,7 @@ def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
     fig.patches.extend([Rectangle((x0, y0), width, height, # (lower-left corner), width, height
                                   fill=False, color='orange', lw=1, zorder=1000,
                                   transform=fig.transFigure, figure=fig)])
-    plt.text(x1+0.01, (y1-y0)/2+y0, 'Balmer+Nebular', ha='center', va='center',
+    plt.text(x1+0.01, (y1-y0)/2+y0, 'Balmer+He+Narrow-Line', ha='center', va='center',
              transform=fig.transFigure, rotation=270, fontsize=10)
 
     llpos = ax[3, 0].get_position()

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -201,7 +201,7 @@ def fastspec(args=None, comm=None):
     if len(Spec.specfiles) == 0:
         return
 
-    data = Spec.read_and_unpack(CFit, fastphot=False, synthphot=True, remember_coadd=True)
+    data = Spec.read_and_unpack(CFit, fastphot=False, synthphot=True)
 
     #pdb.set_trace()
     #np.savetxt('linemask3.txt', np.array([np.hstack(data[0]['wave']), np.hstack(data[0]['flux']), np.hstack(data[0]['ivar'])]).T)

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -106,11 +106,14 @@ def fastphot_one(iobj, data, out, meta, CFit):
     return out, meta
 
 def desiqa_one(CFit, EMFit, data, fastfit, metadata, coadd_type,
-               fastphot=False, outdir=None, outprefix=None):
+               fastphot=False, outdir=None, outprefix=None, webqa=False):
     """Multiprocessing wrapper to generate QA for a single object."""
 
     #t0 = time.time()
-    if fastphot:
+    if webqa:
+        build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type=coadd_type,
+                    outprefix=outprefix, outdir=outdir)
+    elif fastphot:
         CFit.qa_fastphot(data, fastfit, metadata, coadd_type=coadd_type,
                          outprefix=outprefix, outdir=outdir)
     else:
@@ -314,3 +317,668 @@ def fastphot(args=None, comm=None):
     write_fastspecfit(out, meta, outfile=args.outfile, specprod=Spec.specprod,
                       coadd_type=Spec.coadd_type, fastphot=True)
 
+def build_webqa(CFit, EMFit, data, fastfit, metadata, coadd_type='healpix',
+                spec_wavelims=(3550, 9900), outprefix=None, outdir=None):
+    """QA for the web page.
+
+    """
+    import subprocess
+    from scipy.ndimage import median_filter
+
+    import matplotlib.pyplot as plt
+    from matplotlib import colors
+    import matplotlib.ticker as ticker
+    from matplotlib.patches import Circle, Rectangle
+    from matplotlib.lines import Line2D
+
+    import seaborn as sns
+    from astropy.table import Table, Column, vstack
+    from PIL import Image, ImageDraw
+    
+    from fastspecfit.util import ivar2var, C_LIGHT
+
+    sns.set(context='talk', style='ticks', font_scale=1.1)#, rc=rc)
+
+    col1 = [colors.to_hex(col) for col in ['dodgerblue', 'darkseagreen', 'orangered']]
+    col2 = [colors.to_hex(col) for col in ['darkblue', 'darkgreen', 'darkred']]
+    col3 = [colors.to_hex(col) for col in ['blue', 'green', 'red']]
+
+    photcol1 = colors.to_hex('darkblue') # 'darkgreen', 'darkred', 'dodgerblue', 'darkseagreen', 'orangered']]
+
+    if outdir is None:
+        outdir = '.'
+    if outprefix is None:
+        outprefix = 'fastfit'
+
+    if metadata['PHOTSYS'] == 'S':
+        filters = CFit.decam
+        allfilters = CFit.decamwise
+    else:
+        filters = CFit.bassmzls
+        allfilters = CFit.bassmzlswise
+
+    if coadd_type == 'healpix':
+        title = 'Survey/Program/HealPix: {}/{}/{}, TargetID: {}'.format(
+            metadata['SURVEY'], metadata['PROGRAM'].capitalize(),
+            metadata['HEALPIX'], metadata['TARGETID'])
+        pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(
+                outprefix, metadata['SURVEY'], metadata['PROGRAM'], metadata['HEALPIX'], metadata['TARGETID']))
+    elif coadd_type == 'cumulative':
+        title = '{}/{}: {} on Tile/Fiber={}/{}'.format(
+            metadata['SURVEY'].upper(), metadata['PROGRAM'], metadata['TARGETID'], metadata['TILEID'], metadata['FIBER'])
+        pngfile = os.path.join(outdir, '{}-{}-{}-{}.png'.format(
+                outprefix, metadata['TILEID'], coadd_type, metadata['TARGETID']))
+    elif coadd_type == 'pernight':
+        title = 'Tile/Night: {}/{}, TargetID/Fiber: {}/{}'.format(
+                metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID'],
+                metadata['FIBER'])
+        pngfile = os.path.join(outdir, '{}-{}-{}-{}.png'.format(
+                outprefix, metadata['TILEID'], metadata['NIGHT'], metadata['TARGETID']))
+    elif coadd_type == 'perexp':
+        title = 'Tile/Night/Expid: {}/{}/{}, TargetID/Fiber: {}/{}'.format(
+                metadata['TILEID'], metadata['NIGHT'], metadata['EXPID'],
+                metadata['TARGETID'], metadata['FIBER'])
+        pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(
+                outprefix, metadata['TILEID'], metadata['NIGHT'],
+                metadata['EXPID'], metadata['TARGETID']))
+
+    redshift = fastfit['CONTINUUM_Z']
+    
+    # rebuild the best-fitting broadband photometric model
+    inodust = np.ndarray.item(np.where(CFit.AV == 0)[0]) # should always be index 0
+    continuum_phot, synthmodelphot = CFit.SSP2data(
+        CFit.sspflux_dustnomvdisp[:, :, inodust], CFit.sspwave, redshift=redshift,
+        synthphot=True, AV=fastfit['CONTINUUM_AV_PHOT'], #test=True,
+        coeff=fastfit['CONTINUUM_COEFF_PHOT'] * CFit.massnorm)
+
+    continuum_wave_phot = CFit.sspwave * (1 + redshift)
+
+    wavemin, wavemax = 0.1, 35.0 # 6.0
+    indx_phot = np.where((continuum_wave_phot/1e4 > wavemin) * (continuum_wave_phot/1e4 < wavemax))[0]     
+
+    phot = CFit.parse_photometry(CFit.bands,
+                                 maggies=np.array([metadata['FLUX_{}'.format(band.upper())] for band in CFit.bands]),
+                                 ivarmaggies=np.array([metadata['FLUX_IVAR_{}'.format(band.upper())] for band in CFit.bands]),
+                                 lambda_eff=allfilters.effective_wavelengths.value,
+                                 min_uncertainty=CFit.min_uncertainty)
+    fiberphot = CFit.parse_photometry(CFit.fiber_bands,
+                                      maggies=np.array([metadata['FIBERTOTFLUX_{}'.format(band.upper())] for band in CFit.fiber_bands]),
+                                      lambda_eff=filters.effective_wavelengths.value)
+
+    # rebuild the best-fitting spectroscopic and photometric models
+    stackwave = np.hstack(data['wave'])
+
+    continuum, _ = EMFit.SSP2data(EMFit.sspflux, EMFit.sspwave, redshift=redshift, 
+                                 specwave=data['wave'], specres=data['res'],
+                                 cameras=data['cameras'],
+                                 AV=fastfit['CONTINUUM_AV_SPEC'],
+                                 vdisp=fastfit['CONTINUUM_VDISP'],
+                                 coeff=fastfit['CONTINUUM_COEFF_SPEC'],
+                                 synthphot=False)
+
+    residuals = [data['flux'][icam] - continuum[icam] for icam in np.arange(len(data['cameras']))]
+    if np.all(fastfit['CONTINUUM_COEFF_SPEC'] == 0):
+        _smooth_continuum = np.zeros_like(stackwave)
+    else:
+        _smooth_continuum, _ = EMFit.smooth_continuum(np.hstack(data['wave']), np.hstack(residuals),
+                                                      np.hstack(data['ivar']), redshift=redshift,
+                                                      linemask=np.hstack(data['linemask']))
+    smooth_continuum = []
+    for campix in data['camerapix']:
+        smooth_continuum.append(_smooth_continuum[campix[0]:campix[1]])
+
+    _emlinemodel = EMFit.emlinemodel_bestfit(data['wave'], data['res'], Table(fastfit))
+
+    # individual-line spectra
+    _emlinemodel_oneline = []
+    for refline in EMFit.linetable: # [EMFit.inrange]: # for all lines in range
+        T = Table(fastfit['CONTINUUM_Z', 'MGII_DOUBLET_RATIO', 'OII_DOUBLET_RATIO', 'SII_DOUBLET_RATIO'])
+        for oneline in EMFit.linetable: # need all lines for the model
+            linename = oneline['name']
+            for linecol in ['AMP', 'VSHIFT', 'SIGMA']:
+                col = linename.upper()+'_'+linecol
+                if linename == refline['name']:
+                    T.add_column(Column(name=col, data=fastfit[col], dtype=fastfit[col].dtype))
+                else:
+                    T.add_column(Column(name=col, data=0.0, dtype=fastfit[col].dtype))
+        # special case the parameter doublets
+        if refline['name'] == 'mgii_2796':
+            T['MGII_2803_AMP'] = fastfit['MGII_2803_AMP']
+        if refline['name'] == 'oii_3726':
+            T['OII_3729_AMP'] = fastfit['OII_3729_AMP']
+        if refline['name'] == 'sii_6731':
+            T['SII_6716_AMP'] = fastfit['SII_6716_AMP']
+        _emlinemodel_oneline1 = EMFit.emlinemodel_bestfit(data['wave'], data['res'], T)
+        if np.sum(np.hstack(_emlinemodel_oneline1)) > 0:
+            _emlinemodel_oneline.append(_emlinemodel_oneline1)
+
+    # Grab the viewer cutout.
+    width = int(60 / 0.262)   # =1 arcmin
+    height = int(width / 1.3) # 3:2 aspect ratio
+    
+    cutoutpng = os.path.join('/tmp', 'tmp.'+os.path.basename(pngfile))
+    if not os.path.isfile(cutoutpng):
+        cmd = 'wget -O {outfile} https://www.legacysurvey.org/viewer/jpeg-cutout?ra={ra}&dec={dec}&width={width}&height={height}&layer=ls-dr9'
+        cmd = cmd.format(outfile=cutoutpng, ra=metadata['RA'], dec=metadata['DEC'],
+                         width=width, height=height)
+        print(cmd)
+        err = subprocess.call(cmd.split())
+        if err != 0:
+            errmsg = 'Something went wrong retrieving the png cutout'
+            log.critical(errmsg)
+            raise ValueError(errmsg)
+
+    #leg = {
+    #    'zredrock': '$z_{{\\rm redrock}}$={:.6f}'.format(redshift),
+    #    'dv_balmer': '$\\Delta v_{{\\rm narrow}}$={:.2f} km/s'.format(C_LIGHT*(fastfit['NARROW_Z']-redshift)),
+    #    'dv_forbid': '$\\Delta v_{{\\rm broad}}$={:.2f} km/s'.format(C_LIGHT*(fastfit['BROAD_Z']-redshift)),
+    #    'dv_broad': '$\\Delta v_{{\\rm UV}}$={:.2f} km/s'.format(C_LIGHT*(fastfit['UV_Z']-redshift)),
+    #    'sigma_balmer': '$\\sigma_{{\\rm narrow}}$={:.1f} km/s'.format(fastfit['NARROW_SIGMA']),
+    #    'sigma_forbid': '$\\sigma_{{\\rm broad}}$={:.1f} km/s'.format(fastfit['BROAD_SIGMA']),
+    #    'sigma_broad': '$\\sigma_{{\\rm UV}}$={:.1f} km/s'.format(fastfit['UV_SIGMA']),
+    #    'chi2': '$\\chi^{{2}}_{{\\nu}}$={:.3f}'.format(fastfit['CONTINUUM_RCHI2_SPEC']),
+    #    'rchi2': '$\\chi^{{2}}_{{\\nu}}$={:.3f}'.format(fastfit['RCHI2']),
+    #    'deltarchi2': '$\\Delta\\chi^{{2}}_{{\\nu,\\rm broad,narrow}}$={:.3f}'.format(fastfit['DELTA_LINERCHI2']),
+    #    'age': '<Age>={:.3f} Gyr'.format(fastfit['CONTINUUM_AGE_SPEC']),
+    #    }
+    #
+    #if fastfit['CONTINUUM_VDISP_IVAR'] == 0:
+    #    leg.update({'vdisp': '$\\sigma_{{\\rm star}}$={:.1f} km/s'.format(fastfit['CONTINUUM_VDISP'])})
+    #else:
+    #    leg.update({'vdisp': '$\\sigma_{{\\rm star}}$={:.1f}+/-{:.1f} km/s'.format(
+    #        fastfit['CONTINUUM_VDISP'], 1/np.sqrt(fastfit['CONTINUUM_VDISP_IVAR']))})
+    #    
+    #if fastfit['CONTINUUM_AV_IVAR_SPEC'] == 0:
+    #    leg.update({'AV': '$A(V)$={:.3f} mag'.format(fastfit['CONTINUUM_AV_SPEC'])})
+    #else:
+    #    leg.update({'AV': '$A(V)$={:.3f}+/-{:.3f} mag'.format(
+    #        fastfit['CONTINUUM_AV_SPEC'], 1/np.sqrt(fastfit['CONTINUUM_AV_IVAR_SPEC']))})
+    #
+    #legxpos, legypos, legfntsz = 0.98, 0.94, 20
+    #bbox = dict(boxstyle='round', facecolor='lightgray', alpha=0.25)
+
+    # QA choices - everything in inches
+    npanelrows = 7
+    height_onepanel = 1.6
+    fullheight = npanelrows*height_onepanel
+    
+    npanelcols = 13 # 15
+    width_onepanel = 1.3
+    fullwidth = npanelcols*width_onepanel
+    
+    nlinerows = 4 
+    nlinecols = 6 
+    nlinepanels = nlinecols * nlinerows
+    
+    nspecrows = 3
+    nspeccols = 8 
+    
+    nsedrows = npanelrows - nspecrows
+    nsedcols = npanelcols - nlinecols
+    
+    ncutrows = nspecrows
+    ncutcols = npanelcols - nspeccols
+
+    try:
+        assert((ncutrows + nsedrows) == npanelrows)
+        assert((nspecrows + nlinerows) == npanelrows)
+        assert((ncutcols + nspeccols) == npanelcols)
+        assert((nsedcols + nlinecols) == npanelcols)
+    except:
+        pdb.set_trace()
+
+    #print(fullwidth, fullheight)
+    #print(ncutcols, nspeccols, npanelcols)
+    #print(ncutrows, nspecrows, nsedrows, npanelrows)
+    
+    height_ratios = np.hstack(([1.2]*nspecrows, [1.0]*nlinerows))
+
+    plt.clf()
+    fig = plt.figure(figsize=(fullwidth, fullheight))
+    gs = fig.add_gridspec(npanelrows, npanelcols)#, height_ratios=height_ratios)#, width_ratios=width_ratios)
+
+    cutax = fig.add_subplot(gs[0:ncutrows, 0:ncutcols])
+    sedax = fig.add_subplot(gs[ncutrows:(ncutrows+nsedrows), 0:nsedcols])
+    specax = fig.add_subplot(gs[:nspecrows, ncutcols:(ncutcols+nspeccols)])
+
+    # viewer cutout
+    Image.MAX_IMAGE_PIXELS = None
+    with Image.open(cutoutpng) as im:
+        cutax.imshow(im, interpolation='nearest')
+        sz = im.size
+
+    pixscale = 0.262
+    cutax.add_artist(Circle((sz[0] / 2, sz[1] / 2), radius=1.5/2/pixscale, facecolor='none', # DESI fiber=1.5 arcsec diameter
+                            edgecolor='red', ls='-', alpha=0.5))#, label='3" diameter'))
+    cutax.add_artist(Circle((sz[0] / 2, sz[1] / 2), radius=10/2/pixscale, facecolor='none',
+                            edgecolor='red', ls='--', alpha=0.5))#, label='15" diameter'))
+    handles = [Line2D([0], [0], color='red', lw=2, ls='-', label='1.5 arcsec'),
+               Line2D([0], [0], color='red', lw=2, ls='--', label='10 arcsec')]
+    
+    cutax.get_xaxis().set_visible(False)
+    cutax.get_yaxis().set_visible(False)
+    cutax.axis('off')
+    cutax.autoscale(False)
+    cutax.legend(handles=handles, loc='lower left', fontsize=10)
+
+    # full spectrum + best-fitting continuum model
+    ymin_spec, ymax_spec = 1e6, -1e6
+    allfullspec, allfullwave = [], []
+    for ii in np.arange(len(data['cameras'])): # iterate over cameras
+        sigma, good = ivar2var(data['ivar'][ii], sigma=True, allmasked_ok=True)
+
+        specax.fill_between(data['wave'][ii], data['flux'][ii]-sigma,
+                            data['flux'][ii]+sigma, color=col1[ii])
+        _fullspec = continuum[ii] + _emlinemodel[ii]
+        fullspec = continuum[ii] + smooth_continuum[ii] + _emlinemodel[ii]
+        specax.plot(data['wave'][ii], fullspec, color=col2[ii])
+
+        allfullspec.append(_fullspec)
+        allfullwave.append(data['wave'][ii])
+        
+        # get the robust range
+        filtflux = median_filter(data['flux'][ii], 51, mode='nearest')
+        I = data['ivar'][ii] > 0
+        if np.sum(I) > 0:
+            #ymin_spec, ymax_spec = np.percentile(data['flux'][ii], [5, 98]) * [-1, +1]
+            #ymin_spec, ymax_spec = np.percentile(data['flux'][ii], [5, 95])
+            sigflux = np.diff(np.percentile(data['flux'][ii], [25, 75]))[0] / 1.349 # robust
+            if -3 * sigflux < ymin_spec:
+                ymin_spec = -3 * sigflux
+            if 5 * sigflux > ymax_spec:
+                ymax_spec = 5 * sigflux
+            if np.max(filtflux) > ymax_spec:
+                ymax_spec = np.max(filtflux)
+            if np.max(_emlinemodel[ii]) > ymax_spec:
+                ymax_spec = np.max(_emlinemodel[ii]) * 1.2
+            #print(ymin_spec, ymax_spec)
+
+    allfullwave = np.hstack(allfullwave)
+    allfullspec = np.hstack(allfullspec)
+    
+    #specax.plot(stackwave, _smooth_continuum, color='gray')
+    specax.plot(stackwave, np.hstack(continuum), color='k', alpha=0.3)
+
+    specax.set_xlim(spec_wavelims)
+    specax.set_ylim(ymin_spec, ymax_spec)
+    specax.set_xticklabels([])
+    specax.set_yticklabels([])
+    specax.set_xticks([])
+    specax.set_yticks([])
+    specax.spines[['left', 'bottom', 'top']].set_visible(False)
+
+    specax_twin = specax.twinx()
+    specax_twin.set_ylim(ymin_spec, ymax_spec)
+    specax_twin.spines[['left', 'bottom', 'top']].set_visible(False)
+    
+    # photometric SED
+    if fastfit['FLUX_SYNTH_R'] > 0:
+        apfactor = synthmodelphot[synthmodelphot['band'] == 'r']['nanomaggies'][0]/fastfit['FLUX_SYNTH_R']
+    else:
+        apfactor = 1.0
+    factor = apfactor * 1e-17 * 10**(0.4 * 48.6) * allfullwave**2 / (C_LIGHT * 1e13) # [erg/s/cm2/A --> maggies]
+    good = allfullspec > 0
+    sedax.plot(allfullwave[good]/1e4, -2.5*np.log10(allfullspec[good]*factor[good]), color='gray', alpha=0.5)
+
+    if np.all(continuum_phot[indx_phot] <= 0):
+        CFit.log.warning('Best-fitting photometric continuum is all zeros or negative!')
+        continuum_phot_abmag = continuum_phot*0 + np.median(fiberphot['abmag'])
+    else:
+        indx_phot = indx_phot[continuum_phot[indx_phot] > 0] # trim zeros
+        factor = 10**(0.4 * 48.6) * continuum_wave_phot[indx_phot]**2 / (C_LIGHT * 1e13) / CFit.fluxnorm / CFit.massnorm # [erg/s/cm2/A --> maggies]
+        continuum_phot_abmag = -2.5*np.log10(continuum_phot[indx_phot] * factor)
+        sedax.plot(continuum_wave_phot[indx_phot] / 1e4, continuum_phot_abmag, color='tan', zorder=1)
+
+    sedax.scatter(synthmodelphot['lambda_eff']/1e4, synthmodelphot['abmag'], 
+               marker='s', s=200, color='k', facecolor='none',
+               #label=r'$grz$ (spectrum, synthesized)',
+               alpha=0.8, zorder=2)
+    
+    # we have to set the limits *before* we call errorbar, below!
+    dm = 1.0
+    good = phot['abmag_ivar'] > 0
+    goodlim = phot['abmag_limit'] > 0
+    if np.sum(good) > 0 and np.sum(goodlim) > 0:
+        ymin = np.max((np.nanmax(phot['abmag'][good]), np.nanmax(phot['abmag_limit'][goodlim]), np.nanmax(continuum_phot_abmag))) + dm
+        ymax = np.min((np.nanmin(phot['abmag'][good]), np.nanmin(phot['abmag_limit'][goodlim]), np.nanmin(continuum_phot_abmag))) - dm
+    elif np.sum(good) > 0 and np.sum(goodlim) == 0:
+        ymin = np.max((np.nanmax(phot['abmag'][good]), np.nanmax(continuum_phot_abmag))) + dm
+        ymax = np.min((np.nanmin(phot['abmag'][good]), np.nanmin(continuum_phot_abmag))) - dm
+    elif np.sum(good) == 0 and np.sum(goodlim) > 0:
+        ymin = np.max((np.nanmax(phot['abmag_limit'][goodlim]), np.nanmax(continuum_phot_abmag))) + dm
+        ymax = np.min((np.nanmin(phot['abmag_limit'][goodlim]), np.nanmin(continuum_phot_abmag))) - dm
+    else:
+        good = phot['abmag'] > 0
+        goodlim = phot['abmag_limit'] > 0
+        if np.sum(good) > 0 and np.sum(goodlim) > 0:
+            ymin = np.max((np.nanmax(phot['abmag'][good]), np.nanmax(phot['abmag_limit'][goodlim]))) + dm
+            ymax = np.min((np.nanmin(phot['abmag'][good]), np.nanmin(phot['abmag_limit'][goodlim]))) - dm
+        elif np.sum(good) > 0 and np.sum(goodlim) == 0:                
+            ymin = np.nanmax(phot['abmag'][good]) + dm
+            ymax = np.nanmin(phot['abmag'][good]) - dm
+        elif np.sum(good) == 0 and np.sum(goodlim) > 0:
+            ymin = np.nanmax(phot['abmag_limit'][goodlim]) + dm
+            ymax = np.nanmin(phot['abmag_limit'][goodlim]) - dm
+        else:
+            ymin, ymax = [30, 20]
+        
+    if ymin > 30:
+        ymin = 30
+    if np.isnan(ymin) or np.isnan(ymax):
+        raise('Problem here!')
+
+    sedax.set_xlabel(r'Observed-frame Wavelength ($\mu$m)') 
+    sedax.set_ylabel('AB mag') 
+    #sedax.set_ylabel(r'Apparent Brightness (AB mag)') 
+    sedax.set_xlim(wavemin, wavemax)
+    sedax.set_ylim(ymin, ymax)
+    sedax.set_xscale('log')
+
+    @ticker.FuncFormatter
+    def major_formatter(x, pos):
+        if x > 1:
+            return f'{x:.0f}'
+        else:
+            return f'{x:.1f}'
+    
+    sedax.xaxis.set_major_formatter(major_formatter)
+    sedax.set_xticks([0.1, 0.2, 0.5, 1.0, 1.5, 3.0, 5.0, 10.0, 20.0])
+
+    # integrated flux / photometry
+    abmag = np.squeeze(phot['abmag'])
+    abmag_limit = np.squeeze(phot['abmag_limit'])
+    abmag_fainterr = np.squeeze(phot['abmag_fainterr'])
+    abmag_brighterr = np.squeeze(phot['abmag_brighterr'])
+    yerr = np.squeeze([abmag_brighterr, abmag_fainterr])
+
+    dofit = np.where(CFit.bands_to_fit)[0]
+    if len(dofit) > 0:
+        good = np.where((abmag[dofit] > 0) * (abmag_limit[dofit] == 0))[0]
+        upper = np.where(abmag_limit[dofit] > 0)[0]
+        if len(good) > 0:
+            sedax.errorbar(phot['lambda_eff'][dofit][good]/1e4, abmag[dofit][good],
+                        yerr=yerr[:, dofit[good]],
+                        fmt='o', markersize=12, markeredgewidth=3, markeredgecolor=photcol1,
+                        markerfacecolor=photcol1, elinewidth=3, ecolor=photcol1, capsize=4,
+                        label=r'$grz\,W_{1}W_{2}W_{3}W_{4}$', zorder=2)
+        if len(upper) > 0:
+            sedax.errorbar(phot['lambda_eff'][dofit][upper]/1e4, abmag_limit[dofit][upper],
+                        lolims=True, yerr=0.75,
+                        fmt='o', markersize=12, markeredgewidth=3, markeredgecolor=photcol1,
+                        markerfacecolor=photcol1, elinewidth=3, ecolor=photcol1, capsize=4)
+
+    ignorefit = np.where(CFit.bands_to_fit == False)[0]
+    if len(ignorefit) > 0:
+        good = np.where((abmag[ignorefit] > 0) * (abmag_limit[ignorefit] == 0))[0]
+        upper = np.where(abmag_limit[ignorefit] > 0)[0]
+        if len(good) > 0:
+            sedax.errorbar(phot['lambda_eff'][ignorefit][good]/1e4, abmag[ignorefit][good],
+                        yerr=yerr[:, ignorefit[good]],
+                        fmt='o', markersize=12, markeredgewidth=3, markeredgecolor=photcol1,
+                        markerfacecolor='none', elinewidth=3, ecolor=photcol1, capsize=4)
+        if len(upper) > 0:
+            sedax.errorbar(phot['lambda_eff'][ignorefit][upper]/1e4, abmag_limit[ignorefit][upper],
+                        lolims=True, yerr=0.75, fmt='o', markersize=12, markeredgewidth=3,
+                        markeredgecolor=photcol1, markerfacecolor='none', elinewidth=3,
+                        ecolor=photcol1, capsize=5)
+
+    sedax.plot([spec_wavelims[0]/1e4, spec_wavelims[1]/1e4], [ymin-1, ymin-1],
+               lw=2, ls='-', color='gray', marker='s')#, alpha=0.5)
+    sedax.text(((spec_wavelims[1]-spec_wavelims[0])/2+spec_wavelims[0]*0.8)/1e4, ymin-1.4,
+               'DESI x {:.2f}'.format(apfactor), ha='center', va='center', fontsize=10,
+               color='gray')
+    
+    # zoom in on individual emission lines - use linetable!
+    plotsig_default = 200.0 # [km/s]
+    plotsig_default_balmer = 500.0 # [km/s]
+    plotsig_default_broad = 2000.0 # [km/s]
+    
+    linetable = EMFit.linetable # custom plotgroups and labels
+    #linetable.remove_columns(['isbalmer', 'isbroad', 'amp'])
+
+    if True:
+        lya = Table()
+        lya['name'] = ['lya']
+        lya['restwave'] = [1215.67]
+        lya['nicename'] = ['Ly$\\alpha$-$\lambda$1215']
+        lya['isbroad'] = [True]
+        lya['isbalmer'] = [False]
+        lya['plotgroup'] = ['lya_1215']
+        linetable = vstack((lya, linetable))
+
+        fastfit = Table(fastfit)
+        fastfit['LYA_SIGMA'] = [plotsig_default_broad]
+
+    linetable = linetable[np.logical_and.reduce((
+        linetable['name'] != 'hei_4471',
+        linetable['name'] != 'hei_5876',
+        linetable['name'] != 'heii_4686',
+        linetable['name'] != 'hei_broad_4471',
+        linetable['name'] != 'hei_broad_5876',
+        linetable['name'] != 'heii_broad_4686',
+        ))]
+
+    # custom groups
+    linetable['plotgroup'][linetable['name'] == 'hgamma'] = 'hgamma'
+    linetable['plotgroup'][linetable['name'] == 'hgamma_broad'] = 'hgamma'
+    linetable['nicename'][linetable['name'] == 'hgamma'] = 'H$\gamma$-$\lambda$4340'
+    linetable['nicename'][linetable['name'] == 'hgamma_broad'] = 'H$\gamma$-$\lambda$4340'
+
+    linetable['plotgroup'][linetable['name'] == 'oiii_4363'] = 'oiii_4363'
+    linetable['nicename'][linetable['name'] == 'oiii_4363'] = '[OIII]-$\lambda4363$'
+
+    linetable['plotgroup'][linetable['name'] == 'oiii_4959'] = 'oiii_4959'
+    linetable['nicename'][linetable['name'] == 'oiii_4959'] = '[OIII]-$\lambda4959$'
+
+    linetable['plotgroup'][linetable['name'] == 'oiii_5007'] = 'oiii_5007'
+    linetable['nicename'][linetable['name'] == 'oiii_5007'] = '[OIII]-$\lambda5007$'
+
+    #linetable['linetype'] = 
+
+    uplotgroups = np.unique(linetable['plotgroup'].data)
+    nline = len(uplotgroups)
+    
+    meanwaves, deltawaves, sigmas, linenames = [], [], [], []
+    for plotgroup in uplotgroups:
+        I = np.where(plotgroup == linetable['plotgroup'])[0]
+        linenames.append(linetable['nicename'][I[0]].replace('-', ' '))
+        meanwaves.append(np.mean(linetable['restwave'][I]))
+        deltawaves.append((np.max(linetable['restwave'][I]) - np.min(linetable['restwave'][I])) / 2)
+    
+        sigmas1 = np.array([fastfit['{}_SIGMA'.format(line.upper())] for line in linetable[I]['name']])
+        sigmas1 = sigmas1[sigmas1 > 0]
+        if len(sigmas1) > 0:
+            plotsig = 1.5*np.mean(sigmas1)
+        else:
+            if np.any(linetable['isbroad'][I]):
+                if np.any(linetable['isbalmer'][I]):
+                    plotsig = fastfit['BROAD_SIGMA']
+                    if plotsig < 50:
+                        plotsig = fastfit['NARROW_SIGMA']
+                        if plotsig < 50:
+                            plotsig = plotsig_default
+                            #plotsig = plotsig_default_broad
+                else:
+                    plotsig = fastfit['UV_SIGMA']                    
+                    if plotsig < 50:
+                        plotsig = plotsig_default_broad
+            else:
+                plotsig = fastfit['NARROW_SIGMA']
+                if plotsig < 50:
+                    plotsig = plotsig_default
+        sigmas.append(plotsig)
+    
+    #srt = np.argsort(meanwaves)
+    order = [
+        # UV/QSO - 6
+        'lya_1215', 'oi_1304', 'siliv_1396', 'civ_1549', 'siliii_1892_ciii_1908', 'mgii_2796_2803',
+        # Balmer + nebular - 12
+        'nev_3346', 'nev_3426', 'oii_3726_29', 'neiii_3869_h6', 'hepsilon', 'hdelta',
+        'hgamma', 'hbeta', 'oiii_4959', 'oiii_5007', 'halpha_nii_6548_48', 'sii_6716_31',
+        # auroral - 6
+        'oiii_4363', 'nii_5755', 'oi_6300_siii_6312', 'oii_7320_30', 'siii_9069', 'siii_9532'
+        ]
+    srt = np.hstack([np.where(uplotgroups == grp)[0] for grp in order])
+
+    meanwaves = np.hstack(meanwaves)[srt]
+    deltawaves = np.hstack(deltawaves)[srt]
+    sigmas = np.hstack(sigmas)[srt]
+    linenames = np.hstack(linenames)[srt]
+
+    # add linelabels to the specx plot
+    #for line in linetable:
+    #    meanwave = line['restwave']*(1+redshift)
+    #    if meanwave > spec_wavelims[0] and meanwave < spec_wavelims[1]:
+    #        specax.text(meanwave, ymax_spec, line['nicename'], ha='center', va='top',
+    #                    rotation=270, fontsize=7, alpha=0.5)
+    for meanwave, linename in zip(meanwaves*(1+redshift), linenames):
+        #print(meanwave, ymax_spec)
+        if meanwave > spec_wavelims[0] and meanwave < spec_wavelims[1]:
+            if 'SiIII' in linename:
+                thislinename = '\n'+linename.replace('+', '+\n  ')
+            else:
+                thislinename = linename
+            specax.text(meanwave, ymax_spec, thislinename, ha='center', va='top',
+                        rotation=270, fontsize=7, alpha=0.5)
+    
+    removelabels = np.ones(nline, bool)
+    ymin, ymax = np.zeros(nline)+1e6, np.zeros(nline)-1e6
+
+    rowoffset = ncutrows
+    coloffset = nsedcols
+
+    ax, irow, icol = [], 0, 0
+    for iax, (meanwave, deltawave, sig, linename) in enumerate(zip(meanwaves, deltawaves, sigmas, linenames)):    
+    #for iax in np.arange(nlinepanels):
+        icol = iax % nlinecols
+        if iax > 0 and iax % nlinecols == 0:
+            irow += 1
+        #print(iax, icol+coloffset, irow+rowoffset)
+    
+        xx = fig.add_subplot(gs[irow+rowoffset, icol+coloffset])
+        ax.append(xx)
+    
+        wmin = (meanwave - deltawave) * (1+redshift) - 6 * sig * meanwave * (1+redshift) / C_LIGHT
+        wmax = (meanwave + deltawave) * (1+redshift) + 6 * sig * meanwave * (1+redshift) / C_LIGHT
+        #print(linename, wmin, wmax)
+    
+        # iterate over cameras
+        for ii in np.arange(len(data['cameras'])): # iterate over cameras
+            emlinewave = data['wave'][ii]
+            emlineflux = data['flux'][ii] - continuum[ii] - smooth_continuum[ii]
+            emlinemodel = _emlinemodel[ii]
+    
+            emlinesigma, good = ivar2var(data['ivar'][ii], sigma=True, allmasked_ok=True)
+            emlinewave = emlinewave[good]
+            emlineflux = emlineflux[good]
+            emlinesigma = emlinesigma[good]
+            emlinemodel = emlinemodel[good]
+    
+            emlinemodel_oneline = []
+            for _emlinemodel_oneline1 in _emlinemodel_oneline:
+                emlinemodel_oneline.append(_emlinemodel_oneline1[ii][good])
+    
+            indx = np.where((emlinewave > wmin) * (emlinewave < wmax))[0]
+            if len(indx) > 1:
+                removelabels[iax] = False
+                xx.fill_between(emlinewave[indx], emlineflux[indx]-emlinesigma[indx],
+                                emlineflux[indx]+emlinesigma[indx], color=col1[ii],
+                                alpha=0.5)
+                # plot the individual lines first then the total model
+                for emlinemodel_oneline1 in emlinemodel_oneline:
+                    if np.sum(emlinemodel_oneline1[indx]) > 0:
+                        #P = emlinemodel_oneline1[indx] > 0
+                        xx.plot(emlinewave[indx], emlinemodel_oneline1[indx], lw=1, alpha=0.8, color=col2[ii])
+                xx.plot(emlinewave[indx], emlinemodel[indx], color=col2[ii], lw=2)
+                    
+                # get the robust range
+                sigflux = np.std(emlineflux[indx])
+                filtflux = median_filter(emlineflux[indx], 3, mode='nearest')
+    
+                _ymin, _ymax = -1.5 * sigflux, 5 * sigflux
+                if np.max(emlinemodel[indx]) > _ymax:
+                    _ymax = np.max(emlinemodel[indx]) * 1.3
+                if np.max(filtflux) > _ymax:
+                    _ymax = np.max(filtflux)
+                if np.min(emlinemodel[indx]) < _ymin:
+                    _ymin = 0.8 * np.min(emlinemodel[indx])
+                    
+                if _ymax > ymax[iax]:
+                    ymax[iax] = _ymax
+                if _ymin < ymin[iax]:
+                    ymin[iax] = _ymin
+    
+                xx.set_xlim(wmin, wmax)
+
+            if 'SiIII' in linename or '6312' in linename:
+                thislinename = '\n'+linename.replace('+', '+\n  ')
+            elif '2803' in linename:
+                thislinename = '\n'+linename.replace(',2803', ',\n 2803')
+            else:
+                thislinename = linename
+            xx.text(0.04, 0.89, thislinename, ha='left', va='center',
+                    transform=xx.transAxes, fontsize=7)
+            
+    for iax, xx in enumerate(ax):
+        if removelabels[iax]:
+            xx.set_ylim(0, 1)
+            xx.set_xticklabels([])
+            xx.set_yticklabels([])
+        else:
+            xx.set_ylim(ymin[iax], ymax[iax])
+            #xlim = xx.get_xlim()
+            #xx.xaxis.set_major_locator(ticker.MaxNLocator(2))
+            xx.set_xticklabels([])
+            xx.set_yticklabels([])
+        xx.axis('off')
+
+    #plt.subplots_adjust(wspace=0.27, top=tp, bottom=bt, left=lf, right=rt, hspace=0.22)
+    plt.subplots_adjust(bottom=0.1, top=0.94, left=0.08, right=0.91)
+
+    # common axis labels
+    ppos = specax.get_position()
+    x0, y0, x1, y1 = ppos.x0, ppos.y0, ppos.x1, ppos.y1
+    plt.text(x1+0.05, (y1-y0)/2+y0, 
+             r'$F_{\lambda}$ ($10^{-17}~{\rm erg}~{\rm s}^{-1}~{\rm cm}^{-2}~\AA^{-1}$)',
+             ha='center', va='center', 
+             transform=fig.transFigure, rotation=270)#, fontsize=)
+
+    # draw a box around the three groups of lines
+    ax = np.array(ax).reshape(nlinerows, nlinecols)
+
+    # UV/QSO
+    llpos = ax[0, 0].get_position()
+    urpos = ax[0, nlinecols-1].get_position()
+    x0, y0, x1, y1 = llpos.x0, llpos.y0, urpos.x1, urpos.y1
+    width, height = urpos.x1-llpos.x0, urpos.y1-llpos.y0
+    fig.patches.extend([Rectangle((x0, y0), width, height, # (lower-left corner), width, height
+                                  fill=False, color='purple', lw=1, zorder=1000,
+                                  transform=fig.transFigure, figure=fig)])
+    plt.text(x1+0.01, (y1-y0)/2+y0, 'UV/QSO', ha='center', va='center',
+             transform=fig.transFigure, rotation=270, fontsize=10)
+
+    llpos = ax[2, 0].get_position()
+    urpos = ax[1, nlinecols-1].get_position()
+    x0, y0, x1, y1 = llpos.x0, llpos.y0, urpos.x1, urpos.y1
+    width, height = urpos.x1-llpos.x0, urpos.y1-llpos.y0
+    fig.patches.extend([Rectangle((x0, y0), width, height, # (lower-left corner), width, height
+                                  fill=False, color='orange', lw=1, zorder=1000,
+                                  transform=fig.transFigure, figure=fig)])
+    plt.text(x1+0.01, (y1-y0)/2+y0, 'Balmer+Nebular', ha='center', va='center',
+             transform=fig.transFigure, rotation=270, fontsize=10)
+
+    llpos = ax[3, 0].get_position()
+    urpos = ax[3, nlinecols-1].get_position()
+    x0, y0, x1, y1 = llpos.x0, llpos.y0, urpos.x1, urpos.y1
+    width, height = urpos.x1-llpos.x0, urpos.y1-llpos.y0
+    fig.patches.extend([Rectangle((x0, y0), width, height, # (lower-left corner), width, height
+                                  fill=False, color='firebrick', lw=1, zorder=1000,
+                                  transform=fig.transFigure, figure=fig)])
+    plt.text(x1+0.01, (y1-y0)/2+y0, 'Auroral', ha='center', va='center',
+             transform=fig.transFigure, rotation=270, fontsize=10)
+
+    fig.suptitle(title, fontsize=22)
+
+    EMFit.log.info('Writing {}'.format(pngfile))
+    fig.savefig(pngfile)
+    plt.close()

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -793,8 +793,63 @@ class DESISpectra(object):
                     coadd_ivar = coadd_spec.ivar[coadd_bands][igal, :]
                     coadd_res = Resolution(coadd_spec.resolution_data[coadd_bands][igal, :])
 
+                    coadd_linemask_dict = CFit.build_linemask(coadd_wave, coadd_flux, coadd_ivar, redshift=data['zredrock'])
+                    data['coadd_linename'] = coadd_linemask_dict['linename']
+                    data['coadd_linepix'] = [np.where(lpix)[0] for lpix in coadd_linemask_dict['linepix']]
+                    data['coadd_contpix'] = [np.where(cpix)[0] for cpix in coadd_linemask_dict['contpix']]
+
+                    data['linesigma_narrow'] = coadd_linemask_dict['linesigma_narrow']
+                    data['linesigma_balmer'] = coadd_linemask_dict['linesigma_balmer']
+                    data['linesigma_uv'] = coadd_linemask_dict['linesigma_uv']
+
+                    data['linesigma_narrow_snr'] = coadd_linemask_dict['linesigma_narrow_snr']
+                    data['linesigma_balmer_snr'] = coadd_linemask_dict['linesigma_balmer_snr']
+                    data['linesigma_uv_snr'] = coadd_linemask_dict['linesigma_uv_snr']
+
+                    # Map the pixels belonging to individual emission lines and
+                    # their local continuum back onto the original per-camera
+                    # spectra. These lists of arrays are used in
+                    # continuum.ContinnuumTools.smooth_continuum.
+                    for icam in np.arange(len(data['cameras'])):
+                        data['linemask'].append(np.interp(data['wave'][icam], coadd_wave, coadd_linemask_dict['linemask']*1) > 0)
+                        data['linemask_all'].append(np.interp(data['wave'][icam], coadd_wave, coadd_linemask_dict['linemask_all']*1) > 0)
+                        _linename, _linenpix, _contpix = [], [], []
+                        for ipix in np.arange(len(coadd_linemask_dict['linepix'])):
+                            I = np.interp(data['wave'][icam], coadd_wave, coadd_linemask_dict['linepix'][ipix]*1) > 0
+                            J = np.interp(data['wave'][icam], coadd_wave, coadd_linemask_dict['contpix'][ipix]*1) > 0
+                            #if '4686' in coadd_linemask_dict['linename'][ipix]:
+                            #    pdb.set_trace()
+                            if np.sum(I) > 3 and np.sum(J) > 3:
+                                _linename.append(coadd_linemask_dict['linename'][ipix])
+                                _linenpix.append(np.where(I)[0])
+                                _contpix.append(np.where(J)[0])
+                        data['linename'].append(_linename)
+                        data['linepix'].append(_linenpix)
+                        data['contpix'].append(_contpix)
+                        #for ipix in np.arange(len(coadd_linemask_dict['contpix'])):
+                        #    if icam == 1:
+                        #        pdb.set_trace()
+                        #    J = np.interp(data['wave'][icam], coadd_wave, coadd_linemask_dict['contpix'][ipix]*1) > 0
+                        #    if np.sum(J) > 0:
+                        #        _contpix.append(np.where(J)[0])
+                        #data['contpix'].append(_contpix)
+
+                    #import matplotlib.pyplot as plt
+                    #plt.clf()
+                    #for ii in np.arange(3):
+                    #    plt.plot(data['wave'][ii], data['flux'][ii])
+                    #plt.plot(coadd_wave, coadd_flux-2, alpha=0.6, color='k')
+                    #plt.xlim(5500, 6000)
+                    #plt.savefig('test.png')
+                    #pdb.set_trace()
+
                     data.update({'coadd_wave': coadd_wave, 'coadd_flux': coadd_flux,
-                                 'coadd_ivar': coadd_ivar, 'coadd_res': coadd_res})
+                                 'coadd_ivar': coadd_ivar, 'coadd_res': coadd_res,
+                                 'coadd_linemask': coadd_linemask_dict['linemask'],
+                                 'coadd_linemask_all': coadd_linemask_dict['linemask_all']})
+
+                    #data.update({'coadd_wave': coadd_wave, 'coadd_flux': coadd_flux,
+                    #             'coadd_ivar': coadd_ivar, 'coadd_res': coadd_res})
 
                     # Optionally synthesize photometry from the coadded spectrum.
                     if synthphot:

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -93,7 +93,6 @@ def unpack_one_spectrum(spec, coadd_spec, igal, meta, ebv, CFit, fastphot, synth
     flag pixels which may be affected by emission lines.
 
     """
-    from desispec.resolution import Resolution
     from desiutil.dust import mwdust_transmission, dust_transmission
 
     data = {'targetid': meta['TARGETID'], 'zredrock': meta['Z'],
@@ -158,6 +157,8 @@ def unpack_one_spectrum(spec, coadd_spec, igal, meta, ebv, CFit, fastphot, synth
         lambda_eff=filters.effective_wavelengths.value)
 
     if not fastphot:
+        from desispec.resolution import Resolution
+        
         data.update({'wave': [], 'flux': [], 'ivar': [], 'res': [],
                      'linemask': [], 'linemask_all': [],
                      'linename': [], 'linepix': [], 'contpix': [],
@@ -867,13 +868,16 @@ class DESISpectra(object):
             #if args.fastphot:
             #    spec, coadd_spec = None, None
             #else:
-    
-            spec = read_spectra(specfile).select(targets=meta['TARGETID'])
-            assert(np.all(spec.fibermap['TARGETID'] == meta['TARGETID']))
-    
-            # Coadd across cameras.
-            #t1 = time.time()                
-            coadd_spec = coadd_cameras(spec)
+
+            if fastphot:
+                spec, coadd_spec = None, None
+            else:
+                spec = read_spectra(specfile).select(targets=meta['TARGETID'])
+                assert(np.all(spec.fibermap['TARGETID'] == meta['TARGETID']))
+
+                # Coadd across cameras.
+                coadd_spec = coadd_cameras(spec)
+
             unpackargs = [(spec, coadd_spec, igal, meta[igal], ebv[igal], CFit, 
                            fastphot, synthphot) for igal in np.arange(len(meta))]
     

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -781,13 +781,11 @@ class DESISpectra(object):
                     # an "hstacked" spectrum.
                     data['npixpercamera'] = npixpercamera
 
+                    ncam = len(data['cameras'])
                     npixpercam = np.hstack([0, npixpercamera])
-                    ipix, jpix = [], []
-                    for icam in np.arange(len(data['cameras'])):
-                        ipix.append(np.sum(npixpercam[:icam+1]))
-                        jpix.append(np.sum(npixpercam[:icam+2]))
-                    data['ipix'] = ipix
-                    data['jpix'] = jpix
+                    data['camerapix'] = np.zeros((ncam, 2), np.int16)
+                    for icam in np.arange(ncam):
+                        data['camerapix'][icam, :] = [np.sum(npixpercam[:icam+1]), np.sum(npixpercam[:icam+2])]
                                             
                     # coadded spectrum
                     coadd_wave = coadd_spec.wave[coadd_bands]

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -932,7 +932,7 @@ class DESISpectra(object):
         if fastphot:
             out = hstack((out, CFit.init_phot_output(nobj)))
         else:
-            out = hstack((out, CFit.init_spec_output(nobj), EMFit.init_output(CFit.linetable, nobj)))
+            out = hstack((out, CFit.init_spec_output(nobj), EMFit.init_output(nobj=nobj)))
 
         return out, meta
 

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1128,7 +1128,8 @@ def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
 
     log.info('Writing out took {:.2f} sec'.format(time.time()-t0))
 
-def select(fastfit, metadata, coadd_type, healpixels=None, tiles=None, nights=None):
+def select(fastfit, metadata, coadd_type, healpixels=None, tiles=None,
+           nights=None, return_index=False):
     """Optionally trim to a particular healpix or tile and/or night."""
     keep = np.ones(len(fastfit), bool)
     if coadd_type == 'healpix':
@@ -1151,4 +1152,8 @@ def select(fastfit, metadata, coadd_type, healpixels=None, tiles=None, nights=No
                 nightkeep = np.logical_or(nightkeep, metadata['NIGHT'].astype(str) == night)
             keep = np.logical_and(keep, nightkeep)
             log.info('Keeping {:,d} objects from night(s) {}'.format(len(fastfit), ','.join(nights)))
-    return fastfit[keep], metadata[keep]
+            
+    if return_index:
+        return np.where(keep)[0]
+    else:
+        return fastfit[keep], metadata[keep]

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -137,7 +137,7 @@ def backup_logs(logfile):
 def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
          survey=None, program=None, healpix=None, tile=None, night=None, 
          outdir_data='.', outdir_html='.', mp=1, merge=False, makeqa=False,
-         fastphot=False, overwrite=False):
+         webqa=False, fastphot=False, overwrite=False):
 
     import fitsio
     from astropy.table import Table, vstack
@@ -263,6 +263,11 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
         redrockfiles = None
         outfiles = _findfiles(outdir, prefix=outprefix, survey=survey, program=program, healpix=healpix, tile=tile, night=night, gzip=gzip)
         log.info('Found {} {} files to be merged.'.format(len(outfiles), outprefix))
+    elif webqa:
+        redrockfiles = None
+        outfiles = _findfiles(outdir, prefix=outprefix, survey=survey, program=program, healpix=healpix, tile=tile, night=night, gzip=gzip)
+        log.info('Found {} {} files for QA.'.format(len(outfiles), outprefix))
+        ntargs = [(outfile, True) for outfile in outfiles]
     elif makeqa:
         redrockfiles = None
         outfiles = _findfiles(outdir, prefix=outprefix, survey=survey, program=program, healpix=healpix, tile=tile, night=night, gzip=gzip)
@@ -340,7 +345,7 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
                 log.debug('No {} files in {} found!'.format(outprefix, outdir))
             return '', list(), list(), list(), None
         return outdir, redrockfiles, outfiles, None, None
-    elif makeqa:
+    elif makeqa or webqa:
         if len(outfiles) == 0:
             if rank == 0:
                 log.debug('No {} files in {} found!'.format(outprefix, outdir))

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -226,7 +226,8 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
                         # for a given tile, take just the most recent night
                         thisnightdir = nightdirs[-1]
                         thesefiles.append(glob(os.path.join(thisnightdir, '{}-[0-9]-{}-thru????????.{}'.format(prefix, onetile, fitssuffix))))
-                thesefiles = np.array(sorted(set(np.hstack(thesefiles))))
+                if len(thesefiles) > 0:
+                    thesefiles = np.array(sorted(set(np.hstack(thesefiles))))
         elif coadd_type == 'pernight':
             if tile is not None and night is not None:
                 thesefiles = []


### PR DESCRIPTION
[WIP]

Still WIP but opening a PR to track related issues.

This PR is a fairly major rewrite of the emission-line fitting engine with an eye toward porting the code to the Perlmutter/GPUs (e.g., https://jaxopt.github.io/stable/constrained.html). Specifically, all the `astropy.modeling` routines have been replaced with a simpler table-based `linemodel` of parameters (including tied parameters), resulting in about 300 fewer lines of code and notable speed-ups.

However, the speed-ups have been used to include one additional (third) round of fitting where emission lines are minimally constrained to one another, which leads to notable improvements in the line-fitting results for systems with complex line-kinematics (and to account for any cross-camera wavelength-calibration issues).

Second, I've moved away from the home-grown `fnnls` algorithm for continuum fitting and am now just using `scipy.optimize.nnls` which I also hope to be able to port to a GPU.