### PR TITLE
initial hooks to fit stacked spectra

### DIFF
--- a/bin/fastspecfit-qa
+++ b/bin/fastspecfit-qa
@@ -135,20 +135,31 @@ def main(args=None, comm=None):
 
     templates = get_templates_filename(templateversion=args.templateversion, imf=args.imf)
 
-    def _wrap_qa(redrockfile, indx=None):
+    def _wrap_qa(redrockfile, indx=None, stackfit=False):
         if indx is None:
             indx = np.arange(len(fastfit))
 
-        targetids = fastfit['TARGETID'][indx]
-        Spec.select(redrockfiles=redrockfile, targetids=targetids,
-                    redrockfile_prefix=args.redrockfile_prefix,
-                    specfile_prefix=args.specfile_prefix,
-                    qnfile_prefix=args.qnfile_prefix)
-        data = Spec.read_and_unpack(fastphot=fastphot, synthphot=True, mp=args.mp)
+        if stackfit:
+            stackids = fastfit['STACKID'][indx]
+            data = Spec.read_stacked(redrockfile, stackids=stackids, mp=args.mp)
+            args.nophoto = True # force nophoto=True
 
+            minspecwave = np.min(data[0]['coadd_wave']) - 20
+            maxspecwave = np.max(data[0]['coadd_wave']) + 20
+        else:
+            targetids = fastfit['TARGETID'][indx]
+            Spec.select(redrockfiles=redrockfile, targetids=targetids,
+                        redrockfile_prefix=args.redrockfile_prefix,
+                        specfile_prefix=args.specfile_prefix,
+                        qnfile_prefix=args.qnfile_prefix)
+            data = Spec.read_and_unpack(fastphot=fastphot, synthphot=True, mp=args.mp)
+
+            minspecwave = 3500.
+            maxspecwave = 9900.
+            
         qaargs = [(data[igal], fastfit[indx[igal]], metadata[indx[igal]],
-                   templates, coadd_type, fastphot, args.nophoto, args.outdir,
-                   args.outprefix, log)
+                   templates, coadd_type, minspecwave, maxspecwave, 
+                   fastphot, args.nophoto, stackfit, args.outdir, args.outprefix, log)
                    for igal in np.arange(len(indx))]                
         if args.mp > 1:
             import multiprocessing
@@ -179,6 +190,9 @@ def main(args=None, comm=None):
     elif coadd_type == 'custom':
         for redrockfile in args.redrockfiles:
             _wrap_qa(redrockfile)
+    elif coadd_type == 'stacked':
+        for redrockfile in args.redrockfiles:
+            _wrap_qa(redrockfile, stackfit=True)
     else:
         allspecprods = metadata['SPECPROD'].data
         alltiles = metadata['TILEID'].astype(str).data

--- a/bin/stackfit
+++ b/bin/stackfit
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Fast broadband photometry fitting.
+
+Example call:
+  stackfit /global/cfs/cdirs/desi/science/gqp/fastspecfit_stacks/test_stack_file.fits -o stackfit.fits --ntargets 2 --mp 1
+
+"""
+if __name__ == '__main__':
+    from fastspecfit.fastspecfit import stackfit
+    stackfit(comm=None)

--- a/bin/stackfit
+++ b/bin/stackfit
@@ -2,7 +2,7 @@
 """Fast broadband photometry fitting.
 
 Example call:
-  stackfit /global/cfs/cdirs/desi/science/gqp/fastspecfit_stacks/test_stack_file.fits -o stackfit.fits --ntargets 2 --mp 1
+  stackfit /global/cfs/cdirs/desi/science/gqp/fastspecfit_stacks/test_stack_file_mstar_z_bins.fits -o stackfit.fits --ntargets 2 --mp 1
 
 """
 if __name__ == '__main__':

--- a/bin/stackfit
+++ b/bin/stackfit
@@ -3,6 +3,7 @@
 
 Example call:
   stackfit /global/cfs/cdirs/desi/science/gqp/fastspecfit_stacks/test_ivar_stack_mstar_z_bins_3.fits -o stackfit.fits --ntargets 2 --mp 1
+  fastspecfit-qa stackfit.fits --redrockfiles /global/cfs/cdirs/desi/science/gqp/fastspecfit_stacks/test_ivar_stack_mstar_z_bins_3.fits -o desi-users/ioannis/tmp
 
 """
 if __name__ == '__main__':

--- a/bin/stackfit
+++ b/bin/stackfit
@@ -2,7 +2,7 @@
 """Fast broadband photometry fitting.
 
 Example call:
-  stackfit /global/cfs/cdirs/desi/science/gqp/fastspecfit_stacks/test_stack_file_mstar_z_bins.fits -o stackfit.fits --ntargets 2 --mp 1
+  stackfit /global/cfs/cdirs/desi/science/gqp/fastspecfit_stacks/test_ivar_stack_mstar_z_bins_3.fits -o stackfit.fits --ntargets 2 --mp 1
 
 """
 if __name__ == '__main__':

--- a/bin/validate-production
+++ b/bin/validate-production
@@ -53,7 +53,7 @@ def check_one_catalog(zcatfile, specprod):
             np.sum(zdiff), len(fast), np.sum(zdiff)/len(fast), fastfile))
 
     outfile = os.path.basename(fastfile)
-    outfile = outfile.replace('fastspec-', '{fastspec,fastphot}-')
+    outfile = outfile.replace('fastspec-', '{fastspec}-')
 
     return outfile, len(fast), np.sum(zdiff)
 
@@ -77,7 +77,7 @@ def check_catalogs(specprod_dir, fastspecdir, specprod, mp=1):
     fast = fitsio.read(fastfile, ext='METADATA', columns=['Z', 'Z_RR'])
     zdiff = fast['Z'] != fast['Z_RR']
     fastfile = os.path.basename(fastfile)
-    fastfile = fastfile.replace('fastspec-', '{fastspec,fastphot}-')
+    fastfile = fastfile.replace('fastspec-', '{fastspec}-')
 
     fastfiles.append(fastfile)
     nrows.append(len(fast))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,9 +7,11 @@ Change Log
 
 * Web-app updates needed for Fuji/v2.0 database load [`PR #107`_].
 * Get target cutouts using image coadds on-disk [`PR #108`_].
+* Initial hooks to fit stacked spectra [`PR #113`_].
 
 .. _`PR #107`: https://github.com/desihub/fastspecfit/pull/107
 .. _`PR #108`: https://github.com/desihub/fastspecfit/pull/108
+.. _`PR #113`: https://github.com/desihub/fastspecfit/pull/113
 
 2.1.1 (2023-02-22)
 ------------------

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1446,7 +1446,7 @@ class ContinuumTools(Filters):
         redshift = data['zredrock']
         if redshift <= 0.0:
             errmsg = 'Input redshift not defined, zero, or negative!'
-            self.log.warning(errmsg)
+            log.warning(errmsg)
             kcorr = np.zeros(len(self.absmag_bands))
             absmag = np.zeros(len(self.absmag_bands))#-99.0
             ivarabsmag = np.zeros(len(self.absmag_bands))
@@ -1757,8 +1757,10 @@ def continuum_specfit(data, result, templatecache, nophoto=False, constrain_age=
         #Ivdisp = np.where((specivar > 0) * (specsmooth != 0.0) * (restwave > 3500.0) * (restwave < 5500.0))[0]
         compute_vdisp = (len(Ivdisp) > 0) and (np.ptp(restwave[Ivdisp]) > 500.0)
 
-        log.info('S/N_b={:.2f}, S/N_r={:.2f}, S/N_z={:.2f}, rest wavelength coverage={:.0f}-{:.0f} A.'.format(
-            result['SNR_B'], result['SNR_R'], result['SNR_Z'], restwave[0], restwave[-1]))
+        # stacked spectra do not have all three cameras
+        if 'SNR_B' in result.columns and 'SNR_R' in result.columns and 'SNR_Z' in result.columns:
+            log.info('S/N_b={:.2f}, S/N_r={:.2f}, S/N_z={:.2f}, rest wavelength coverage={:.0f}-{:.0f} A.'.format(
+                result['SNR_B'], result['SNR_R'], result['SNR_Z'], restwave[0], restwave[-1]))
 
         if compute_vdisp:
             t0 = time.time()
@@ -1950,8 +1952,9 @@ def continuum_specfit(data, result, templatecache, nophoto=False, constrain_age=
                 corr = np.median(smooth_continuum[icam][nonzero] / continuummodel[icam][nonzero])
                 result['SMOOTHCORR_{}'.format(cam.upper())] = corr * 100 # [%]
 
-        log.info('Smooth continuum correction: b={:.3f}%, r={:.3f}%, z={:.3f}%'.format(
-            result['SMOOTHCORR_B'], result['SMOOTHCORR_R'], result['SMOOTHCORR_Z']))
+        if 'SMOOTHCORR_B' in result.columns and 'SMOOTHCORR_R' in result.columns and 'SMOOTHCORR_Z' in result.columns:
+            log.info('Smooth continuum correction: b={:.3f}%, r={:.3f}%, z={:.3f}%'.format(
+                result['SMOOTHCORR_B'], result['SMOOTHCORR_R'], result['SMOOTHCORR_Z']))
 
     # Compute K-corrections, rest-frame quantities, and physical properties.
     if np.all(coeff == 0):

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -2611,7 +2611,7 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
     modelspectra.add_column(Column(name='CONTINUUM', dtype='f4', data=modelcontinuum))
     modelspectra.add_column(Column(name='SMOOTHCONTINUUM', dtype='f4', data=modelsmoothcontinuum))
     modelspectra.add_column(Column(name='EMLINEMODEL', dtype='f4', data=modelemspectrum))
-
+    pdb.set_trace()
     # Finally, optionally synthesize photometry (excluding the
     # smoothcontinuum!) and measure Dn(4000) from the line-free spectrum.
     if synthphot:

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -2584,8 +2584,8 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
     minwave, maxwave, dwave = np.min(data['coadd_wave']), np.max(data['coadd_wave']), np.diff(data['coadd_wave'][:2])[0]
     minwave = float(int(minwave * 1000) / 1000)
     maxwave = float(int(maxwave * 1000) / 1000)
-    dwave = float(np.round(dwave * 1000) / 1000)
-    npix = int((maxwave-minwave)/dwave)+1
+    dwave = float(int(np.round(dwave * 1000)) / 1000)
+    npix = int(np.round((maxwave-minwave)/dwave)) + 1
     modelwave = minwave + dwave * np.arange(npix)
 
     modelspectra = Table()
@@ -2611,7 +2611,7 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
     modelspectra.add_column(Column(name='CONTINUUM', dtype='f4', data=modelcontinuum))
     modelspectra.add_column(Column(name='SMOOTHCONTINUUM', dtype='f4', data=modelsmoothcontinuum))
     modelspectra.add_column(Column(name='EMLINEMODEL', dtype='f4', data=modelemspectrum))
-    pdb.set_trace()
+
     # Finally, optionally synthesize photometry (excluding the
     # smoothcontinuum!) and measure Dn(4000) from the line-free spectrum.
     if synthphot:

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -2584,7 +2584,7 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
     minwave, maxwave, dwave = np.min(data['coadd_wave']), np.max(data['coadd_wave']), np.diff(data['coadd_wave'][:2])[0]
     minwave = float(int(minwave * 1000) / 1000)
     maxwave = float(int(maxwave * 1000) / 1000)
-    dwave = float(int(dwave * 1000) / 1000)
+    dwave = float(np.round(dwave * 1000) / 1000)
     npix = int((maxwave-minwave)/dwave)+1
     modelwave = minwave + dwave * np.arange(npix)
 

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -186,8 +186,8 @@ def fastspec(fastphot=False, stackfit=False, args=None, comm=None, verbose=False
         data = Spec.read_and_unpack(fastphot=fastphot, mp=args.mp)
 
         # default wavelength ranges
-        minspecwave = 3600.0
-        maxspecwave = 9900.0
+        minspecwave = 3500.
+        maxspecwave = 9900.
         
     log.info('Reading and unpacking {} spectra to be fitted took {:.2f} seconds.'.format(
         Spec.ntargets, time.time()-t0))

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -303,6 +303,148 @@ def unpack_one_spectrum(iobj, specdata, meta, ebv, Filters, fastphot, synthphot,
 
     return specdata, meta
 
+def _unpack_one_stacked_spectrum(args):
+    """Multiprocessing wrapper."""
+    return unpack_one_stacked_spectrum(*args)
+
+def unpack_one_stacked_spectrum(iobj, specdata, meta, Filters, synthphot, log):
+    """Unpack the data for a single stacked spectrum. Also flag pixels which may be
+    affected by emission lines.
+
+    """
+    log.info('Pre-processing object {} [stackid {} z={:.6f}].'.format(
+        iobj, meta['STACKID'], meta['REDSHIFT']))
+
+    if specdata['photsys'] == 'S':
+        filters = Filters.decam
+        allfilters = Filters.decamwise
+    else:
+        filters = Filters.bassmzls
+        allfilters = Filters.bassmzlswise
+
+    # Dummy imaging photometry.
+    maggies = np.zeros(len(Filters.bands))
+    ivarmaggies = np.zeros(len(Filters.bands))
+    
+    specdata['phot'] = Filters.parse_photometry(
+        Filters.bands, maggies=maggies, ivarmaggies=ivarmaggies, nanomaggies=True,
+        lambda_eff=allfilters.effective_wavelengths.value,
+        min_uncertainty=Filters.min_uncertainty, log=log)
+    
+    #specdata['fiberphot'] = specdata['phot']
+    #specdata['fibertotphot'] = specdata['phot']
+
+    specdata.update({'linemask': [], 'linemask_all': [], 'linename': [],
+                     'linepix': [], 'contpix': [],
+                     'wave': [], 'flux': [], 'ivar': [], 'mask': [], 'res': [], 
+                     'snr': np.zeros(1, 'f4'),
+                     #'npixpercamera': len(specdata['wave0'][0]),
+                     })
+
+    cameras, npixpercamera = [], []
+    for icam, camera in enumerate(specdata['cameras']):
+        # Check whether the camera is fully masked.
+        if np.sum(specdata['ivar0'][icam]) == 0:
+            log.warning('Dropping fully masked camera {}.'.format(camera))
+        else:
+            ivar = specdata['ivar0'][icam]
+            mask = specdata['mask0'][icam]
+
+            # always mask the first and last pixels
+            mask[0] = 1
+            mask[-1] = 1
+
+            # In the pipeline, if mask!=0 that does not mean ivar==0, but we
+            # want to be more aggressive about masking here.
+            ivar[mask != 0] = 0
+
+            if np.all(ivar == 0):
+                log.warning('Dropping fully masked camera {}.'.format(camera))                    
+            else:
+                cameras.append(camera)
+                npixpercamera.append(len(specdata['wave0'][icam])) # number of pixels in this camera
+
+                # Compute the SNR before we correct for dust.
+                specdata['snr'][icam] = np.median(specdata['flux0'][icam] * np.sqrt(ivar))
+                specdata['flux'].append(specdata['flux0'][icam])
+                specdata['ivar'].append(ivar)
+                specdata['wave'].append(specdata['wave0'][icam])
+                specdata['mask'].append(specdata['mask0'][icam])
+                specdata['res'].append(specdata['res0'][icam])
+                
+    if len(cameras) == 0:
+        errmsg = 'No good data, which should never happen.'
+        log.critical(errmsg)
+        raise ValueError(errmsg)
+
+    # Pre-compute some convenience variables for "un-hstacking"
+    # an "hstacked" spectrum.
+    specdata['cameras'] = cameras
+    specdata['npixpercamera'] = npixpercamera
+    
+    ncam = len(specdata['cameras'])
+    npixpercam = np.hstack([0, npixpercamera])
+    specdata['camerapix'] = np.zeros((ncam, 2), np.int16)
+    for icam in np.arange(ncam):
+        specdata['camerapix'][icam, :] = [np.sum(npixpercam[:icam+1]), np.sum(npixpercam[:icam+2])]
+
+    # clean up the data dictionary
+    for key in ['wave0', 'flux0', 'ivar0', 'mask0', 'res0']:
+        del specdata[key]
+
+    # coadded spectrum
+    coadd_linemask_dict = Filters.build_linemask(specdata['coadd_wave'], specdata['coadd_flux'],
+                                                 specdata['coadd_ivar'], redshift=specdata['zredrock'],
+                                                 linetable=Filters.linetable)
+    specdata['coadd_linename'] = coadd_linemask_dict['linename']
+    specdata['coadd_linepix'] = [np.where(lpix)[0] for lpix in coadd_linemask_dict['linepix']]
+    specdata['coadd_contpix'] = [np.where(cpix)[0] for cpix in coadd_linemask_dict['contpix']]
+
+    specdata['linesigma_narrow'] = coadd_linemask_dict['linesigma_narrow']
+    specdata['linesigma_balmer'] = coadd_linemask_dict['linesigma_balmer']
+    specdata['linesigma_uv'] = coadd_linemask_dict['linesigma_uv']
+
+    specdata['linesigma_narrow_snr'] = coadd_linemask_dict['linesigma_narrow_snr']
+    specdata['linesigma_balmer_snr'] = coadd_linemask_dict['linesigma_balmer_snr']
+    specdata['linesigma_uv_snr'] = coadd_linemask_dict['linesigma_uv_snr']
+
+    specdata['smoothsigma'] = coadd_linemask_dict['smoothsigma']
+    
+    # Map the pixels belonging to individual emission lines and
+    # their local continuum back onto the original per-camera
+    # spectra. These lists of arrays are used in
+    # continuum.ContinnuumTools.smooth_continuum.
+    for icam in np.arange(len(specdata['cameras'])):
+        #specdata['smoothflux'].append(np.interp(specdata['wave'][icam], specdata['coadd_wave'], coadd_linemask_dict['smoothflux']))
+        specdata['linemask'].append(np.interp(specdata['wave'][icam], specdata['coadd_wave'], coadd_linemask_dict['linemask']*1) > 0)
+        specdata['linemask_all'].append(np.interp(specdata['wave'][icam], specdata['coadd_wave'], coadd_linemask_dict['linemask_all']*1) > 0)
+        _linename, _linenpix, _contpix = [], [], []
+        for ipix in np.arange(len(coadd_linemask_dict['linepix'])):
+            I = np.interp(specdata['wave'][icam], specdata['coadd_wave'], coadd_linemask_dict['linepix'][ipix]*1) > 0
+            J = np.interp(specdata['wave'][icam], specdata['coadd_wave'], coadd_linemask_dict['contpix'][ipix]*1) > 0
+            if np.sum(I) > 3 and np.sum(J) > 3:
+                _linename.append(coadd_linemask_dict['linename'][ipix])
+                _linenpix.append(np.where(I)[0])
+                _contpix.append(np.where(J)[0])
+        specdata['linename'].append(_linename)
+        specdata['linepix'].append(_linenpix)
+        specdata['contpix'].append(_contpix)
+
+    specdata.update({'coadd_linemask': coadd_linemask_dict['linemask'],
+                     'coadd_linemask_all': coadd_linemask_dict['linemask_all']})
+
+    # Optionally synthesize photometry from the coadded spectrum.
+    if synthphot:
+        padflux, padwave = filters.pad_spectrum(specdata['coadd_flux'], specdata['coadd_wave'], method='edge')
+        synthmaggies = filters.get_ab_maggies(padflux / FLUXNORM, padwave)
+        synthmaggies = synthmaggies.as_array().view('f8')
+
+        specdata['synthphot'] = Filters.parse_photometry(Filters.synth_bands,
+            maggies=synthmaggies, nanomaggies=False,
+            lambda_eff=filters.effective_wavelengths.value, log=log)
+
+    return specdata, meta
+
 class DESISpectra(TabulatedDESI):
     def __init__(self, redux_dir=None, fiberassign_dir=None, dr9dir=None, mapdir=None):
         """Class to read in DESI spectra and associated metadata.
@@ -1000,6 +1142,252 @@ class DESISpectra(TabulatedDESI):
                     out = P.map(_unpack_one_spectrum, unpackargs)
             else:
                 out = [unpack_one_spectrum(*_unpackargs) for _unpackargs in unpackargs]
+                
+            out = list(zip(*out))
+            self.meta[ispec] = Table(np.hstack(out[1]))
+            alldata.append(out[0])
+            del out
+    
+        alldata = np.concatenate(alldata)
+        self.meta = vstack(self.meta)
+        self.ntargets = len(self.meta)
+
+        return alldata
+
+    def read_stacked(self, stackfiles, firsttarget=0, ntargets=None,
+                     stackids=None, synthphot=True, mp=1):
+        """Read one or more stacked spectra.
+        
+        Parameters
+        ----------
+        stackfiles : str or array
+            Full path to one or more input stacked-spectra file(s).
+        stackids : int or array or `None`
+            Restrict the sample to the set of stackids in this list. If `None`,
+            fit everything.
+        firsttarget : int
+            Integer offset of the first object to consider in each file. Useful
+            for debugging and testing. Defaults to 0.
+        ntargets : int or `None`
+            Number of objects to analyze in each file. Useful for debugging and
+            testing. If `None`, select all targets which satisfy the selection
+            criteria.
+        synthphot : bool
+            Synthesize photometry from the coadded optical spectrum. Optional;
+            defaults to `True`.
+
+        Returns
+        -------
+        List of dictionaries (:class:`dict`, one per object) the following keys:
+            targetid : numpy.int64
+                DESI target ID.
+            zredrock : numpy.float64
+                Redrock redshift.
+            cameras : :class:`list`
+                List of camera names present for this spectrum.
+            wave : :class:`list`
+                Three-element list of `numpy.ndarray` wavelength vectors, one for
+                each camera.    
+            flux : :class:`list`
+                Three-element list of `numpy.ndarray` flux spectra, one for each
+                camera and corrected for Milky Way extinction.
+            ivar : :class:`list`
+                Three-element list of `numpy.ndarray` inverse variance spectra, one
+                for each camera.    
+            res : :class:`list`
+                Three-element list of :class:`desispec.resolution.Resolution`
+                objects, one for each camera.
+            snr : `numpy.ndarray`
+                Median per-pixel signal-to-noise ratio in the grz cameras.
+            linemask : :class:`list`
+                Three-element list of `numpy.ndarray` boolean emission-line masks,
+                one for each camera. This mask is used during continuum-fitting.
+            linename : :class:`list`
+                Three-element list of emission line names which might be present
+                in each of the three DESI cameras.
+            linepix : :class:`list`
+                Three-element list of pixel indices, one per camera, which were
+                identified in :class:`FFit.build_linemask` to belong to emission
+                lines.
+            contpix : :class:`list`
+                Three-element list of pixel indices, one per camera, which were
+                identified in :class:`FFit.build_linemask` to not be
+                "contaminated" by emission lines.
+            coadd_wave : `numpy.ndarray`
+                Coadded wavelength vector with all three cameras combined.
+            coadd_flux : `numpy.ndarray`
+                Flux corresponding to `coadd_wave`.
+            coadd_ivar : `numpy.ndarray`
+                Inverse variance corresponding to `coadd_flux`.
+            photsys : str
+                Photometric system.
+            phot : `astropy.table.Table`
+                Total photometry in `grzW1W2`, corrected for Milky Way extinction.
+            fiberphot : `astropy.table.Table`
+                Fiber photometry in `grzW1W2`, corrected for Milky Way extinction.
+            fibertotphot : `astropy.table.Table`
+                Fibertot photometry in `grzW1W2`, corrected for Milky Way extinction.
+            synthphot : :class:`astropy.table.Table`
+                Photometry in `grz` synthesized from the Galactic
+                extinction-corrected coadded spectra (with a mild extrapolation
+                of the data blueward and redward to accommodate the g-band and
+                z-band filter curves, respectively.
+
+        """
+        from astropy.table import vstack
+        from scipy.sparse import identity
+        from desispec.resolution import Resolution
+        from fastspecfit.continuum import ContinuumTools
+
+        if stackfiles is None:
+            errmsg = 'At least one stackfiles file is required.'
+            log.critical(errmsg)
+            raise ValueError(errmsg)
+
+        if len(np.atleast_1d(stackfiles)) == 0:
+            errmsg = 'No stackfiles found!'
+            log.warning(errmsg)
+            raise ValueError(errmsg)
+
+        stackfiles = np.array(sorted(set(np.atleast_1d(stackfiles))))
+        log.info('Reading and parsing {} unique stackfile(s).'.format(len(stackfiles)))
+
+        self.specprod = 'custom'
+        self.coadd_type = 'custom'
+        READCOLS = ['STACKID', 'REDSHIFT']
+        
+        self.stackfiles, self.meta = [], []
+        
+        for istack, stackfile in enumerate(np.atleast_1d(stackfiles)):
+            if not os.path.isfile(stackfile):
+                log.warning('File {} not found!'.format(stackfile))
+                continue
+
+            # Gather some coadd information from the header.
+            hdr = fitsio.read_header(stackfile, ext=0)
+
+            if self.coadd_type == 'custom':
+                survey = 'custom'
+                program = 'custom'
+                healpix = np.int32(0)
+                thrunight = None
+                log.info('specprod={}, coadd_type={}, survey={}, program={}, healpix={}'.format(
+                    self.specprod, self.coadd_type, survey, program, healpix))
+                    
+            # If stackids is *not* given, read everything.
+
+            if stackids is None:
+                meta = fitsio.read(stackfile, 'SPECINFO', columns=READCOLS)
+                fitindx = np.arange(len(meta))
+                #fitindx = fitsio.FITS(stackfile)['SPECINFO'].get_nrows()
+
+                print('HACK!!')
+                meta['STACKID'] = fitindx
+                
+                # Check for uniqueness.
+                uu, cc = np.unique(meta['STACKID'], return_counts=True)
+                if np.any(cc > 1):
+                    errmsg = 'Found {} duplicate STACKIDs in {}: {}'.format(
+                        np.sum(cc>1), stackfile, ' '.join(uu[cc > 1].astype(str)))
+                    log.critical(errmsg)
+                    raise ValueError(errmsg)
+            else:
+                # We already know we like the input stackids, so no selection
+                # needed.
+                allstackids = fitsio.read(stackfile, 'SPECINFO', columns='STACKID')
+                fitindx = np.where([tid in stackids for tid in allstackids])[0]                
+                
+            if len(fitindx) == 0:
+                log.info('No requested targets found in stackfile {}'.format(stackfile))
+                continue
+
+            # Do we want just a subset of the available objects?
+            if ntargets is None:
+                _ntargets = len(fitindx)
+            else:
+                _ntargets = ntargets
+            if _ntargets > len(fitindx):
+                log.warning('Number of requested ntargets exceeds the number of targets on {}; reading all of them.'.format(
+                    stackfile))
+
+            __ntargets = len(fitindx)
+            fitindx = fitindx[firsttarget:firsttarget+_ntargets]
+            if len(fitindx) == 0:
+                log.info('All {} targets in stackfile {} have been dropped (firsttarget={}, ntargets={}).'.format(
+                    __ntargets, stackfile, firsttarget, _ntargets))
+                continue
+                
+            # If firsttarget is a large index then the set can become empty.
+            if stackids is None:
+                meta = Table(meta[fitindx])
+                print('HACK!!')
+                meta['STACKID'] = fitindx
+            else:
+                meta = Table(fitsio.read(stackfile, 'SPECINFO', rows=fitindx, columns=READCOLS))
+
+            if self.coadd_type == 'custom':
+                meta['SURVEY'] = survey
+                meta['PROGRAM'] = program
+                meta['HEALPIX'] = healpix
+
+            self.meta.append(Table(meta))
+            self.stackfiles.append(stackfile)
+
+        if len(self.meta) == 0:
+            log.warning('No targets read!')
+            return
+
+        # Now read the data as in self.read_and_unpack (for unstacked spectra).
+        CTools = ContinuumTools()
+
+        alldata = []
+        for ispec, (stackfile, meta) in enumerate(zip(self.stackfiles, self.meta)):
+            nobj = len(meta)
+            if nobj == 1:
+                log.info('Reading {} spectrum from {}'.format(nobj, stackfile))
+            else:
+                log.info('Reading {} spectra from {}'.format(nobj, stackfile))
+
+            # Age of the universe.
+            #dlum = self.luminosity_distance(meta['REDSHIFT'])
+            #dmod = self.distance_modulus(meta['REDSHIFT'])
+            tuniv = self.universe_age(meta['REDSHIFT'])
+
+            log.info('Fix me -- handle fitting a subset of objects.')
+            wave = fitsio.read(stackfile, 'WAVE')[0, :]
+            flux = fitsio.read(stackfile, 'FLUX')
+            ivar = fitsio.read(stackfile, 'IVAR')
+            npix = len(wave)
+
+            # unpack the desispec.spectra.Spectra objects into simple arrays
+            unpackargs = []
+            for iobj in np.arange(len(meta)):
+                specdata = {
+                    'targetid': meta['STACKID'][iobj], 'zredrock': meta['REDSHIFT'][iobj],
+                    'photsys': 'S',
+                    'cameras': ['grz'],
+                    #'dluminosity': dlum[iobj], 'dmodulus': dmod[iobj],
+                    'tuniv': tuniv[iobj],
+                    'wave0': [wave],
+                    'flux0': [flux[iobj, :]],
+                    'ivar0': [ivar[iobj, :]],
+                    'mask0': [np.zeros(npix, np.int16)],
+                    'res0': [Resolution(identity(n=npix))], # Hack!
+                    } 
+                specdata.update({
+                    'coadd_wave': specdata['wave0'][0],
+                    'coadd_flux': specdata['flux0'][0],
+                    'coadd_ivar': specdata['ivar0'][0],
+                    'coadd_res': specdata['res0'][0],
+                    })
+                unpackargs.append((iobj, specdata, meta[iobj], CTools, synthphot, log))
+                    
+            if mp > 1:
+                import multiprocessing
+                with multiprocessing.Pool(mp) as P:
+                    out = P.map(_unpack_one_stacked_spectrum, unpackargs)
+            else:
+                out = [unpack_one_stacked_spectrum(*_unpackargs) for _unpackargs in unpackargs]
                 
             out = list(zip(*out))
             self.meta[ispec] = Table(np.hstack(out[1]))

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1488,7 +1488,11 @@ def init_fastspec_output(input_meta, specprod, templates=None, ncoeff=None,
     # All of this business is so we can get the columns in the order we want
     # (i.e., the order that matches the data model).
     if stackfit:
-        print('WRITE ME')
+        for metacol in ['STACKID', 'SURVEY', 'PROGRAM']:
+            if metacol in metacols:
+                meta[metacol] = input_meta[metacol]
+                if metacol in colunit.keys():
+                    meta[metacol].unit = colunit[metacol]
     else:
         for metacol in ['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'TILEID', 'NIGHT', 'FIBER',
                         'EXPID', 'TILEID_LIST', 'RA', 'DEC', 'COADD_FIBERSTATUS']:

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1531,9 +1531,14 @@ def init_fastspec_output(input_meta, specprod, templates=None, ncoeff=None,
 
     # fastspec table
     out = Table()
-    for col in ['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'TILEID', 'NIGHT', 'FIBER', 'EXPID']:
-        if col in metacols:
-            out[col] = input_meta[col]
+    if stackfit:
+        for col in ['STACKID', 'SURVEY', 'PROGRAM']:
+            if col in metacols:
+                out[col] = input_meta[col]
+    else:
+        for col in ['TARGETID', 'SURVEY', 'PROGRAM', 'HEALPIX', 'TILEID', 'NIGHT', 'FIBER', 'EXPID']:
+            if col in metacols:
+                out[col] = input_meta[col]
 
     out.add_column(Column(name='Z', length=nobj, dtype='f8')) # redshift
     out.add_column(Column(name='COEFF', length=nobj, shape=(ncoeff,), dtype='f4'))
@@ -1880,6 +1885,9 @@ def get_qa_filename(metadata, coadd_type, outprefix=None, outdir=None,
             pngfile = os.path.join(outdir, '{}-{}-{}-{}-{}.png'.format(
                 outprefix, _metadata['SURVEY'], _metadata['PROGRAM'],
                 _metadata['HEALPIX'], _metadata['TARGETID']))
+        elif coadd_type == 'stacked':
+            pngfile = os.path.join(outdir, '{}-{}-{}.png'.format(
+                outprefix, coadd_type, _metadata['STACKID']))
         else:
             errmsg = 'Unrecognized coadd_type {}!'.format(coadd_type)
             log.critical(errmsg)


### PR DESCRIPTION
Working with @dirkscholte, this PR adds the option of fitting stacked spectra. The data model for stacked spectra still needs to be documented, but we have something basic working based on the tools (written by @biprateep and @dirkscholte) in `desihub/desigal.specutils`.  (Writing out a proper "stacked" or average resolution matrix is still a work in progress which @dirkscholte is leading but which is independent of this PR.)

One example: to do the fitting do:
```
stackfit $DESI_ROOT/science/gqp/fastspecfit_stacks/test_ivar_stack_mstar_z_bins_3.fits \
  -o stackfit.fits --ntargets 2 --mp 2
```
And to generate the QA do:
```
fastspecfit-qa stackfit.fits --redrockfiles $DESI_ROOT/science/gqp/fastspecfit_stacks/test_ivar_stack_mstar_z_bins_3.fits \
  -o desi-users/ioannis/tmp
```
<img width="1581" alt="Screenshot 2023-03-30 at 5 50 53 PM" src="https://user-images.githubusercontent.com/1431820/228972361-3556d226-b02c-457e-90c4-5f9fe9ec387f.png">

(Note that the fit is poor in the red and the blue because we're using the identity matrix as the resolution matrix at the moment.)
