### PR TITLE
get target cutouts using image coadds on-disk

### DIFF
--- a/bin/get-cutouts
+++ b/bin/get-cutouts
@@ -339,14 +339,11 @@ def main():
     parser.add_argument('--program', type=str, default='bright,dark,other,backup', help='Program to process.') # backup not supported
     parser.add_argument('--tile', default=None, type=str, nargs='*', help='Tile(s) to process.')
     parser.add_argument('--night', default=None, type=str, nargs='*', help='Night(s) to process (ignored if coadd-type is cumulative).')
-    
     parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
-    parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
-    
+
     parser.add_argument('--overwrite', action='store_true', help='Overwrite any existing output files.')
     parser.add_argument('--plan', action='store_true', help='Plan how many nodes to use and how to distribute the targets.')
     parser.add_argument('--nompi', action='store_true', help='Do not use MPI parallelism.')
-    parser.add_argument('--nolog', action='store_true', help='Do not write to the log file.')
     parser.add_argument('--dry-run', action='store_true', help='Generate but do not run commands.')
 
     parser.add_argument('--outdir-html', default='/global/cfs/cdirs/desi/users/ioannis/fastspecfit',

--- a/bin/get-cutouts
+++ b/bin/get-cutouts
@@ -1,9 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """MPI wrapper to get a large number of image cutouts. Only run ahead of a VAC
 release.
 
-get-cutouts --mp 128
+get-cutouts --survey cmx --mp 16 --dry-run
+
+shifterimg pull dstndstn/viewer-cutouts:latest
+shifter --image dstndstn/viewer-cutouts cutout --output cutout.jpg --ra 234.2915 --dec 16.7684 --size 256 --layer ls-dr9 --pixscale 0.262 --force
+
+shifter --image dstndstn/viewer-cutouts bash
+/global/u2/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts --survey cmx --program other --mp 128
 
 """
 import pdb # for debugging
@@ -14,16 +20,19 @@ import fitsio
 import multiprocessing
 from glob import glob
 
-from desiutil.log import get_logger
-log = get_logger()
-
 def _cutout_one(args):
     return cutout_one(*args)
 
 def cutout_one(jpegfile, ra, dec, dry_run):
+    """
+    pixscale = 0.262
+    width = int(30 / pixscale)   # =114
+    height = int(width / 1.3) # =87 [3:2 aspect ratio]
+
+    """
     import subprocess
 
-    cmd = 'cutout --output {} --ra {} --dec {} --size 256 --layer ls-dr9 --pixscale 0.262 --force'.format(
+    cmd = 'cutout --output {} --ra {} --dec {} --width 114 --height 87 --layer ls-dr9 --pixscale 0.262 --force'.format(
         jpegfile, ra, dec)
     if dry_run:
         print(cmd)
@@ -33,32 +42,28 @@ def cutout_one(jpegfile, ra, dec, dry_run):
 def _get_jpegfiles_one(args):
     return get_jpegfiles_one(*args)
 
-def get_jpegfiles_one(fastspecfile, coadd_type, htmldir_root, overwrite, log):
+def get_jpegfiles_one(fastspecfile, coadd_type, htmldir_root, overwrite):
     meta = fitsio.read(fastspecfile, 'METADATA', columns=['SURVEY', 'PROGRAM', 'HEALPIX', 'TARGETID', 'RA', 'DEC'])
     htmldir = os.path.join(htmldir_root, meta['SURVEY'][0], meta['PROGRAM'][0], str(meta['HEALPIX'][0]//100), str(meta['HEALPIX'][0]))
     jpegfiles = get_cutout_filename(meta, coadd_type, outprefix='fastspec',
-                                    htmldir=htmldir, log=log)
+                                    htmldir=htmldir)
     allra, alldec = meta['RA'], meta['DEC']
     if overwrite is False:
         I = np.array([not os.path.isfile(jpegfile) for jpegfile in jpegfiles])
         J = ~I
         if np.sum(J) > 0:
-            log.info('Skipping {} existing QA file(s).'.format(np.sum(J)))
+            print('Skipping {} existing QA file(s).'.format(np.sum(J)))
             jpegfiles = jpegfiles[I]
             allra = allra[I]
             alldec = alldec[I]
 
     return jpegfiles, allra, alldec, len(jpegfiles)
 
-def get_cutout_filename(metadata, coadd_type, outprefix=None, htmldir=None, log=None):
+def get_cutout_filename(metadata, coadd_type, outprefix=None, htmldir=None):
     """Build the cutout filename.
 
     """
     import astropy
-
-    if log is None:
-        from desiutil.log import get_logger
-        log = get_logger()
 
     if htmldir is None:
         htmldir = '.'
@@ -87,7 +92,7 @@ def get_cutout_filename(metadata, coadd_type, outprefix=None, htmldir=None, log=
                 _metadata['HEALPIX'], _metadata['TARGETID']))
         else:
             errmsg = 'Unrecognized coadd_type {}!'.format(coadd_type)
-            log.critical(errmsg)
+            print(errmsg)
             raise ValueError(errmsg)
         return jpegfile
 
@@ -103,7 +108,6 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
          outdir_data='.', outdir_html='.', mp=1, overwrite=False):
 
     from astropy.table import Table
-    from fastspecfit.io import DESI_ROOT_NERSC
                                 
     t0 = time.time()
     if comm is None:
@@ -111,7 +115,8 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
     else:
         rank, size = comm.rank, comm.size
 
-    desi_root = os.environ.get('DESI_ROOT', DESI_ROOT_NERSC)
+    desi_root = '/global/cfs/cdirs/desi'
+    #desi_root = os.environ.get('DESI_ROOT', DESI_ROOT_NERSC)
     # look for data in the standard location
 
     if coadd_type == 'healpix':
@@ -127,7 +132,7 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
             alltileinfo = Table.read(tilefile)
             tileinfo = alltileinfo[['sv' in survey for survey in alltileinfo['SURVEY']]]
 
-            log.info('Retrieved a list of {} {} tiles from {}'.format(
+            print('Retrieved a list of {} {} tiles from {}'.format(
                 len(tileinfo), ','.join(sorted(set(tileinfo['SURVEY']))), tilefile))
 
             tile = np.array(list(set(tileinfo['TILEID'])))
@@ -146,7 +151,7 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
             thesefiles = []
             for onesurvey in np.atleast_1d(survey):
                 for oneprogram in np.atleast_1d(program):
-                    log.info('Building file list for survey={} and program={}'.format(onesurvey, oneprogram))
+                    print('Building file list for survey={} and program={}'.format(onesurvey, oneprogram))
                     if healpix is not None:
                         for onepix in healpixels:
                             _thesefiles = glob(os.path.join(filedir, onesurvey, oneprogram, str(int(onepix)//100), onepix,
@@ -213,12 +218,12 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
 
     if nfile == 0:
         if rank == 0:
-            log.info('No fastspecfiles found!')
+            print('No fastspecfiles found!')
         return list(), list(), list(), list
 
-    log.info('Found {} fastspecfiles.'.format(nfile))
+    print('Found {} fastspecfiles.'.format(nfile))
 
-    mpargs = [(fastspecfile, coadd_type, htmldir, overwrite, log)
+    mpargs = [(fastspecfile, coadd_type, htmldir, overwrite)
               for fastspecfile in fastspecfiles]
     if mp > 1:
         with multiprocessing.Pool(mp) as P:
@@ -234,7 +239,7 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
         
     iempty = np.where(ntargets == 0)[0]
     if len(iempty) > 0:
-        log.info('Skipping {} fastspecfiles with no jpeg files to make.'.format(len(iempty)))
+        print('Skipping {} fastspecfiles with no jpeg files to make.'.format(len(iempty)))
 
     itodo = np.where(ntargets > 0)[0]
     if len(itodo) > 0:
@@ -243,8 +248,8 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
         alldec = alldec[itodo]
         ntargets = ntargets[itodo]
 
-        log.info('Missing cutouts for {} targets.'.format(np.sum(ntargets)))
-        #log.info('Working on {} files with a total of {} targets.'.format(len(itodo), np.sum(ntargets)))
+        print('Missing cutouts for {} targets.'.format(np.sum(ntargets)))
+        #print('Working on {} files with a total of {} targets.'.format(len(itodo), np.sum(ntargets)))
 
         indices = np.arange(len(jpegfiles))
 
@@ -280,7 +285,7 @@ def do_cutouts(args, comm=None, outdir_data='.', outdir_html='.'):
                 healpix=args.healpix, tile=args.tile, night=args.night,
                 outdir_data=outdir_data, outdir_html=outdir_html,
                 overwrite=args.overwrite, mp=args.mp)
-        log.info('Planning took {:.2f} sec'.format(time.time() - t0))
+        print('Planning took {:.2f} sec'.format(time.time() - t0))
     else:
         jpegfiles, allra, alldec = [], [], []
 
@@ -289,18 +294,16 @@ def do_cutouts(args, comm=None, outdir_data='.', outdir_html='.'):
         allra = comm.bcast(allra, root=0)
         alldec = comm.bcast(alldec, root=0)
         groups = comm.bcast(groups, root=0)
-
     sys.stdout.flush()
     
+    assert(len(groups) == size)
+
     # all done
-    if len(jpegfiles) == 0:
+    if len(np.hstack(jpegfiles)) == 0:
         return
         
-    assert(len(groups) == size)
-    assert(len(np.concatenate(groups)) == len(jpegfiles))
-
     for ii in groups[rank]:
-        log.debug('Rank {} started at {}'.format(rank, time.asctime()))
+        print('Rank {} started at {}'.format(rank, time.asctime()))
         sys.stdout.flush()
 
         mpargs = [(jpegfile, ra, dec, args.dry_run) for jpegfile, ra, dec in zip(jpegfiles[ii], allra[ii], alldec[ii])]
@@ -310,16 +313,14 @@ def do_cutouts(args, comm=None, outdir_data='.', outdir_html='.'):
         else:
             [cutout_one(*mparg) for mparg in mpargs]
 
-        pdb.set_trace()
-
-    log.debug('  rank {} is done'.format(rank))
+    print('  rank {} is done'.format(rank))
     sys.stdout.flush()
 
     if comm is not None:
         comm.barrier()
 
     if rank == 0 and not args.dry_run:
-        log.info('All done at {}'.format(time.asctime()))
+        print('All done at {}'.format(time.asctime()))
         
 def main():
     """Main wrapper.

--- a/bin/get-cutouts
+++ b/bin/get-cutouts
@@ -1,0 +1,388 @@
+#!/usr/bin/env python
+
+"""MPI wrapper to get a large number of image cutouts. Only run ahead of a VAC
+release.
+
+get-cutouts --mp 128
+
+"""
+import pdb # for debugging
+
+import os, sys, time
+import numpy as np
+import fitsio
+import multiprocessing
+from glob import glob
+
+from desiutil.log import get_logger
+log = get_logger()
+
+def _cutout_one(args):
+    return cutout_one(*args)
+
+def cutout_one(jpegfile, ra, dec, dry_run):
+    import subprocess
+
+    cmd = 'cutout --output {} --ra {} --dec {} --size 256 --layer ls-dr9 --pixscale 0.262 --force'.format(
+        jpegfile, ra, dec)
+    if dry_run:
+        print(cmd)
+    else:
+        subprocess.call(cmd.split())    
+
+def _get_jpegfiles_one(args):
+    return get_jpegfiles_one(*args)
+
+def get_jpegfiles_one(fastspecfile, coadd_type, htmldir_root, overwrite, log):
+    meta = fitsio.read(fastspecfile, 'METADATA', columns=['SURVEY', 'PROGRAM', 'HEALPIX', 'TARGETID', 'RA', 'DEC'])
+    htmldir = os.path.join(htmldir_root, meta['SURVEY'][0], meta['PROGRAM'][0], str(meta['HEALPIX'][0]//100), str(meta['HEALPIX'][0]))
+    jpegfiles = get_cutout_filename(meta, coadd_type, outprefix='fastspec',
+                                    htmldir=htmldir, log=log)
+    allra, alldec = meta['RA'], meta['DEC']
+    if overwrite is False:
+        I = np.array([not os.path.isfile(jpegfile) for jpegfile in jpegfiles])
+        J = ~I
+        if np.sum(J) > 0:
+            log.info('Skipping {} existing QA file(s).'.format(np.sum(J)))
+            jpegfiles = jpegfiles[I]
+            allra = allra[I]
+            alldec = alldec[I]
+
+    return jpegfiles, allra, alldec, len(jpegfiles)
+
+def get_cutout_filename(metadata, coadd_type, outprefix=None, htmldir=None, log=None):
+    """Build the cutout filename.
+
+    """
+    import astropy
+
+    if log is None:
+        from desiutil.log import get_logger
+        log = get_logger()
+
+    if htmldir is None:
+        htmldir = '.'
+        
+    if outprefix is None:
+        outprefix = 'fastspec'
+
+    def _one_filename(_metadata):
+        if coadd_type == 'healpix':
+            jpegfile = os.path.join(htmldir, 'tmp.{}-{}-{}-{}-{}.jpeg'.format(
+                outprefix, _metadata['SURVEY'], _metadata['PROGRAM'],
+                _metadata['HEALPIX'], _metadata['TARGETID']))
+        elif coadd_type == 'cumulative':
+            jpegfile = os.path.join(htmldir, 'tmp.{}-{}-{}-{}.jpeg'.format(
+                outprefix, _metadata['TILEID'], coadd_type, _metadata['TARGETID']))
+        elif coadd_type == 'pernight':
+            jpegfile = os.path.join(htmldir, 'tmp.{}-{}-{}-{}.jpeg'.format(
+                outprefix, _metadata['TILEID'], _metadata['NIGHT'], _metadata['TARGETID']))
+        elif coadd_type == 'perexp':
+            jpegfile = os.path.join(htmldir, 'tmp.{}-{}-{}-{}-{}.jpeg'.format(
+                outprefix, _metadata['TILEID'], _metadata['NIGHT'],
+                _metadata['EXPID'], _metadata['TARGETID']))
+        elif coadd_type == 'custom':
+            jpegfile = os.path.join(htmldir, 'tmp.{}-{}-{}-{}-{}.jpeg'.format(
+                outprefix, _metadata['SURVEY'], _metadata['PROGRAM'],
+                _metadata['HEALPIX'], _metadata['TARGETID']))
+        else:
+            errmsg = 'Unrecognized coadd_type {}!'.format(coadd_type)
+            log.critical(errmsg)
+            raise ValueError(errmsg)
+        return jpegfile
+
+    if type(metadata) is astropy.table.row.Row:
+        jpegfile = _one_filename(metadata)
+    else:
+        jpegfile = [_one_filename(_metadata) for _metadata in metadata]
+    
+    return np.array(jpegfile)
+
+def plan(comm=None, specprod=None, coadd_type='healpix',
+         survey=None, program=None, healpix=None, tile=None, night=None, 
+         outdir_data='.', outdir_html='.', mp=1, overwrite=False):
+
+    from astropy.table import Table
+    from fastspecfit.io import DESI_ROOT_NERSC
+                                
+    t0 = time.time()
+    if comm is None:
+        rank, size = 0, 1
+    else:
+        rank, size = comm.rank, comm.size
+
+    desi_root = os.environ.get('DESI_ROOT', DESI_ROOT_NERSC)
+    # look for data in the standard location
+
+    if coadd_type == 'healpix':
+        subdir = 'healpix'
+        if healpix is not None:
+            healpixels = healpix.split(',')
+    else:
+        subdir = 'tiles'
+
+        # figure out which tiles belong to the SV programs
+        if tile is None:
+            tilefile = os.path.join(desi_root, 'spectro', 'redux', specprod, 'tiles-{}.csv'.format(specprod))
+            alltileinfo = Table.read(tilefile)
+            tileinfo = alltileinfo[['sv' in survey for survey in alltileinfo['SURVEY']]]
+
+            log.info('Retrieved a list of {} {} tiles from {}'.format(
+                len(tileinfo), ','.join(sorted(set(tileinfo['SURVEY']))), tilefile))
+
+            tile = np.array(list(set(tileinfo['TILEID'])))
+
+    outdir = os.path.join(outdir_data, specprod, subdir)
+    htmldir = os.path.join(outdir_data, specprod, 'html', subdir)
+
+    def _findfiles(filedir, prefix='fastspec', survey=None, program=None, healpix=None,
+                   tile=None, night=None, gzip=False):
+        if gzip:
+            fitssuffix = 'fits.gz'
+        else:
+            fitssuffix = 'fits'
+            
+        if coadd_type == 'healpix':
+            thesefiles = []
+            for onesurvey in np.atleast_1d(survey):
+                for oneprogram in np.atleast_1d(program):
+                    log.info('Building file list for survey={} and program={}'.format(onesurvey, oneprogram))
+                    if healpix is not None:
+                        for onepix in healpixels:
+                            _thesefiles = glob(os.path.join(filedir, onesurvey, oneprogram, str(int(onepix)//100), onepix,
+                                                            '{}-{}-{}-*.{}'.format(prefix, onesurvey, oneprogram, fitssuffix)))
+                            thesefiles.append(_thesefiles)
+                    else:
+                        allpix = glob(os.path.join(filedir, onesurvey, oneprogram, '*'))
+                        for onepix in allpix:
+                            _thesefiles = glob(os.path.join(onepix, '*', '{}-{}-{}-*.{}'.format(prefix, onesurvey, oneprogram, fitssuffix)))
+                            thesefiles.append(_thesefiles)
+            if len(thesefiles) > 0:
+                thesefiles = np.array(sorted(np.unique(np.hstack(thesefiles))))
+        elif coadd_type == 'cumulative':
+            # Scrape the disk to get the tiles, but since we read the csv file I don't think this ever happens.
+            if tile is None:
+                tiledirs = np.array(sorted(set(glob(os.path.join(filedir, 'cumulative', '?????')))))
+                if len(tiledirs) > 0:
+                    tile = [int(os.path.basename(tiledir)) for tiledir in tiledirs]
+            if tile is not None:
+                thesefiles = []
+                for onetile in tile:
+                    nightdirs = np.array(sorted(set(glob(os.path.join(filedir, 'cumulative', str(onetile), '????????')))))
+                    if len(nightdirs) > 0:
+                        # for a given tile, take just the most recent night
+                        thisnightdir = nightdirs[-1]
+                        thesefiles.append(glob(os.path.join(thisnightdir, '{}-[0-9]-{}-thru????????.{}'.format(prefix, onetile, fitssuffix))))
+                if len(thesefiles) > 0:
+                    thesefiles = np.array(sorted(set(np.hstack(thesefiles))))
+        elif coadd_type == 'pernight':
+            if tile is not None and night is not None:
+                thesefiles = []
+                for onetile in tile:
+                    for onenight in night:
+                        thesefiles.append(glob(os.path.join(
+                            filedir, 'pernight', str(onetile), str(onenight), '{}-[0-9]-{}-{}.{}'.format(prefix, onetile, onenight, fitssuffix))))
+                if len(thesefiles) > 0:
+                    thesefiles = np.array(sorted(set(np.hstack(thesefiles))))
+            elif tile is not None and night is None:
+                thesefiles = np.array(sorted(set(np.hstack([glob(os.path.join(
+                    filedir, 'pernight', str(onetile), '????????', '{}-[0-9]-{}-????????.{}'.format(
+                    prefix, onetile, fitssuffix))) for onetile in tile]))))
+            elif tile is None and night is not None:
+                thesefiles = np.array(sorted(set(np.hstack([glob(os.path.join(
+                    filedir, 'pernight', '?????', str(onenight), '{}-[0-9]-?????-{}.{}'.format(
+                    prefix, onenight, fitssuffix))) for onenight in night]))))
+            else:
+                thesefiles = np.array(sorted(set(glob(os.path.join(
+                    filedir, '?????', '????????', '{}-[0-9]-?????-????????.{}'.format(prefix, fitssuffix))))))
+        elif coadd_type == 'perexp':
+            if tile is not None:
+                thesefiles = np.array(sorted(set(np.hstack([glob(os.path.join(
+                    filedir, 'perexp', str(onetile), '????????', '{}-[0-9]-{}-exp????????.{}'.format(
+                    prefix, onetile, fitssuffix))) for onetile in tile]))))
+            else:
+                thesefiles = np.array(sorted(set(glob(os.path.join(
+                    filedir, 'perexp', '?????', '????????', '{}-[0-9]-?????-exp????????.{}'.format(prefix, fitssuffix))))))
+        else:
+            pass
+        return thesefiles
+
+    fastspecfiles = _findfiles(outdir, prefix='fastspec', survey=survey, program=program,
+                               healpix=healpix, tile=tile, night=night, gzip=True)
+    nfile = len(fastspecfiles)
+
+    if nfile == 0:
+        if rank == 0:
+            log.info('No fastspecfiles found!')
+        return list(), list(), list(), list
+
+    log.info('Found {} fastspecfiles.'.format(nfile))
+
+    mpargs = [(fastspecfile, coadd_type, htmldir, overwrite, log)
+              for fastspecfile in fastspecfiles]
+    if mp > 1:
+        with multiprocessing.Pool(mp) as P:
+            out = P.map(_get_jpegfiles_one, mpargs)
+    else:
+        out = [get_jpegfiles_one(*mparg) for mparg in mpargs]
+    out = list(zip(*out))
+    
+    jpegfiles = np.array(out[0], dtype=object)
+    allra = np.array(out[1], dtype=object)
+    alldec = np.array(out[2], dtype=object)
+    ntargets = np.array(out[3])
+        
+    iempty = np.where(ntargets == 0)[0]
+    if len(iempty) > 0:
+        log.info('Skipping {} fastspecfiles with no jpeg files to make.'.format(len(iempty)))
+
+    itodo = np.where(ntargets > 0)[0]
+    if len(itodo) > 0:
+        jpegfiles = jpegfiles[itodo]
+        allra = allra[itodo]
+        alldec = alldec[itodo]
+        ntargets = ntargets[itodo]
+
+        log.info('Missing cutouts for {} targets.'.format(np.sum(ntargets)))
+        #log.info('Working on {} files with a total of {} targets.'.format(len(itodo), np.sum(ntargets)))
+
+        indices = np.arange(len(jpegfiles))
+
+        # Assign the sample to ranks to make the jpegfiles distribution per rank ~flat.
+        # https://stackoverflow.com/questions/33555496/split-array-into-equally-weighted-chunks-based-on-order
+        cumuweight = ntargets.cumsum() / ntargets.sum()
+        idx = np.searchsorted(cumuweight, np.linspace(0, 1, size, endpoint=False)[1:])
+        if len(idx) < size: # can happen in corner cases or with 1 rank
+            groups = np.array_split(indices, size) # unweighted
+        else:
+            groups = np.array_split(indices, idx) # weighted
+        for ii in range(size): # sort by weight
+            srt = np.argsort(ntargets[groups[ii]])
+            groups[ii] = groups[ii][srt]
+    else:
+        groups = [np.array([])]
+
+    return jpegfiles, allra, alldec, groups
+
+def do_cutouts(args, comm=None, outdir_data='.', outdir_html='.'):
+
+    if comm is None:
+        rank, size = 0, 1
+    else:
+        rank, size = comm.rank, comm.size
+
+    t0 = time.time()
+    if rank == 0:
+        jpegfiles, allra, alldec, groups = plan(
+                comm=comm, specprod=args.specprod,
+                coadd_type=args.coadd_type,
+                survey=args.survey, program=args.program,
+                healpix=args.healpix, tile=args.tile, night=args.night,
+                outdir_data=outdir_data, outdir_html=outdir_html,
+                overwrite=args.overwrite, mp=args.mp)
+        log.info('Planning took {:.2f} sec'.format(time.time() - t0))
+    else:
+        jpegfiles, allra, alldec = [], [], []
+
+    if comm:
+        jpegfiles = comm.bcast(jpegfiles, root=0)
+        allra = comm.bcast(allra, root=0)
+        alldec = comm.bcast(alldec, root=0)
+        groups = comm.bcast(groups, root=0)
+
+    sys.stdout.flush()
+    
+    # all done
+    if len(jpegfiles) == 0:
+        return
+        
+    assert(len(groups) == size)
+    assert(len(np.concatenate(groups)) == len(jpegfiles))
+
+    for ii in groups[rank]:
+        log.debug('Rank {} started at {}'.format(rank, time.asctime()))
+        sys.stdout.flush()
+
+        mpargs = [(jpegfile, ra, dec, args.dry_run) for jpegfile, ra, dec in zip(jpegfiles[ii], allra[ii], alldec[ii])]
+        if args.mp > 1:
+            with multiprocessing.Pool(args.mp) as P:
+                P.map(_cutout_one, mpargs)
+        else:
+            [cutout_one(*mparg) for mparg in mpargs]
+
+        pdb.set_trace()
+
+    log.debug('  rank {} is done'.format(rank))
+    sys.stdout.flush()
+
+    if comm is not None:
+        comm.barrier()
+
+    if rank == 0 and not args.dry_run:
+        log.info('All done at {}'.format(time.asctime()))
+        
+def main():
+    """Main wrapper.
+
+    """
+    import argparse    
+    
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--coadd-type', type=str, default='healpix', choices=['healpix', 'cumulative', 'pernight', 'perexp'],
+                        help='Specify which type of spectra/zbest files to process.')
+    parser.add_argument('--specprod', type=str, default='fuji', #choices=['fuji', 'guadalupe', 'iron'],
+                        help='Spectroscopic production to process.')
+    
+    parser.add_argument('--healpix', type=str, default=None, help='Comma-separated list of healpixels to process.')
+    parser.add_argument('--survey', type=str, default='main,special,cmx,sv1,sv2,sv3', help='Survey to process.')
+    parser.add_argument('--program', type=str, default='bright,dark,other,backup', help='Program to process.') # backup not supported
+    parser.add_argument('--tile', default=None, type=str, nargs='*', help='Tile(s) to process.')
+    parser.add_argument('--night', default=None, type=str, nargs='*', help='Night(s) to process (ignored if coadd-type is cumulative).')
+    
+    parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
+    parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
+    
+    parser.add_argument('--overwrite', action='store_true', help='Overwrite any existing output files.')
+    parser.add_argument('--plan', action='store_true', help='Plan how many nodes to use and how to distribute the targets.')
+    parser.add_argument('--nompi', action='store_true', help='Do not use MPI parallelism.')
+    parser.add_argument('--nolog', action='store_true', help='Do not write to the log file.')
+    parser.add_argument('--dry-run', action='store_true', help='Generate but do not run commands.')
+
+    parser.add_argument('--outdir-html', default='/global/cfs/cdirs/desi/users/ioannis/fastspecfit',
+                        type=str, help='Base output HTML directory.')
+    parser.add_argument('--outdir-data', default='/global/cfs/cdirs/desi/spectro/fastspecfit',
+                        type=str, help='Base output data directory.')
+    
+    args = parser.parse_args()
+
+    if args.nompi:
+        comm = None
+    else:
+        try:
+            from mpi4py import MPI
+            comm = MPI.COMM_WORLD
+        except ImportError:
+            comm = None
+
+    if args.coadd_type == 'healpix':
+        args.survey = args.survey.split(',')
+        args.program = args.program.split(',')
+
+    if args.plan:
+        if comm is None:
+            rank = 0
+        else:
+            rank = comm.rank
+            
+        if rank == 0:
+            plan(comm=comm, specprod=args.specprod, coadd_type=args.coadd_type,
+                 survey=args.survey, program=args.program,
+                 healpix=args.healpix, tile=args.tile, night=args.night,
+                 outdir_data=args.outdir_data, outdir_html=args.outdir_html,
+                 overwrite=args.overwrite, mp=args.mp)
+    else:
+        do_cutouts(args, comm=comm, outdir_data=args.outdir_data,
+                   outdir_html=args.outdir_html)
+
+if __name__ == '__main__':
+    main()

--- a/bin/get-cutouts.sh
+++ b/bin/get-cutouts.sh
@@ -1,0 +1,97 @@
+#! /bin/bash
+
+# Perlmutter w/o shifter
+#salloc -N 4 -C cpu -A desi -L cfs -t 04:00:00 --qos interactive --image=dstndstn/viewer-cutouts 
+
+# Testing--
+#srun -n 4 -c 128 shifter /global/homes/i/ioannis/code/desihub/fastspecfit/bin/mpi-fastspecfit.sh fastspec-test fuji 128 > /global/cfs/cdirs/desi/spectro/fastspecfit/fuji/logs/fastspec-test.log.1 2>&1 &
+
+codedir=/global/homes/i/ioannis/code/desihub
+#codedir=/usr/local/bin
+mpiscript=$codedir/fastspecfit/bin/mpi-fastspecfit
+
+echo 'Loading DESI software stack 23.1'
+source /global/cfs/cdirs/desi/software/desi_environment.sh 23.1
+module swap desispec/0.57.0
+module load fastspecfit/2.1.1
+
+#for package in desispec fastspecfit; do
+#    echo Loading local check-out of $package
+#    export PATH=$codedir/$package/bin:$PATH
+#    export PYTHONPATH=$codedir/$package/py:$PYTHONPATH
+#done
+
+outdir_data=/global/cfs/cdirs/desi/spectro/fastspecfit
+outdir_html=/global/cfs/cdirs/desi/users/ioannis/fastspecfit
+
+export DESI_ROOT='/global/cfs/cdirs/desi'
+export DUST_DIR='/global/cfs/cdirs/cosmo/data/dust/v0_1'
+export DR9_DIR='/global/cfs/cdirs/desi/external/legacysurvey/dr9'
+export FTEMPLATES_DIR='/global/cfs/cdirs/desi/science/gqp/templates/fastspecfit'
+
+export TMPCACHE=$(mktemp -d)
+export MPLCONFIGDIR=$TMPCACHE/matplotlib
+mkdir $MPLCONFIGDIR
+cp -r $HOME/.config/matplotlib $MPLCONFIGDIR
+
+export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export KMP_AFFINITY=disabled
+export MPICH_GNI_FORK_MODE=FULLCOPY
+
+stage=$1
+specprod=$2
+mp=$3
+coadd_type=$4
+survey=$5
+program=$6
+
+#echo stage=$stage
+#echo specprod=$specprod
+#echo mp=$mp
+#echo coadd_type=$coadd_type
+#echo survey=$survey
+#echo program=$program
+
+# petal 8 on tiles 80613, 80606, 80607
+#args="--outdir-data $outdir_data --outdir-html $outdir_html --healpix 17684,17685,17686,17687,17692,7015,7020,7021,7022,7023,7026,7032,7015,7020,7021,7022,7023,7032"
+
+args="--outdir-data $outdir_data --outdir-html $outdir_html"
+
+if [[ $stage == "fastspec-test" ]]; then
+    args=$args" --ntest 12"
+fi
+if [[ $stage == "fastphot-test" ]]; then
+    args=$args" --fastphot --ntest 100"
+fi
+if [[ $stage == "fastphot" ]]; then
+    args=$args" --fastphot"
+fi
+if [[ $stage == "makeqa" ]]; then
+    args=$args" --makeqa"
+fi
+
+if [[ $specprod != " " ]] && [[ $specprod != "" ]] && [[ $specprod != "-" ]]; then
+    args=$args" --specprod $specprod"
+fi
+if [[ $mp != " " ]] && [[ $mp != "" ]] && [[ $mp != "-" ]]; then
+    args=$args" --mp $mp"
+fi
+if [[ $coadd_type != " " ]] && [[ $coadd_type != "" ]] && [[ $coadd_type != "-" ]]; then
+    args=$args" --coadd-type $coadd_type"
+else
+    args=$args" --coadd-type healpix"
+fi
+if [[ $survey != " " ]] && [[ $survey != "" ]] && [[ $survey != "-" ]]; then
+    args=$args" --survey $survey"
+fi
+if [[ ! -z $program ]] && [[ $program != "" ]] && [[ $program != "-" ]]; then
+    args=$args" --program $program"
+fi
+
+shifter --image dstndstn/viewer-cutouts /global/u2/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts --survey cmx --program other --mp 128
+
+
+
+echo python $mpiscript $args
+time python $mpiscript $args

--- a/bin/get-cutouts.sh
+++ b/bin/get-cutouts.sh
@@ -1,75 +1,26 @@
 #! /bin/bash
 
-# Perlmutter w/o shifter
 #salloc -N 4 -C cpu -A desi -L cfs -t 04:00:00 --qos interactive --image=dstndstn/viewer-cutouts 
-
-# Testing--
-#srun -n 4 -c 128 shifter /global/homes/i/ioannis/code/desihub/fastspecfit/bin/mpi-fastspecfit.sh fastspec-test fuji 128 > /global/cfs/cdirs/desi/spectro/fastspecfit/fuji/logs/fastspec-test.log.1 2>&1 &
+#srun -n 4 -c 128 shifter /global/homes/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts.sh fuji 128 > /global/cfs/cdirs/desi/spectro/fastspecfit/fuji/v2.0/logs/cutouts-fuji-01.log 2>&1 &
 
 codedir=/global/homes/i/ioannis/code/desihub
-#codedir=/usr/local/bin
-mpiscript=$codedir/fastspecfit/bin/mpi-fastspecfit
-
-echo 'Loading DESI software stack 23.1'
-source /global/cfs/cdirs/desi/software/desi_environment.sh 23.1
-module swap desispec/0.57.0
-module load fastspecfit/2.1.1
-
-#for package in desispec fastspecfit; do
-#    echo Loading local check-out of $package
-#    export PATH=$codedir/$package/bin:$PATH
-#    export PYTHONPATH=$codedir/$package/py:$PYTHONPATH
-#done
+mpiscript=$codedir/fastspecfit/bin/get-cutouts
 
 outdir_data=/global/cfs/cdirs/desi/spectro/fastspecfit
 outdir_html=/global/cfs/cdirs/desi/users/ioannis/fastspecfit
-
-export DESI_ROOT='/global/cfs/cdirs/desi'
-export DUST_DIR='/global/cfs/cdirs/cosmo/data/dust/v0_1'
-export DR9_DIR='/global/cfs/cdirs/desi/external/legacysurvey/dr9'
-export FTEMPLATES_DIR='/global/cfs/cdirs/desi/science/gqp/templates/fastspecfit'
-
-export TMPCACHE=$(mktemp -d)
-export MPLCONFIGDIR=$TMPCACHE/matplotlib
-mkdir $MPLCONFIGDIR
-cp -r $HOME/.config/matplotlib $MPLCONFIGDIR
 
 export OMP_NUM_THREADS=1
 export MKL_NUM_THREADS=1
 export KMP_AFFINITY=disabled
 export MPICH_GNI_FORK_MODE=FULLCOPY
 
-stage=$1
-specprod=$2
-mp=$3
-coadd_type=$4
-survey=$5
-program=$6
-
-#echo stage=$stage
-#echo specprod=$specprod
-#echo mp=$mp
-#echo coadd_type=$coadd_type
-#echo survey=$survey
-#echo program=$program
-
-# petal 8 on tiles 80613, 80606, 80607
-#args="--outdir-data $outdir_data --outdir-html $outdir_html --healpix 17684,17685,17686,17687,17692,7015,7020,7021,7022,7023,7026,7032,7015,7020,7021,7022,7023,7032"
+specprod=$1
+mp=$2
+coadd_type=$3
+survey=$4
+program=$5
 
 args="--outdir-data $outdir_data --outdir-html $outdir_html"
-
-if [[ $stage == "fastspec-test" ]]; then
-    args=$args" --ntest 12"
-fi
-if [[ $stage == "fastphot-test" ]]; then
-    args=$args" --fastphot --ntest 100"
-fi
-if [[ $stage == "fastphot" ]]; then
-    args=$args" --fastphot"
-fi
-if [[ $stage == "makeqa" ]]; then
-    args=$args" --makeqa"
-fi
 
 if [[ $specprod != " " ]] && [[ $specprod != "" ]] && [[ $specprod != "-" ]]; then
     args=$args" --specprod $specprod"
@@ -89,9 +40,5 @@ if [[ ! -z $program ]] && [[ $program != "" ]] && [[ $program != "-" ]]; then
     args=$args" --program $program"
 fi
 
-shifter --image dstndstn/viewer-cutouts /global/u2/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts --survey cmx --program other --mp 128
-
-
-
-echo python $mpiscript $args
-time python $mpiscript $args
+echo $mpiscript $args
+time $mpiscript $args

--- a/bin/get-cutouts.slurm
+++ b/bin/get-cutouts.slurm
@@ -1,0 +1,14 @@
+#! /bin/bash
+#SBATCH -A desi
+#SBATCH -C cpu
+#SBATCH -o /global/cfs/cdirs/desi/spectro/fastspecfit/fuji/logs/cutouts-fuji-01.log.%j
+#SBATCH --mail-user=jmoustakas@siena.edu
+#SBATCH --mail-type=ALL
+#SBATCH -q regular
+#SBATCH -N 8
+#SBATCH -n 8
+#SBATCH -t 01:00:00
+
+# sbatch /global/homes/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts.slurm
+
+time srun -n 64 -c 128 /global/homes/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts.sh fastspec fuji 128 healpix

--- a/bin/get-cutouts.slurm
+++ b/bin/get-cutouts.slurm
@@ -1,14 +1,15 @@
 #! /bin/bash
 #SBATCH -A desi
 #SBATCH -C cpu
-#SBATCH -o /global/cfs/cdirs/desi/spectro/fastspecfit/fuji/logs/cutouts-fuji-01.log.%j
+#SBATCH -o /global/cfs/cdirs/desi/spectro/fastspecfit/fuji/v2.0/logs/cutouts-fuji-01.log.%j
 #SBATCH --mail-user=jmoustakas@siena.edu
+#SBATCH --image=dstndstn/viewer-cutouts
 #SBATCH --mail-type=ALL
 #SBATCH -q regular
-#SBATCH -N 8
-#SBATCH -n 8
-#SBATCH -t 01:00:00
+#SBATCH -N 4
+#SBATCH -n 4
+#SBATCH -t 00:05:00
 
 # sbatch /global/homes/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts.slurm
 
-time srun -n 64 -c 128 /global/homes/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts.sh fastspec fuji 128 healpix
+time srun -n 4 -c 128 /global/homes/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts.sh fuji 128 healpix sv2

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -16,9 +16,6 @@ API
 .. automodule:: fastspecfit.fastspecfit
    :members:
 
-.. automodule:: fastspecfit.fnnls
-   :members:
-
 .. automodule:: fastspecfit.html
    :members:
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,8 +6,10 @@ Change Log
 ------------------------
 
 * Web-app updates needed for Fuji/v2.0 database load [`PR #107`_].
+* Get target cutouts using image coadds on-disk [`PR #108`_].
 
 .. _`PR #107`: https://github.com/desihub/fastspecfit/pull/107
+.. _`PR #108`: https://github.com/desihub/fastspecfit/pull/108
 
 2.1.1 (2023-02-22)
 ------------------


### PR DESCRIPTION
The bottleneck for generating QA output is the (web-based) cutout server, which often times out (especially when being hit hundreds of times per second) and results in blank images in the final file, which isn't ideal.

This PR wraps MPI code on @dstndstn's cut-out script (https://github.com/legacysurvey/imagine/blob/main/cutout.py) to pre-generate image cutouts for large samples of targets using the existing color coadds on disk at NERSC.

`fastspecfit-qa` (via `mpi-fastspecfit --makeqa`) will use the temporary cutout when building its QA and then delete it, so that we don't have end up with double the inodes.