### PR TITLE
add support for DR10 photometry

### DIFF
--- a/bin/fastspecfit-qa
+++ b/bin/fastspecfit-qa
@@ -30,7 +30,7 @@ def parse(options=None):
     parser.add_argument('--specfile-prefix', type=str, default='coadd-', help='Prefix of the spectral file(s).')
     parser.add_argument('--qnfile-prefix', type=str, default='qso_qn-', help='Prefix of the QuasarNet afterburner file(s).')
     parser.add_argument('--mapdir', type=str, default=None, help='Optional directory name for the dust maps.')
-    parser.add_argument('--dr9dir', type=str, default=None, help='Optional directory name for the DR9 photometry.')
+    parser.add_argument('--legacysurveydir', type=str, default=None, help='Optional directory name for the DR9 photometry.')
 
     parser.add_argument('--targetids', type=str, default=None, help='Comma-separated list of target IDs to process.')
     parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
@@ -138,7 +138,7 @@ def main(args=None, comm=None):
     log.info('Building QA for {} objects.'.format(len(metadata)))
 
     # Initialize the I/O class.
-    Spec = DESISpectra(redux_dir=args.redux_dir, dr9dir=args.dr9dir, mapdir=args.mapdir)
+    Spec = DESISpectra(redux_dir=args.redux_dir, legacysurveydir=args.legacysurveydir, mapdir=args.mapdir)
 
     templates = get_templates_filename(templateversion=args.templateversion, imf=args.imf)
 

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -123,7 +123,7 @@ def parse(options=None, log=None):
     parser.add_argument('--specfile-prefix', type=str, default='coadd-', help='Prefix of the spectral file(s).')
     parser.add_argument('--qnfile-prefix', type=str, default='qso_qn-', help='Prefix of the QuasarNet afterburner file(s).')
     parser.add_argument('--mapdir', type=str, default=None, help='Optional directory name for the dust maps.')
-    parser.add_argument('--dr9dir', type=str, default=None, help='Optional directory name for the DR9 photometry.')
+    parser.add_argument('--legacysurveydir', type=str, default=None, help='Optional directory name for the DR9 photometry.')
     parser.add_argument('--specproddir', type=str, default=None, help='Optional directory name for the spectroscopic production.')
     parser.add_argument('--verbose', action='store_true', help='Be verbose (for debugging purposes).')
 
@@ -182,7 +182,7 @@ def fastspec(fastphot=False, stackfit=False, args=None, comm=None, verbose=False
 
     # Read the data.
     t0 = time.time()
-    Spec = DESISpectra(dr9dir=args.dr9dir, mapdir=args.mapdir)
+    Spec = DESISpectra(legacysurveydir=args.legacysurveydir, mapdir=args.mapdir)
 
     if stackfit:
         data = Spec.read_stacked(args.redrockfiles, firsttarget=args.firsttarget,

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -21,7 +21,7 @@ log = get_logger()
 # Default environment variables.
 DESI_ROOT_NERSC = '/global/cfs/cdirs/desi'
 DUST_DIR_NERSC = '/global/cfs/cdirs/cosmo/data/dust/v0_1'
-DR9_DIR_NERSC = '/global/cfs/cdirs/desi/external/legacysurvey/dr9'
+LEGACYSURVEY_DIR_NERSC = '/global/cfs/cdirs/desi/external/legacysurvey/dr9'
 FTEMPLATES_DIR_NERSC = '/global/cfs/cdirs/desi/science/gqp/templates/fastspecfit'
 
 # list of all possible targeting bit columns
@@ -444,7 +444,7 @@ def unpack_one_stacked_spectrum(iobj, specdata, meta, Filters, synthphot, log):
     return specdata, meta
 
 class DESISpectra(TabulatedDESI):
-    def __init__(self, redux_dir=None, fiberassign_dir=None, dr9dir=None, mapdir=None):
+    def __init__(self, redux_dir=None, fiberassign_dir=None, legacysurveydir=None, mapdir=None):
         """Class to read in DESI spectra and associated metadata.
 
         Parameters
@@ -472,10 +472,10 @@ class DESISpectra(TabulatedDESI):
         else:
             self.fiberassign_dir = fiberassign_dir
 
-        if dr9dir is None:
-            self.dr9dir = os.environ.get('DR9_DIR', DR9_DIR_NERSC)
+        if legacysurveydir is None:
+            self.legacysurveydir = os.environ.get('LEGACYSURVEY_DIR', LEGACYSURVEY_DIR_NERSC)
         else:
-            self.dr9dir = dr9dir
+            self.legacysurveydir = legacysurveydir
 
         if mapdir is None:
             self.mapdir = os.path.join(os.environ.get('DUST_DIR', DUST_DIR_NERSC), 'maps')
@@ -943,9 +943,9 @@ class DESISpectra(TabulatedDESI):
         # because otherwise BRICKNAME gets "repaired!"
         t0 = time.time()
         input_meta = vstack(self.meta).copy() 
-        tractor = gather_tractorphot(input_meta, columns=TARGETCOLS, dr9dir=self.dr9dir)
+        tractor = gather_tractorphot(input_meta, columns=TARGETCOLS, legacysurveydir=self.legacysurveydir)
         #tractor = gather_tractorphot(input_meta, columns=np.hstack((
-        #    TARGETCOLS, 'FRACFLUX_W1', 'FRACFLUX_W2', 'FRACFLUX_W3', 'FRACFLUX_W4')), dr9dir=self.dr9dir)
+        #    TARGETCOLS, 'FRACFLUX_W1', 'FRACFLUX_W2', 'FRACFLUX_W3', 'FRACFLUX_W4')), legacysurveydir=self.legacysurveydir)
 
         metas = []
         for meta in self.meta:
@@ -1803,7 +1803,7 @@ def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
 
     primhdr = fitsheader(primhdr)
     add_dependencies(primhdr, module_names=possible_dependencies+['fastspecfit'],
-                     envvar_names=['DESI_ROOT', 'FTEMPLATES_DIR', 'DUST_DIR', 'DR9_DIR'])
+                     envvar_names=['DESI_ROOT', 'FTEMPLATES_DIR', 'DUST_DIR', 'LEGACYSURVEY_DIR'])
 
     hdus = fits.HDUList()
     hdus.append(fits.PrimaryHDU(None, primhdr))

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1737,7 +1737,7 @@ def read_fastspecfit(fastfitfile, rows=None, columns=None, read_models=False):
 
         # Add specprod to the metadata table so that we can stack across
         # productions (e.g., Fuji+Guadalupe).
-        hdr = fitsio.read_header(fastfitfile, ext='PRIMARY')
+        hdr = fitsio.read_header(fastfitfile)#, ext='PRIMARY')
         if 'SPECPROD' in hdr:
             specprod = hdr['SPECPROD']
             meta['SPECPROD'] = specprod

--- a/py/fastspecfit/test/test_fastspecfit.py
+++ b/py/fastspecfit/test/test_fastspecfit.py
@@ -27,7 +27,7 @@ class TestFastspec(unittest.TestCase):
         os.environ['DESI_ROOT'] = resource_filename('fastspecfit.test', 'data')
         cls.specproddir = resource_filename('fastspecfit.test', 'data')
         cls.mapdir = resource_filename('fastspecfit.test', 'data')
-        cls.dr9dir = resource_filename('fastspecfit.test', 'data')
+        cls.legacysurveydir = resource_filename('fastspecfit.test', 'data')
         cls.redrockfile = resource_filename('fastspecfit.test', 'data/redrock-4-80613-thru20210324.fits')
 
         cls.outdir = tempfile.mkdtemp()
@@ -59,8 +59,8 @@ class TestFastspec(unittest.TestCase):
         import fitsio
         from fastspecfit.fastspecfit import fastphot, parse
 
-        cmd = 'fastphot {} -o {} --mapdir {} --dr9dir {} --specproddir {} --templates {}'.format(
-            self.redrockfile, self.fastphot_outfile, self.mapdir, self.dr9dir, self.specproddir, self.templates)
+        cmd = 'fastphot {} -o {} --mapdir {} --legacysurveydir {} --specproddir {} --templates {}'.format(
+            self.redrockfile, self.fastphot_outfile, self.mapdir, self.legacysurveydir, self.specproddir, self.templates)
         args = parse(options=cmd.split()[1:])
         fastphot(args=args)
 
@@ -76,8 +76,8 @@ class TestFastspec(unittest.TestCase):
         import fitsio
         from fastspecfit.fastspecfit import fastspec, parse
     
-        cmd = 'fastspec {} -o {} --mapdir {} --dr9dir {} --specproddir {} --templates {}'.format(
-            self.redrockfile, self.fastspec_outfile, self.mapdir, self.dr9dir, self.specproddir, self.templates)
+        cmd = 'fastspec {} -o {} --mapdir {} --legacysurveydir {} --specproddir {} --templates {}'.format(
+            self.redrockfile, self.fastspec_outfile, self.mapdir, self.legacysurveydir, self.specproddir, self.templates)
         args = parse(options=cmd.split()[1:])
         fastspec(args=args)
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ matplotlib
 fitsio
 git+https://github.com/desihub/desimodel.git@0.18.0#egg=desimodel
 git+https://github.com/desihub/desitarget.git@2.6.0#egg=desitarget
-git+https://github.com/desihub/desispec.git@0.57.0#egg=desispec
+git+https://github.com/desihub/desispec.git@main#egg=desispec
 git+https://github.com/desihub/speclite.git@v0.16#egg=speclite


### PR DESCRIPTION
This PR generalizes the handling of the Legacy Surveys photometry to handle DR9 as well as DR10 (input) photometry.