### PR TITLE
require more pixels to estimate the variance in the emission-line amplitude

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,6 +11,16 @@ Change Log
 * Do not constrain the SPS age by default [`PR #132`_].
 * Bug fix of emission-line subtracted Dn(4000) measurement [`PR #135`_].
 * Update IGM attenuation coefficients [`PR #136`_].
+* Several significant changes [`PR #137`_]:
+  * Record the observed-space emission-line amplitude in `_AMP` and move the
+    model-space amplitude to `_MODELAMP`.
+  * Demand at least 12 pixels to measure the scatter in the pixels under the
+    line (therefore `_AMP_IVAR` should be more reliable for narrow lines).
+  * Major bug fix whereby the model emission-line spectra were not being
+    convolved with the resolution matrix.
+  * Redefine `_CHI2` for an emission line as the observed not reduced chi2.
+  * Switch from (deprecated) `pkg_resources` to `importlib`.
+  * Updated documentation (data model) and several non-negligible speed-ups.
 
 .. _`PR #115`: https://github.com/desihub/fastspecfit/pull/115
 .. _`PR #116`: https://github.com/desihub/fastspecfit/pull/116
@@ -18,6 +28,7 @@ Change Log
 .. _`PR #132`: https://github.com/desihub/fastspecfit/pull/132
 .. _`PR #135`: https://github.com/desihub/fastspecfit/pull/135
 .. _`PR #136`: https://github.com/desihub/fastspecfit/pull/136
+.. _`PR #137`: https://github.com/desihub/fastspecfit/pull/137
 
 2.1.2 (2023-04-01)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -12,14 +12,15 @@ Change Log
 * Bug fix of emission-line subtracted Dn(4000) measurement [`PR #135`_].
 * Update IGM attenuation coefficients [`PR #136`_].
 * Several significant changes [`PR #137`_]:
-  * Record the observed-space emission-line amplitude in `_AMP` and move the
-    model-space amplitude to `_MODELAMP`.
+  
+  * Record the observed-space emission-line amplitude in ``_AMP`` and move the
+    model-space amplitude to ``_MODELAMP``. 
   * Demand at least 12 pixels to measure the scatter in the pixels under the
-    line (therefore `_AMP_IVAR` should be more reliable for narrow lines).
+    line (therefore ``_AMP_IVAR`` should be more reliable for narrow lines).
   * Major bug fix whereby the model emission-line spectra were not being
     convolved with the resolution matrix.
-  * Redefine `_CHI2` for an emission line as the observed not reduced chi2.
-  * Switch from (deprecated) `pkg_resources` to `importlib`.
+  * Redefine ``_CHI2`` for an emission line as the observed not reduced chi2.
+  * Switch from (deprecated) ``pkg_resources`` to ``importlib``.
   * Updated documentation (data model) and several non-negligible speed-ups.
 
 .. _`PR #115`: https://github.com/desihub/fastspecfit/pull/115

--- a/doc/fastspec.rst
+++ b/doc/fastspec.rst
@@ -184,6 +184,7 @@ Name                         Type         Units                         Descript
           MGII_DOUBLET_RATIO      float32                               MgII 2796 / 2803 doublet line-ratio.
            OII_DOUBLET_RATIO      float32                               [OII] 3726 / 3729 doublet line-ratio.
            SII_DOUBLET_RATIO      float32                               [SII] 6731 / 6716 doublet line-ratio.
+            LYALPHA_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission-line amplitude.
                  LYALPHA_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
             LYALPHA_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                 LYALPHA_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -198,8 +199,9 @@ Name                         Type         Units                         Descript
              LYALPHA_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
           LYALPHA_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
             LYALPHA_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-                LYALPHA_CHI2      float32                               Reduced chi^2 of the line-fit.
+                LYALPHA_CHI2      float32                               Chi-squared of the line-fit.
                 LYALPHA_NPIX        int32                               Number of pixels attributed to the emission line.
+            OI_1304_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission-line amplitude.
                  OI_1304_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
             OI_1304_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                 OI_1304_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -214,8 +216,9 @@ Name                         Type         Units                         Descript
              OI_1304_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
           OI_1304_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
             OI_1304_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-                OI_1304_CHI2      float32                               Reduced chi^2 of the line-fit.
+                OI_1304_CHI2      float32                               Chi-squared of the line-fit.
                 OI_1304_NPIX        int32                               Number of pixels attributed to the emission line.
+         SILIV_1396_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission-line amplitude.
               SILIV_1396_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
          SILIV_1396_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
              SILIV_1396_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -230,8 +233,9 @@ Name                         Type         Units                         Descript
           SILIV_1396_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
        SILIV_1396_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
          SILIV_1396_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-             SILIV_1396_CHI2      float32                               Reduced chi^2 of the line-fit.
+             SILIV_1396_CHI2      float32                               Chi-squared of the line-fit.
              SILIV_1396_NPIX        int32                               Number of pixels attributed to the emission line.
+           CIV_1549_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 CIV_1549_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            CIV_1549_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                CIV_1549_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -246,8 +250,9 @@ Name                         Type         Units                         Descript
             CIV_1549_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          CIV_1549_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            CIV_1549_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               CIV_1549_CHI2      float32                               Reduced chi^2 of the line-fit.
+               CIV_1549_CHI2      float32                               Chi-squared of the line-fit.
                CIV_1549_NPIX        int32                               Number of pixels attributed to the emission line.
+        SILIII_1892_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
              SILIII_1892_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
         SILIII_1892_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
             SILIII_1892_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -262,8 +267,9 @@ Name                         Type         Units                         Descript
          SILIII_1892_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
       SILIII_1892_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
         SILIII_1892_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-            SILIII_1892_CHI2      float32                               Reduced chi^2 of the line-fit.
+            SILIII_1892_CHI2      float32                               Chi-squared of the line-fit.
             SILIII_1892_NPIX        int32                               Number of pixels attributed to the emission line.
+          CIII_1908_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                CIII_1908_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
           CIII_1908_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
               CIII_1908_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -278,8 +284,9 @@ Name                         Type         Units                         Descript
            CIII_1908_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
         CIII_1908_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
           CIII_1908_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-              CIII_1908_CHI2      float32                               Reduced chi^2 of the line-fit.
+              CIII_1908_CHI2      float32                               Chi-squared of the line-fit.
               CIII_1908_NPIX        int32                               Number of pixels attributed to the emission line.
+          MGII_2796_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                MGII_2796_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
           MGII_2796_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
               MGII_2796_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -293,8 +300,9 @@ Name                         Type         Units                         Descript
            MGII_2796_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
         MGII_2796_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
           MGII_2796_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-              MGII_2796_CHI2      float32                               Reduced chi^2 of the line-fit.
+              MGII_2796_CHI2      float32                               Chi-squared of the line-fit.
               MGII_2796_NPIX        int32                               Number of pixels attributed to the emission line.
+          MGII_2803_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                MGII_2803_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
           MGII_2803_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
               MGII_2803_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -309,8 +317,9 @@ Name                         Type         Units                         Descript
            MGII_2803_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
         MGII_2803_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
           MGII_2803_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-              MGII_2803_CHI2      float32                               Reduced chi^2 of the line-fit.
+              MGII_2803_CHI2      float32                               Chi-squared of the line-fit.
               MGII_2803_NPIX        int32                               Number of pixels attributed to the emission line.
+           NEV_3346_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 NEV_3346_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            NEV_3346_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                NEV_3346_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -325,8 +334,9 @@ Name                         Type         Units                         Descript
             NEV_3346_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          NEV_3346_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            NEV_3346_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               NEV_3346_CHI2      float32                               Reduced chi^2 of the line-fit.
+               NEV_3346_CHI2      float32                               Chi-squared of the line-fit.
                NEV_3346_NPIX        int32                               Number of pixels attributed to the emission line.
+           NEV_3426_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 NEV_3426_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            NEV_3426_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                NEV_3426_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -341,8 +351,9 @@ Name                         Type         Units                         Descript
             NEV_3426_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          NEV_3426_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            NEV_3426_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               NEV_3426_CHI2      float32                               Reduced chi^2 of the line-fit.
+               NEV_3426_CHI2      float32                               Chi-squared of the line-fit.
                NEV_3426_NPIX        int32                               Number of pixels attributed to the emission line.
+           OII_3726_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 OII_3726_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            OII_3726_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                OII_3726_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -357,8 +368,9 @@ Name                         Type         Units                         Descript
             OII_3726_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          OII_3726_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            OII_3726_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               OII_3726_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+               OII_3726_CHI2      float32                               Chi-squared of the line-fit.
                OII_3726_NPIX        int32                               Number of pixels attributed to the emission line.
+           OII_3729_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 OII_3729_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            OII_3729_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                OII_3729_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -373,8 +385,9 @@ Name                         Type         Units                         Descript
             OII_3729_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          OII_3729_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            OII_3729_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               OII_3729_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+               OII_3729_CHI2      float32                               Chi-squared of the line-fit.
                OII_3729_NPIX        int32                               Number of pixels attributed to the emission line.
+         NEIII_3869_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
               NEIII_3869_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
          NEIII_3869_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
              NEIII_3869_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -389,8 +402,9 @@ Name                         Type         Units                         Descript
           NEIII_3869_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
        NEIII_3869_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
          NEIII_3869_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-             NEIII_3869_CHI2      float32                               Reduced chi^2 of the line-fit.
+             NEIII_3869_CHI2      float32                               Chi-squared of the line-fit.
              NEIII_3869_NPIX        int32                               Number of pixels attributed to the emission line.
+                 H6_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                       H6_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
                  H6_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                      H6_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -405,8 +419,9 @@ Name                         Type         Units                         Descript
                   H6_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
                H6_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
                  H6_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-                     H6_CHI2      float32                               Reduced chi^2 of the line-fit.
+                     H6_CHI2      float32                               Chi-squared of the line-fit.
                      H6_NPIX        int32                               Number of pixels attributed to the emission line.
+           H6_BROAD_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 H6_BROAD_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            H6_BROAD_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                H6_BROAD_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -420,8 +435,9 @@ Name                         Type         Units                         Descript
             H6_BROAD_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          H6_BROAD_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            H6_BROAD_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               H6_BROAD_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+               H6_BROAD_CHI2      float32                               Chi-squared of the line-fit.
                H6_BROAD_NPIX        int32                               Number of pixels attributed to the emission line.
+           HEPSILON_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 HEPSILON_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            HEPSILON_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                HEPSILON_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -436,8 +452,9 @@ Name                         Type         Units                         Descript
             HEPSILON_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          HEPSILON_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            HEPSILON_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               HEPSILON_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+               HEPSILON_CHI2      float32                               Chi-squared of the line-fit.
                HEPSILON_NPIX        int32                               Number of pixels attributed to the emission line.
+     HEPSILON_BROAD_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
           HEPSILON_BROAD_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
      HEPSILON_BROAD_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
          HEPSILON_BROAD_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -452,8 +469,9 @@ Name                         Type         Units                         Descript
       HEPSILON_BROAD_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
    HEPSILON_BROAD_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
      HEPSILON_BROAD_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-         HEPSILON_BROAD_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+         HEPSILON_BROAD_CHI2      float32                               Chi-squared of the line-fit.
          HEPSILON_BROAD_NPIX        int32                               Number of pixels attributed to the emission line.
+             HDELTA_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                   HDELTA_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
              HDELTA_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                  HDELTA_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -468,8 +486,9 @@ Name                         Type         Units                         Descript
               HDELTA_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
            HDELTA_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
              HDELTA_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-                 HDELTA_CHI2      float32                               Reduced chi^2 of the line-fit.
+                 HDELTA_CHI2      float32                               Chi-squared of the line-fit.
                  HDELTA_NPIX        int32                               Number of pixels attributed to the emission line.
+       HDELTA_BROAD_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
             HDELTA_BROAD_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
        HDELTA_BROAD_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
            HDELTA_BROAD_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -484,8 +503,9 @@ Name                         Type         Units                         Descript
         HDELTA_BROAD_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
      HDELTA_BROAD_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
        HDELTA_BROAD_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-           HDELTA_BROAD_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+           HDELTA_BROAD_CHI2      float32                               Chi-squared of the line-fit.
            HDELTA_BROAD_NPIX        int32                               Number of pixels attributed to the emission line.
+             HGAMMA_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                   HGAMMA_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
              HGAMMA_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                  HGAMMA_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -500,8 +520,9 @@ Name                         Type         Units                         Descript
               HGAMMA_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
            HGAMMA_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
              HGAMMA_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-                 HGAMMA_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+                 HGAMMA_CHI2      float32                               Chi-squared of the line-fit.
                  HGAMMA_NPIX        int32                               Number of pixels attributed to the emission line.
+       HGAMMA_BROAD_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
             HGAMMA_BROAD_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
        HGAMMA_BROAD_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
            HGAMMA_BROAD_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -516,8 +537,9 @@ Name                         Type         Units                         Descript
         HGAMMA_BROAD_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
      HGAMMA_BROAD_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
        HGAMMA_BROAD_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-           HGAMMA_BROAD_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+           HGAMMA_BROAD_CHI2      float32                               Chi-squared of the line-fit.
            HGAMMA_BROAD_NPIX        int32                               Number of pixels attributed to the emission line.
+          OIII_4363_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                OIII_4363_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
           OIII_4363_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
               OIII_4363_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -532,8 +554,9 @@ Name                         Type         Units                         Descript
            OIII_4363_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
         OIII_4363_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
           OIII_4363_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-              OIII_4363_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+              OIII_4363_CHI2      float32                               Chi-squared of the line-fit.
               OIII_4363_NPIX        int32                               Number of pixels attributed to the emission line.
+           HEI_4471_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 HEI_4471_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            HEI_4471_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                HEI_4471_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -548,8 +571,9 @@ Name                         Type         Units                         Descript
             HEI_4471_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          HEI_4471_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            HEI_4471_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               HEI_4471_CHI2      float32                               Reduced chi^2 of the line-fit.
+               HEI_4471_CHI2      float32                               Chi-squared of the line-fit.
                HEI_4471_NPIX        int32                               Number of pixels attributed to the emission line.
+          HEII_4686_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                HEII_4686_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
           HEII_4686_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
               HEII_4686_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -564,8 +588,9 @@ Name                         Type         Units                         Descript
            HEII_4686_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
         HEII_4686_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
           HEII_4686_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-              HEII_4686_CHI2      float32                               Reduced chi^2 of the line-fit.
+              HEII_4686_CHI2      float32                               Chi-squared of the line-fit.
               HEII_4686_NPIX        int32                               Number of pixels attributed to the emission line.
+              HBETA_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                    HBETA_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
               HBETA_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                   HBETA_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -580,8 +605,9 @@ Name                         Type         Units                         Descript
                HBETA_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
             HBETA_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
               HBETA_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-                  HBETA_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+                  HBETA_CHI2      float32                               Chi-squared of the line-fit.
                   HBETA_NPIX        int32                               Number of pixels attributed to the emission line.
+        HBETA_BROAD_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
              HBETA_BROAD_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
         HBETA_BROAD_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
             HBETA_BROAD_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -596,8 +622,9 @@ Name                         Type         Units                         Descript
          HBETA_BROAD_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
       HBETA_BROAD_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
         HBETA_BROAD_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-            HBETA_BROAD_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+            HBETA_BROAD_CHI2      float32                               Chi-squared of the line-fit.
             HBETA_BROAD_NPIX        int32                               Number of pixels attributed to the emission line.
+          OIII_4959_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                OIII_4959_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
           OIII_4959_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
               OIII_4959_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -612,8 +639,9 @@ Name                         Type         Units                         Descript
            OIII_4959_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
         OIII_4959_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
           OIII_4959_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-              OIII_4959_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+              OIII_4959_CHI2      float32                               Chi-squared of the line-fit.
               OIII_4959_NPIX        int32                               Number of pixels attributed to the emission line.
+          OIII_5007_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                OIII_5007_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
           OIII_5007_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
               OIII_5007_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -628,8 +656,9 @@ Name                         Type         Units                         Descript
            OIII_5007_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
         OIII_5007_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
           OIII_5007_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-              OIII_5007_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+              OIII_5007_CHI2      float32                               Chi-squared of the line-fit.
               OIII_5007_NPIX        int32                               Number of pixels attributed to the emission line.
+           NII_5755_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 NII_5755_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            NII_5755_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                NII_5755_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -644,8 +673,9 @@ Name                         Type         Units                         Descript
             NII_5755_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          NII_5755_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            NII_5755_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               NII_5755_CHI2      float32                               Reduced chi^2 of the line-fit.
+               NII_5755_CHI2      float32                               Chi-squared of the line-fit.
                NII_5755_NPIX        int32                               Number of pixels attributed to the emission line.
+           HEI_5876_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 HEI_5876_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            HEI_5876_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                HEI_5876_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -660,8 +690,9 @@ Name                         Type         Units                         Descript
             HEI_5876_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          HEI_5876_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            HEI_5876_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               HEI_5876_CHI2      float32                               Reduced chi^2 of the line-fit.
+               HEI_5876_CHI2      float32                               Chi-squared of the line-fit.
                HEI_5876_NPIX        int32                               Number of pixels attributed to the emission line.
+            OI_6300_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                  OI_6300_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
             OI_6300_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                 OI_6300_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -676,8 +707,9 @@ Name                         Type         Units                         Descript
              OI_6300_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
           OI_6300_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
             OI_6300_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-                OI_6300_CHI2      float32                               Reduced chi^2 of the line-fit.
+                OI_6300_CHI2      float32                               Chi-squared of the line-fit.
                 OI_6300_NPIX        int32                               Number of pixels attributed to the emission line.
+           NII_6548_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 NII_6548_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            NII_6548_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                NII_6548_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -692,8 +724,9 @@ Name                         Type         Units                         Descript
             NII_6548_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          NII_6548_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            NII_6548_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               NII_6548_CHI2      float32                               Reduced chi^2 of the line-fit.
+               NII_6548_CHI2      float32                               Chi-squared of the line-fit.
                NII_6548_NPIX        int32                               Number of pixels attributed to the emission line.
+             HALPHA_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                   HALPHA_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
              HALPHA_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                  HALPHA_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -708,8 +741,9 @@ Name                         Type         Units                         Descript
               HALPHA_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
            HALPHA_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
              HALPHA_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-                 HALPHA_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+                 HALPHA_CHI2      float32                               Chi-squared of the line-fit.
                  HALPHA_NPIX        int32                               Number of pixels attributed to the emission line.
+       HALPHA_BROAD_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
             HALPHA_BROAD_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
        HALPHA_BROAD_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
            HALPHA_BROAD_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -724,8 +758,9 @@ Name                         Type         Units                         Descript
         HALPHA_BROAD_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
      HALPHA_BROAD_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
        HALPHA_BROAD_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-           HALPHA_BROAD_CHI2      float32                               Reduced chi^2 of the line-fit (default value 1e6).
+           HALPHA_BROAD_CHI2      float32                               Chi-squared of the line-fit.
            HALPHA_BROAD_NPIX        int32                               Number of pixels attributed to the emission line.
+           NII_6584_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 NII_6584_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            NII_6584_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                NII_6584_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -740,8 +775,9 @@ Name                         Type         Units                         Descript
             NII_6584_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          NII_6584_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            NII_6584_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               NII_6584_CHI2      float32                               Reduced chi^2 of the line-fit.
+               NII_6584_CHI2      float32                               Chi-squared of the line-fit.
                NII_6584_NPIX        int32                               Number of pixels attributed to the emission line.
+           SII_6716_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 SII_6716_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            SII_6716_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                SII_6716_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -756,8 +792,9 @@ Name                         Type         Units                         Descript
             SII_6716_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          SII_6716_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            SII_6716_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               SII_6716_CHI2      float32                               Reduced chi^2 of the line-fit.
+               SII_6716_CHI2      float32                               Chi-squared of the line-fit.
                SII_6716_NPIX        int32                               Number of pixels attributed to the emission line.
+           SII_6731_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 SII_6731_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            SII_6731_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                SII_6731_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -772,8 +809,9 @@ Name                         Type         Units                         Descript
             SII_6731_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          SII_6731_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            SII_6731_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               SII_6731_CHI2      float32                               Reduced chi^2 of the line-fit.
+               SII_6731_CHI2      float32                               Chi-squared of the line-fit.
                SII_6731_NPIX        int32                               Number of pixels attributed to the emission line.
+           OII_7320_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 OII_7320_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            OII_7320_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                OII_7320_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -788,8 +826,9 @@ Name                         Type         Units                         Descript
             OII_7320_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          OII_7320_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            OII_7320_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               OII_7320_CHI2      float32                               Reduced chi^2 of the line-fit.
+               OII_7320_CHI2      float32                               Chi-squared of the line-fit.
                OII_7320_NPIX        int32                               Number of pixels attributed to the emission line.
+           OII_7330_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 OII_7330_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            OII_7330_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
                OII_7330_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -804,8 +843,9 @@ Name                         Type         Units                         Descript
             OII_7330_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
          OII_7330_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
            OII_7330_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-               OII_7330_CHI2      float32                               Reduced chi^2 of the line-fit.
+               OII_7330_CHI2      float32                               Chi-squared of the line-fit.
                OII_7330_NPIX        int32                               Number of pixels attributed to the emission line.
+          SIII_9069_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                SIII_9069_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
           SIII_9069_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
               SIII_9069_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -820,8 +860,9 @@ Name                         Type         Units                         Descript
            SIII_9069_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
         SIII_9069_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
           SIII_9069_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-              SIII_9069_CHI2      float32                               Reduced chi^2 of the line-fit.
+              SIII_9069_CHI2      float32                               Chi-squared of the line-fit.
               SIII_9069_NPIX        int32                               Number of pixels attributed to the emission line.
+          SIII_9532_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                SIII_9532_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
           SIII_9532_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
               SIII_9532_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
@@ -836,7 +877,7 @@ Name                         Type         Units                         Descript
            SIII_9532_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
         SIII_9532_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
           SIII_9532_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
-              SIII_9532_CHI2      float32                               Reduced chi^2 of the line-fit.
+              SIII_9532_CHI2      float32                               Chi-squared of the line-fit.
               SIII_9532_NPIX        int32                               Number of pixels attributed to the emission line.
 ============================ ============ ============================= ============================================
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1430,7 +1430,7 @@ class ContinuumTools(Filters, Inoue14):
 
     @staticmethod
     def call_nnls(modelflux, flux, ivar, xparam=None, debug=False,
-                  interpolate_coeff=False, xlabel=None, log=None):
+                  interpolate_coeff=False, xlabel=None, png=None, log=None):
         """Wrapper on nnls.
     
         Works with both spectroscopic and photometric input and with both 2D and
@@ -1480,11 +1480,14 @@ class ContinuumTools(Filters, Inoue14):
         
         try:
             imin = find_minima(chi2grid)[0]
-            xbest, xerr, chi2min, warn = minfit(xparam[imin-1:imin+2], chi2grid[imin-1:imin+2])
+            if debug:
+                xbest, xerr, chi2min, warn, (a, b, c) = minfit(xparam[imin-1:imin+2], chi2grid[imin-1:imin+2], return_coeff=True)
+            else:
+                xbest, xerr, chi2min, warn = minfit(xparam[imin-1:imin+2], chi2grid[imin-1:imin+2])
         except:
             errmsg = 'A problem was encountered minimizing chi2.'
             log.warning(errmsg)
-            imin, xbest, xerr, chi2min, warn = 0, 0.0, 0.0, 0.0, 1
+            imin, xbest, xerr, chi2min, warn, (a, b, c) = 0, 0.0, 0.0, 0.0, 1, (0., 0., 0.)
     
         if warn == 0:
             xivar = 1.0 / xerr**2
@@ -1510,29 +1513,37 @@ class ContinuumTools(Filters, Inoue14):
     
         if debug:
             if xivar > 0:
-                leg = r'${:.3f}\pm{:.3f}\ (\chi^2_{{min}}={:.2f})$'.format(xbest, 1/np.sqrt(xivar), chi2min)
+                leg = r'${:.1f}\pm{:.1f}$'.format(xbest, 1 / np.sqrt(xivar))
+                #leg = r'${:.3f}\pm{:.3f}\ (\chi^2_{{min}}={:.2f})$'.format(xbest, 1/np.sqrt(xivar), chi2min)
             else:
                 leg = r'${:.3f}$'.format(xbest)
                 
+            if xlabel:
+                leg = f'{xlabel} = {leg}'
+                
             import matplotlib.pyplot as plt
+            import seaborn as sns
+            sns.set(context='talk', style='ticks', font_scale=0.8)
             fig, ax = plt.subplots()
-            ax.scatter(xparam, chi2grid)
-            ax.scatter(xparam[imin-1:imin+2], chi2grid[imin-1:imin+2], color='red')
-            #ax.set_ylim(chi2min*0.95, np.max(chi2grid[imin-1:imin+2])*1.05)
-            #ax.plot(xx, np.polyval([aa, bb, cc], xx), ls='--')
-            ax.axvline(x=xbest, color='k')
-            if xivar > 0:
-                ax.axhline(y=chi2min, color='k')
-            #ax.set_yscale('log')
-            #ax.set_ylim(chi2min, 63.3)
+            ax.scatter(xparam, chi2grid-chi2min, marker='s', s=50, color='gray', edgecolor='k')
+            #ax.scatter(xparam[imin-1:imin+2], chi2grid[imin-1:imin+2]-chi2min, color='red')
+            if not np.all(np.array([a, b, c]) == 0):
+                ax.plot(xparam, np.polyval([a, b, c], xparam)-chi2min, lw=2, ls='--')
+            #ax.axvline(x=xbest, color='k')
+            #if xivar > 0:
+            #    ax.axhline(y=chi2min, color='k')
             if xlabel:
                 ax.set_xlabel(xlabel)
                 #ax.text(0.03, 0.9, '{}={}'.format(xlabel, leg), ha='left',
                 #        va='center', transform=ax.transAxes)
-            ax.text(0.03, 0.9, leg, ha='left', va='center', transform=ax.transAxes)
-            ax.set_ylabel(r'$\chi^2$')
+            ax.text(0.9, 0.9, leg, ha='right', va='center', transform=ax.transAxes)
+            ax.set_ylabel(r'$\Delta\chi^2$')
+            #ax.set_ylabel(r'$\chi^2 - {:.1f}$'.format(chi2min))
             #fig.savefig('qa-chi2min.png')
-            fig.savefig('desi-users/ioannis/tmp/qa-chi2min.png')
+            fig.tight_layout()
+            if png:
+                log.info(f'Writing {png}')
+                fig.savefig(png)
     
         return chi2min, xbest, xivar, bestcoeff
 
@@ -1742,7 +1753,7 @@ class ContinuumTools(Filters, Inoue14):
         return kcorr, absmag, ivarabsmag, bestmaggies, lums, cfluxes
 
 def continuum_specfit(data, result, templatecache, nophoto=False, constrain_age=False,
-                      fastphot=False, log=None, verbose=False):
+                      fastphot=False, log=None, verbose=False, debug_plots=False):
     """Fit the non-negative stellar continuum of a single spectrum.
 
     Parameters
@@ -1905,9 +1916,10 @@ def continuum_specfit(data, result, templatecache, nophoto=False, constrain_age=
             vdispchi2min, vdispbest, vdispivar, _ = CTools.call_nnls(
                 ztemplateflux_vdisp[Ivdisp, :, :], 
                 specflux[Ivdisp], specivar[Ivdisp],
-                xparam=templatecache['vdisp'], xlabel=r'$\sigma$ (km/s)', debug=False, log=log)
+                xparam=templatecache['vdisp'], xlabel=r'$\sigma$ (km/s)', log=log,
+                debug=debug_plots, png='deltachi2-vdisp.png')
             log.info('Fitting for the velocity dispersion took {:.2f} seconds.'.format(time.time()-t0))
-
+            
             if vdispivar > 0:
                 # Require vdisp to be measured with S/N>1, which protects
                 # against tiny ivar becomming infinite in the output table.

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -14,61 +14,6 @@ from astropy.table import Table
 from fastspecfit.io import FLUXNORM
 from fastspecfit.util import C_LIGHT
 
-#import numba
-#@numba.jit(nopython=True)
-def nnls(A, b, maxiter=None, eps=1e-7, v=False):
-    # https://en.wikipedia.org/wiki/Non-negative_least_squares#Algorithms
-    # not sure what eps should be set to
-    m, n = A.shape
-    if b.shape[0] != m:
-        raise ValueError()#f"Shape mismatch: {A.shape} {b.shape}. Expected: (m, n) (m) ")
-    if maxiter is None:
-        # this is what scipy does when maxiter is not specified
-        maxiter = 3 * n
-    # init
-    P = np.zeros(n).astype(bool)
-    R = np.ones(n).astype(bool)
-    x = np.zeros(n)
-    s = np.zeros(n)
-    # compute these once ahead of time
-    ATA = A.T.dot(A)
-    ATb = A.T.dot(b)
-    # main loop
-    w = ATb - ATA.dot(x)
-    j = np.argmax(R * w)
-    c = 0 # iteration count
-    # while R != {} and max(w[R]) > eps
-    while np.any(R) and w[j] > eps:
-        #if v: print(f"{c=}", f"{P=}\n {R=}\n {w=}\n {j=}")
-        # add j to P, remove j from R
-        P[j], R[j] = True, False
-        s[P] = np.linalg.inv(ATA[P][:, P]).dot(ATb[P])
-        s[R] = 0
-        d = 0 # inner loop iteration count, for debugging
-        #if v: print(f"{c=}", f"{P=}\n {R=}\n {s=}")
-        # while P != {} and min(s[P]) < eps
-        # make sure P is not empty before checking min s[P]
-        while np.any(P) and np.min(s[P]) < eps:
-            i = P & (s < eps)
-            #if v: print(f" {d=}", f"  {P=}\n  {i=}\n  {s=}\n  {x=}")
-            a = np.min(x[i] / (x[i] - s[i]))
-            x = x + a * (s - x)
-            j = P & (x < eps)
-            R[j], P[j] = True, False
-            s[P] = np.linalg.inv(ATA[P][:, P]).dot(ATb[P])
-            s[R] = 0
-            d += 1
-        x[:] = s
-        # w = A.T.dot(b - A.dot(x))
-        w = ATb - ATA.dot(x)
-        j = np.argmax(R * w)
-        #if v: print(f"{c=}", f"{P=}\n {R=}\n {w=}\n {j=}")
-        c += 1
-        if c >= maxiter:
-            break
-    res = np.linalg.norm(A.dot(x) - b)
-    return x, res
-
 def _smooth_continuum(wave, flux, ivar, redshift, medbin=150, 
                       smooth_window=50, smooth_step=10, maskkms_uv=3000.0, 
                       maskkms_balmer=1000.0, maskkms_narrow=200.0,

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -74,7 +74,7 @@ def build_emline_model(log10wave, redshift, lineamps, linevshifts, linesigmas,
     else:
         for icam, campix in enumerate(camerapix):
             _emlinemodel = trapz_rebin(10**log10wave, log10model, emlinewave[campix[0]:campix[1]])
-            _emlinemomdel = resolution_matrix[icam].dot(_emlinemodel)
+            _emlinemodel = resolution_matrix[icam].dot(_emlinemodel)
             emlinemodel.append(_emlinemodel)
         return np.hstack(emlinemodel)
 
@@ -854,8 +854,9 @@ class EMFitTools(Filters):
         # line-amplitude is dropped, too (see MgII 2796 on
         # sv1-bright-17680-39627622543528153).
         drop2 = np.zeros(len(parameters), bool)
-        drop2[Ifree] = parameters[Ifree] == linemodel['value'][Ifree]
-        drop2 *= notfixed
+        if False:
+            drop2[Ifree] = parameters[Ifree] == linemodel['value'][Ifree]
+            drop2 *= notfixed
         
         sigmadropped = np.where(self.sigma_param_bool * drop2)[0]
         if len(sigmadropped) > 0:
@@ -939,30 +940,19 @@ class EMFitTools(Filters):
                         model_resamp = trapz_rebin(10**self.log10wave, log10model, _emlinewave[icam])
                         model_convol = resolution_matrix[icam].dot(model_resamp)
                         out_linemodel['obsvalue'][lineindx] = np.max(model_convol)
-                        if out_linemodel[lineindx]['param_name'] == 'oiii_5007_amp':
-                            data = [[10**self.log10wave, log10model], [_emlinewave[icam], model_resamp], [_emlinewave[icam], model_convol]]
-                            #import matplotlib.pyplot as plt
-                            #plt.clf()
-                            #plt.plot(10**self.log10wave, log10model)
-                            #plt.plot(_emlinewave[icam], model_resamp)
-                            #plt.plot(_emlinewave[icam], model_convol)
-                            #plt.xlim(np.min(10**self.log10wave[J]), np.max(10**self.log10wave[J]))
-                            #plt.savefig('desi-users/ioannis/tmp/junk.png')
-                            #pdb.set_trace()
-
-            if True:
-                bestfit = self.bestfit(out_linemodel, redshift, emlinewave, resolution_matrix, camerapix)
-                import matplotlib.pyplot as plt
-                plt.clf()
-                plt.plot(emlinewave, emlineflux, label='data', color='gray', lw=4)
-                plt.plot(emlinewave, bestfit, label='bestfit', ls='--', lw=3, alpha=0.7, color='k')
-                plt.plot(data[0][0], data[0][1], label='hires model')
-                plt.plot(data[1][0], data[1][1], label='resamp')
-                plt.plot(data[2][0], data[2][1], label='convol', lw=2)
-                plt.xlim(5386, 5394)
-                plt.legend()
-                plt.savefig('desi-users/ioannis/tmp/junk.png')
-                pdb.set_trace()
+                        #if out_linemodel[lineindx]['param_name'] == 'oiii_5007_amp':
+                        #    import matplotlib.pyplot as plt
+                        #    bestfit = self.bestfit(out_linemodel, redshift, emlinewave, resolution_matrix, camerapix)
+                        #    plt.clf()
+                        #    plt.plot(emlinewave, emlineflux, label='data', color='gray', lw=4)
+                        #    plt.plot(emlinewave, bestfit, label='bestfit', ls='--', lw=3, alpha=0.7, color='k')
+                        #    plt.plot(10**self.log10wave, log10model, label='hires model')
+                        #    plt.plot(_emlinewave[icam], model_resamp, label='resamp')
+                        #    plt.plot(_emlinewave[icam], model_convol, label='convol', lw=2)
+                        #    plt.xlim(5386, 5394)
+                        #    plt.legend()
+                        #    plt.savefig('desi-users/ioannis/tmp/junk.png')
+                        #    pdb.set_trace()
         
         return out_linemodel
 
@@ -2412,7 +2402,7 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
     t0 = time.time()
     initfit = EMFit.optimize(initial_linemodel_nobroad, emlinewave, emlineflux, 
                              weights, redshift, resolution_matrix, camerapix, 
-                             log=log, debug=False)
+                             log=log, debug=False, get_finalamp=False)
     initmodel = EMFit.bestfit(initfit, redshift, emlinewave, resolution_matrix, camerapix)
     initchi2 = EMFit.chi2(initfit, emlinewave, emlineflux, emlineivar, initmodel)
     nfree = np.sum((initfit['fixed'] == False) * (initfit['tiedtoparam'] == -1))

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -68,7 +68,7 @@ def build_emline_model(log10wave, redshift, lineamps, linevshifts, linesigmas,
     if camerapix is None:
         for icam, specwave in enumerate(emlinewave):
             _emlinemodel = trapz_rebin(10**log10wave, log10model, specwave)
-            _emlinemomdel = resolution_matrix[icam].dot(_emlinemodel)
+            _emlinemodel = resolution_matrix[icam].dot(_emlinemodel)
             emlinemodel.append(_emlinemodel)
         return emlinemodel
     else:

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1153,11 +1153,8 @@ class EMFitTools(Filters):
                         #result['{}_FLUX_IVAR'.format(linename)] = flux_ivar # * u.second**2*u.cm**4/u.erg**2
                         
                         result['{}_FLUX_IVAR'.format(linename)] = boxflux_ivar # * u.second**2*u.cm**4/u.erg**2
-                        
-                        dof = npix - 3 # ??? [redshift, sigma, and amplitude]
-                        chi2 = np.sum(emlineivar[lineindx]*(emlineflux[lineindx]-finalmodel[lineindx])**2) / dof
-    
-                        result['{}_CHI2'.format(linename)] = chi2
+
+                        result['{}_CHI2'.format(linename)] = np.sum(emlineivar[lineindx] * (emlineflux[lineindx] - finalmodel[lineindx])**2)
     
                         # keep track of sigma and z but only using XX-sigma lines
                         linesnr = result['{}_AMP'.format(linename)] * np.sqrt(result['{}_AMP_IVAR'.format(linename)])

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -19,9 +19,8 @@ def read_emlines():
     """Read the set of emission lines of interest.
 
     """
-    from pkg_resources import resource_filename
-    
-    linefile = resource_filename('fastspecfit', 'data/emlines.ecsv')    
+    from importlib import resources
+    linefile = resources.files('fastspecfit').joinpath('data/emlines.ecsv')
     linetable = Table.read(linefile, format='ascii.ecsv', guess=False)
     
     return linetable    

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1028,10 +1028,15 @@ class EMFitTools(Filters):
             linesigma_ang = linesigma * linezwave / C_LIGHT    # [observed-frame Angstrom]
             #log10sigma = linesigma / C_LIGHT / np.log(10)     # line-width [log-10 Angstrom]            
 
+            if linesigma_ang < 2.:
+                linesigma_ang_window = 2.
+            else:
+                linesigma_ang_window = linesigma_ang
+
             # Are the pixels based on the original inverse spectrum fully
             # masked? If so, set everything to zero and move onto the next line.
-            lineindx = np.where((emlinewave >= (linezwave - 3.0*linesigma_ang)) *
-                                (emlinewave <= (linezwave + 3.0*linesigma_ang)))[0]
+            lineindx = np.where((emlinewave >= (linezwave - 3.0*linesigma_ang_window)) *
+                                (emlinewave <= (linezwave + 3.0*linesigma_ang_window)))[0]
             
             if len(lineindx) > 0 and np.sum(oemlineivar[lineindx] == 0) / len(lineindx) > 0.3: # use original ivar
                 result['{}_AMP'.format(linename)] = 0.0
@@ -1039,8 +1044,8 @@ class EMFitTools(Filters):
                 result['{}_SIGMA'.format(linename)] = 0.0
             else:
                 # number of pixels, chi2, and boxcar integration
-                lineindx = np.where((emlinewave >= (linezwave - 3.0*linesigma_ang)) *
-                                    (emlinewave <= (linezwave + 3.0*linesigma_ang)) *
+                lineindx = np.where((emlinewave >= (linezwave - 3.0*linesigma_ang_window)) *
+                                    (emlinewave <= (linezwave + 3.0*linesigma_ang_window)) *
                                     (emlineivar > 0))[0]
     
                 # can happen if sigma is very small (depending on the wavelength)
@@ -1144,12 +1149,12 @@ class EMFitTools(Filters):
                                 narrow_redshifts.append(linez)
     
                 # next, get the continuum, the inverse variance in the line-amplitude, and the EW
-                indxlo = np.where((emlinewave > (linezwave - 10*linesigma * linezwave / C_LIGHT)) *
-                                  (emlinewave < (linezwave - 3.*linesigma * linezwave / C_LIGHT)) *
+                indxlo = np.where((emlinewave > (linezwave - 10*linesigma_ang_window)) *
+                                  (emlinewave < (linezwave - 3.*linesigma_ang_window)) *
                                   (oemlineivar > 0))[0]
                                   #(finalmodel == 0))[0]
-                indxhi = np.where((emlinewave < (linezwave + 10*linesigma * linezwave / C_LIGHT)) *
-                                  (emlinewave > (linezwave + 3.*linesigma * linezwave / C_LIGHT)) *
+                indxhi = np.where((emlinewave < (linezwave + 10*linesigma_ang_window)) *
+                                  (emlinewave > (linezwave + 3.*linesigma_ang_window)) *
                                   (oemlineivar > 0))[0]
                                   #(finalmodel == 0))[0]
                 indx = np.hstack((indxlo, indxhi))
@@ -1200,7 +1205,7 @@ class EMFitTools(Filters):
                 #log.debug(' ')
     
             ## simple QA
-            #if linename == 'OIII_5007':
+            #if linename == 'OIII_4363':
             #    import matplotlib.pyplot as plt
             #    _indx = np.arange(indx[-1]-indx[0])+indx[0]
             #    # continuum bandpasses and statistics

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1250,33 +1250,33 @@ class EMFitTools(Filters):
                 print()
                 #log.debug(' ')
     
-            # simple QA
-            if linename == 'OIII_5007':
-                import matplotlib.pyplot as plt
-                _indx = np.arange(indx[-1]-indx[0])+indx[0]
-                # continuum bandpasses and statistics
-                plt.clf()
-                plt.plot(emlinewave[_indx], specflux_nolines[_indx], color='gray')
-                plt.scatter(emlinewave[indx], specflux_nolines[indx], color='red')
-                plt.axhline(y=cmed, color='k')
-                plt.axhline(y=cmed+1/np.sqrt(civar), color='k', ls='--')
-                plt.axhline(y=cmed-1/np.sqrt(civar), color='k', ls='--')
-                plt.savefig('desi-users/ioannis/tmp/junk.png')
-            
-                # emission-line integration
-                plt.clf()
-                plt.plot(emlinewave[_indx], emlineflux[_indx], color='gray')
-                plt.plot(emlinewave[_indx], finalmodel[_indx], color='red')
-                #plt.plot(emlinewave[_indx], specflux_nolines[_indx], color='orange', alpha=0.5)
-                plt.axvline(x=emlinewave[lineindx[0]], color='blue')
-                plt.axvline(x=emlinewave[lineindx[-1]], color='blue')
-                plt.axhline(y=0, color='k', ls='--')
-                plt.axhline(y=amp_sigma, color='k', ls='--')
-                plt.axhline(y=2*amp_sigma, color='k', ls='--')
-                plt.axhline(y=3*amp_sigma, color='k', ls='--')
-                plt.axhline(y=result['{}_AMP'.format(linename)], color='k', ls='-')
-                plt.savefig('desi-users/ioannis/tmp/junk2.png')
-                pdb.set_trace()
+            ## simple QA
+            #if linename == 'OIII_5007':
+            #    import matplotlib.pyplot as plt
+            #    _indx = np.arange(indx[-1]-indx[0])+indx[0]
+            #    # continuum bandpasses and statistics
+            #    plt.clf()
+            #    plt.plot(emlinewave[_indx], specflux_nolines[_indx], color='gray')
+            #    plt.scatter(emlinewave[indx], specflux_nolines[indx], color='red')
+            #    plt.axhline(y=cmed, color='k')
+            #    plt.axhline(y=cmed+1/np.sqrt(civar), color='k', ls='--')
+            #    plt.axhline(y=cmed-1/np.sqrt(civar), color='k', ls='--')
+            #    plt.savefig('desi-users/ioannis/tmp/junk.png')
+            #
+            #    # emission-line integration
+            #    plt.clf()
+            #    plt.plot(emlinewave[_indx], emlineflux[_indx], color='gray')
+            #    plt.plot(emlinewave[_indx], finalmodel[_indx], color='red')
+            #    #plt.plot(emlinewave[_indx], specflux_nolines[_indx], color='orange', alpha=0.5)
+            #    plt.axvline(x=emlinewave[lineindx[0]], color='blue')
+            #    plt.axvline(x=emlinewave[lineindx[-1]], color='blue')
+            #    plt.axhline(y=0, color='k', ls='--')
+            #    plt.axhline(y=amp_sigma, color='k', ls='--')
+            #    plt.axhline(y=2*amp_sigma, color='k', ls='--')
+            #    plt.axhline(y=3*amp_sigma, color='k', ls='--')
+            #    plt.axhline(y=result['{}_AMP'.format(linename)], color='k', ls='-')
+            #    plt.savefig('desi-users/ioannis/tmp/junk2.png')
+            #    pdb.set_trace()
 
         # Clean up the doublets whose amplitudes were tied in the fitting since
         # they may have been zeroed out in the clean-up, above. This should be
@@ -2123,9 +2123,6 @@ class EMFitTools(Filters):
                 emlinesigma = emlinesigma[good]
                 emlinemodel = emlinemodel[good]
         
-                #if icam == 0:
-                #    import matplotlib.pyplot as plt ; plt.clf() ; plt.plot(emlinewave, emlineflux) ; plt.plot(emlinewave, emlinemodel) ; plt.xlim(4180, 4210) ; plt.ylim(-15, 17) ; plt.savefig('desi-users/ioannis/tmp/junkg.png')
-                    
                 emlinemodel_oneline = []
                 for desiemlines_oneline1 in desiemlines_oneline:
                     emlinemodel_oneline.append(desiemlines_oneline1[icam][good])

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1084,8 +1084,8 @@ class EMFitTools(Filters):
             linesigma_ang = linesigma * linezwave / C_LIGHT    # [observed-frame Angstrom]
 
             # require at least 3 pixels
-            if linesigma_ang < 3 * dpixwave:
-                linesigma_ang_window = 3 * dpixwave
+            if linesigma_ang < 2 * dpixwave:
+                linesigma_ang_window = 2 * dpixwave
             else:
                 linesigma_ang_window = linesigma_ang
 
@@ -2421,7 +2421,8 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
 
         t0 = time.time()
         broadfit = EMFit.optimize(initial_linemodel, emlinewave, emlineflux, weights, 
-                                  redshift, resolution_matrix, camerapix, log=log, debug=False)
+                                  redshift, resolution_matrix, camerapix, log=log,
+                                  debug=False, get_finalamp=True)
         broadmodel = EMFit.bestfit(broadfit, redshift, emlinewave, resolution_matrix, camerapix)
         broadchi2 = EMFit.chi2(broadfit, emlinewave, emlineflux, emlineivar, broadmodel)
         nfree = np.sum((broadfit['fixed'] == False) * (broadfit['tiedtoparam'] == -1))
@@ -2444,7 +2445,8 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
         sigdrop1 = (broadfit[Habroad]['value'] <= broadfit[broadfit['param_name'] == 'halpha_sigma']['value'])[0]
         sigdrop2 = broadfit[Habroad]['value'][0] < EMFit.minsigma_balmer_broad
 
-        ampsnr = broadfit[Bbroad]['value'].data * np.sqrt(broadfit[Bbroad]['civar'].data)
+        ampsnr = broadfit[Bbroad]['obsvalue'].data * np.sqrt(broadfit[Bbroad]['civar'].data)
+        #ampdrop = np.any(ampsnr[-1:] < EMFit.minsnr_balmer_broad)
         ampdrop = np.any(ampsnr[-2:] < EMFit.minsnr_balmer_broad)
 
         #W = (initfit['fixed'] == False) * (initfit['tiedtoparam']==-1)

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1105,37 +1105,9 @@ class EMFitTools(Filters):
                                     (emlinewave <= (linezwave + 3.0*linesigma_ang_window)) *
                                     (emlineivar > 0))[0]
 
-                ## can happen if sigma is very small (depending on the wavelength)
-                #if (linezwave > np.min(emlinewave)) * (linezwave < np.max(emlinewave)) * (len(lineindx) < nminpix):
-                #
-                #    linesigma_ang2 = self.limitsigma_narrow * linezwave / C_LIGHT    # [observed-frame Angstrom]
-                #    lineindx = np.where((emlinewave >= (linezwave - 3.0*linesigma_ang2)) *
-                #                        (emlinewave <= (linezwave + 3.0*linesigma_ang2)))[0]
-                #
-                #    good = oemlineivar[lineindx] > 0 # use the original ivar
-                #    if np.any(good):
-                #        lineindx = np.atleast_1d(lineindx[good])
-                #    else:
-                #        lineindx = np.array([])
-                #    
-                #    #dwave = emlinewave - linezwave
-                #    #lineindx = np.argmin(np.abs(dwave)) + (np.arange(npad+1) - npad//2) # +/- NPAD-pixel pad
-                #    #
-                #    ## check to make sure we don't hit the edges and also trim
-                #    ## out padded pixels with ivar==0
-                #    #good = (lineindx >= 0) * (lineindx < len(emlineivar))
-                #    #if np.any(good):
-                #    #    lineindx = lineindx[good]
-                #    #    good = oemlineivar[lineindx] > 0 # use the original ivar
-                #    #    if np.any(good):
-                #    #        lineindx = np.atleast_1d(lineindx[good])
-                #    #    else:
-                #    #        lineindx = np.array([])
-    
                 npix = len(lineindx)
                 result['{}_NPIX'.format(linename)] = npix
     
-                #if npix >= nminpix: # magic number: required at least XX unmasked pixels centered on the line
                 if npix >= nminpix: # magic number: required at least XX unmasked pixels centered on the line
                     
                     if np.any(emlineivar[lineindx] == 0):
@@ -1182,14 +1154,6 @@ class EMFitTools(Filters):
                         
                         result['{}_FLUX_IVAR'.format(linename)] = boxflux_ivar # * u.second**2*u.cm**4/u.erg**2
                         
-                        ##if linename == 'OII_3729':
-                        #_indx = np.arange((lineindx[-1]+20)-(lineindx[0]-20))+(lineindx[0]-20)
-                        #import matplotlib.pyplot as plt
-                        #plt.clf()
-                        #plt.plot(emlinewave[_indx], emlineflux[_indx], color='gray')
-                        #plt.plot(emlinewave[_indx], lineprofile[_indx], color='red')
-                        #plt.savefig('desi-users/ioannis/tmp/junk-{}.png'.format(linename))
-
                         dof = npix - 3 # ??? [redshift, sigma, and amplitude]
                         chi2 = np.sum(emlineivar[lineindx]*(emlineflux[lineindx]-finalmodel[lineindx])**2) / dof
     
@@ -1221,20 +1185,6 @@ class EMFitTools(Filters):
                                   #(finalmodel == 0))[0]
                 indx = np.hstack((indxlo, indxhi))
 
-                #    dwave = emlinewave - linezwave
-                #    lineindx = np.argmin(np.abs(dwave)) + (np.arange(npad+1) - npad//2) # +/- NPAD-pixel pad
-                #
-                #    # check to make sure we don't hit the edges and also trim
-                #    # out padded pixels with ivar==0
-                #    good = (lineindx >= 0) * (lineindx < len(emlineivar))
-                #    if np.any(good):
-                #        lineindx = lineindx[good]
-                #        good = oemlineivar[lineindx] > 0 # use the original ivar
-                #        if np.any(good):
-                #            lineindx = np.atleast_1d(lineindx[good])
-                #        else:
-                #            lineindx = np.array([])
-                
                 if len(indx) >= nminpix: # require at least XX pixels to get the continuum level
                     #_, cmed, csig = sigma_clipped_stats(specflux_nolines[indx], sigma=3.0)
                     clipflux, _, _ = sigmaclip(specflux_nolines[indx], low=3, high=3)

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1075,8 +1075,8 @@ class EMFitTools(Filters):
                         raise ValueError(errmsg)
                         
                     # boxcar integration of the flux; should we weight by the line-profile???
-                    boxflux = np.sum(emlineflux[lineindx])                
-                    boxflux_ivar = 1 / np.sum(1 / emlineivar[lineindx])
+                    boxflux = np.trapz(emlineflux[lineindx], x=emlinewave[lineindx])
+                    boxflux_ivar = 1 / np.trapz(1 / emlineivar[lineindx], x=emlinewave[lineindx])
     
                     result['{}_BOXFLUX'.format(linename)] = boxflux # * u.erg/(u.second*u.cm**2)
                     result['{}_BOXFLUX_IVAR'.format(linename)] = boxflux_ivar # * u.second**2*u.cm**4/u.erg**2
@@ -1159,7 +1159,7 @@ class EMFitTools(Filters):
                                   #(finalmodel == 0))[0]
                 indx = np.hstack((indxlo, indxhi))
     
-                if len(indx) >= 3: # require at least XX pixels to get the continuum level
+                if len(indx) >= nminpix: # require at least XX pixels to get the continuum level
                     #_, cmed, csig = sigma_clipped_stats(specflux_nolines[indx], sigma=3.0)
                     clipflux, _, _ = sigmaclip(specflux_nolines[indx], low=3, high=3)
                     # corner case: if a portion of a camera is masked

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -643,7 +643,7 @@ def qa_fastspec(data, templatecache, fastspec, metadata, coadd_type='healpix',
             amp = fastspec['{}_MODELAMP'.format(linename)]
             if amp != 0:
                 desiemlines_oneline1 = build_emline_model(
-                    EMFit.log10wave, redshift, np.array([amp]),
+                    EMFit.dlog10wave, redshift, np.array([amp]),
                     np.array([fastspec['{}_VSHIFT'.format(linename)]]),
                     np.array([fastspec['{}_SIGMA'.format(linename)]]),
                     np.array([oneline['restwave']]), data['wave'], data['res'])

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -640,7 +640,7 @@ def qa_fastspec(data, templatecache, fastspec, metadata, coadd_type='healpix',
          
         for oneline in EMFit.linetable[inrange]: # for all lines in range
             linename = oneline['name'].upper()
-            amp = fastspec['{}_AMP'.format(linename)]
+            amp = fastspec['{}_MODELAMP'.format(linename)]
             if amp != 0:
                 desiemlines_oneline1 = build_emline_model(
                     EMFit.log10wave, redshift, np.array([amp]),

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -40,7 +40,8 @@ def _assign_units_to_columns(fastfit, metadata, Spec, templates, fastphot, stack
 
 def fastspec_one(iobj, data, out, meta, templates, log=None,
                  minspecwave=3500., maxspecwave=9900., broadlinefit=True,
-                 fastphot=False, stackfit=False, nophoto=False, percamera_models=False):
+                 fastphot=False, stackfit=False, nophoto=False,
+                 percamera_models=False, debug_plots=False):
     """Multiprocessing wrapper to run :func:`fastspec` on a single object.
 
     """
@@ -60,7 +61,7 @@ def fastspec_one(iobj, data, out, meta, templates, log=None,
 
     continuummodel, smooth_continuum = continuum_specfit(data, out, templatecache,
                                                          fastphot=fastphot, nophoto=nophoto,
-                                                         log=log)
+                                                         debug_plots=debug_plots, log=log)
 
     # Optionally fit the emission-line spectrum.
     if fastphot:
@@ -125,6 +126,7 @@ def parse(options=None, log=None):
     parser.add_argument('--mapdir', type=str, default=None, help='Optional directory name for the dust maps.')
     parser.add_argument('--dr9dir', type=str, default=None, help='Optional directory name for the DR9 photometry.')
     parser.add_argument('--specproddir', type=str, default=None, help='Optional directory name for the spectroscopic production.')
+    parser.add_argument('--debug-plots', action='store_true', help='Generate a variety of debugging plots (written to $PWD).')
     parser.add_argument('--verbose', action='store_true', help='Be verbose (for debugging purposes).')
 
     if log is None:
@@ -225,7 +227,7 @@ def fastspec(fastphot=False, stackfit=False, args=None, comm=None, verbose=False
     t0 = time.time()
     fitargs = [(iobj, data[iobj], out[iobj], meta[iobj], templates, log,
                 minspecwave, maxspecwave, args.broadlinefit, fastphot, stackfit,
-                args.nophoto, args.percamera_models)
+                args.nophoto, args.percamera_models, args.debug_plots)
                 for iobj in np.arange(Spec.ntargets)]
     if args.mp > 1:
         import multiprocessing

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1739,7 +1739,7 @@ def read_fastspecfit(fastfitfile, rows=None, columns=None, read_models=False):
 
         # Add specprod to the metadata table so that we can stack across
         # productions (e.g., Fuji+Guadalupe).
-        hdr = fitsio.read_header(fastfitfile, ext='PRIMARY')
+        hdr = fitsio.read_header(fastfitfile, ext=0)
         if 'SPECPROD' in hdr:
             specprod = hdr['SPECPROD']
             meta['SPECPROD'] = specprod

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1661,6 +1661,8 @@ def init_fastspec_output(input_meta, specprod, templates=None, ncoeff=None,
 
         for line in linetable['name']:
             line = line.upper()
+            out.add_column(Column(name='{}_MODELAMP'.format(line), length=nobj, dtype='f4',
+                                  unit=10**(-17)*u.erg/(u.second*u.cm**2*u.Angstrom)))
             out.add_column(Column(name='{}_AMP'.format(line), length=nobj, dtype='f4',
                                   unit=10**(-17)*u.erg/(u.second*u.cm**2*u.Angstrom)))
             out.add_column(Column(name='{}_AMP_IVAR'.format(line), length=nobj, dtype='f4',

--- a/py/fastspecfit/util.py
+++ b/py/fastspecfit/util.py
@@ -231,7 +231,7 @@ def find_minima(x):
     return ii[jj]
 
 
-def minfit(x, y):
+def minfit(x, y, return_coeff=False):
     """Fits y = y0 + ((x-x0)/xerr)**2
 
     See redrock.zwarning.ZWarningMask.BAD_MINFIT for zwarn failure flags
@@ -244,17 +244,27 @@ def minfit(x, y):
         (tuple):  (x0, xerr, y0, zwarn) where zwarn=0 is good fit.
 
     """
+    a, b, c = 0., 0., 0.
     if len(x) < 3:
-        return (-1,-1,-1,ZWarningMask.BAD_MINFIT)
+        if return_coeff:
+            return (-1,-1,-1,ZWarningMask.BAD_MINFIT,(a,b,c))
+        else:
+            return (-1,-1,-1,ZWarningMask.BAD_MINFIT)
 
     try:
         #- y = a x^2 + b x + c
         a,b,c = np.polyfit(x,y,2)
     except np.linalg.LinAlgError:
-        return (-1,-1,-1,ZWarningMask.BAD_MINFIT)
+        if return_coeff:
+            return (-1,-1,-1,ZWarningMask.BAD_MINFIT,(a,b,c))
+        else:
+            return (-1,-1,-1,ZWarningMask.BAD_MINFIT)
 
     if a == 0.0:
-        return (-1,-1,-1,ZWarningMask.BAD_MINFIT)
+        if return_coeff:
+            return (-1,-1,-1,ZWarningMask.BAD_MINFIT,(a,b,c))
+        else:
+            return (-1,-1,-1,ZWarningMask.BAD_MINFIT)
 
     #- recast as y = y0 + ((x-x0)/xerr)^2
     x0 = -b / (2*a)
@@ -272,7 +282,10 @@ def minfit(x, y):
         xerr = 1 / np.sqrt(-a)
         zwarn |= ZWarningMask.BAD_MINFIT
 
-    return (x0, xerr, y0, zwarn)
+    if return_coeff:
+        return (x0, xerr, y0, zwarn,(a,b,c))
+    else:
+        return (x0, xerr, y0, zwarn)
 
 class TabulatedDESI(object):
     """

--- a/py/fastspecfit/util.py
+++ b/py/fastspecfit/util.py
@@ -292,8 +292,8 @@ class TabulatedDESI(object):
 
     """
     def __init__(self):
-        from pkg_resources import resource_filename
-        cosmofile = resource_filename('fastspecfit', 'data/desi_fiducial_cosmology.dat')
+        from importlib import resources
+        cosmofile = resources.files('fastspecfit').joinpath('data/desi_fiducial_cosmology.dat')
 
         self._z, self._efunc, self._comoving_radial_distance = np.loadtxt(cosmofile, comments='#', usecols=None, unpack=True)
 

--- a/sandbox/nnls.py
+++ b/sandbox/nnls.py
@@ -1,0 +1,55 @@
+#import numba
+#@numba.jit(nopython=True)
+def nnls(A, b, maxiter=None, eps=1e-7, v=False):
+    # https://en.wikipedia.org/wiki/Non-negative_least_squares#Algorithms
+    # not sure what eps should be set to
+    m, n = A.shape
+    if b.shape[0] != m:
+        raise ValueError()#f"Shape mismatch: {A.shape} {b.shape}. Expected: (m, n) (m) ")
+    if maxiter is None:
+        # this is what scipy does when maxiter is not specified
+        maxiter = 3 * n
+    # init
+    P = np.zeros(n).astype(bool)
+    R = np.ones(n).astype(bool)
+    x = np.zeros(n)
+    s = np.zeros(n)
+    # compute these once ahead of time
+    ATA = A.T.dot(A)
+    ATb = A.T.dot(b)
+    # main loop
+    w = ATb - ATA.dot(x)
+    j = np.argmax(R * w)
+    c = 0 # iteration count
+    # while R != {} and max(w[R]) > eps
+    while np.any(R) and w[j] > eps:
+        #if v: print(f"{c=}", f"{P=}\n {R=}\n {w=}\n {j=}")
+        # add j to P, remove j from R
+        P[j], R[j] = True, False
+        s[P] = np.linalg.inv(ATA[P][:, P]).dot(ATb[P])
+        s[R] = 0
+        d = 0 # inner loop iteration count, for debugging
+        #if v: print(f"{c=}", f"{P=}\n {R=}\n {s=}")
+        # while P != {} and min(s[P]) < eps
+        # make sure P is not empty before checking min s[P]
+        while np.any(P) and np.min(s[P]) < eps:
+            i = P & (s < eps)
+            #if v: print(f" {d=}", f"  {P=}\n  {i=}\n  {s=}\n  {x=}")
+            a = np.min(x[i] / (x[i] - s[i]))
+            x = x + a * (s - x)
+            j = P & (x < eps)
+            R[j], P[j] = True, False
+            s[P] = np.linalg.inv(ATA[P][:, P]).dot(ATb[P])
+            s[R] = 0
+            d += 1
+        x[:] = s
+        # w = A.T.dot(b - A.dot(x))
+        w = ATb - ATA.dot(x)
+        j = np.argmax(R * w)
+        #if v: print(f"{c=}", f"{P=}\n {R=}\n {w=}\n {j=}")
+        c += 1
+        if c >= maxiter:
+            break
+    res = np.linalg.norm(A.dot(x) - b)
+    return x, res
+


### PR DESCRIPTION
@yuvoonng

This PR addresses #124 by requiring more pixels when estimating the variance in the continuum around narrow emission lines, which more realistically helps identify lower signal-to-noise ratio lines. Previously, I required a minimum of just 3 pixels around each emission line; now I require 8.

Using the sample of 40 objects in #124, here are the new S/N distributions for [OIII] 4363:

<img width="995" alt="Screenshot 2023-07-25 at 12 34 20 PM" src="https://github.com/desihub/fastspecfit/assets/1431820/4dbeec72-db42-4d0b-9492-3833f263cb36">

And here are some numbers (where `v1==Iron/v1.0` and `v2==this branch`.

Note that the final numbers may be affected by whatever we decide to do about #127, but nevertheless I'm planning to merge this PR as "the right thing to do" regardless.

```
     TARGETID     HEALPIX OIII_4363_AMP_V1 OIII_4363_AMP_SNR_V1 OIII_4363_AMP_V2 OIII_4363_AMP_SNR_V2 OIII_4363_FLUX_V1 OIII_4363_FLUX_SNR_V1 OIII_4363_FLUX_V2 OIII_4363_FLUX_SNR_V2 OIII_4363_NPIX_V1 OIII_4363_NPIX_V2
----------------- ------- ---------------- -------------------- ---------------- -------------------- ----------------- --------------------- ----------------- --------------------- ----------------- -----------------
39627474161632453   22658       0.80158347             5.891087       0.80158395            2.9583058        0.92319894             1.9468902        0.92283833             1.9461436                 4                11
39627618634434462   26747        0.6733961             5.064175       0.67379916            2.1789978         0.9386274             1.8015784        0.93921065             1.8025398                 4                11
39627637492024014   25867       0.79047346             8.422631       0.79109126            5.2172384         1.2159652             1.9418195         1.2169718             1.9434173                 5                11
39627654223107867   40932       0.78591675             9.234115        0.7847825            1.6301938         1.0199049             1.6069658         1.0184418             1.6046405                 4                11
39627666319479872   40921       0.81066114            7.5306277         0.810805            2.6544473        0.91887105             1.5535815          0.919182             1.5541008                 4                11
39627669842691869   18725        0.5316252            5.3706093        0.5355014             1.976125         0.7802198              1.819081        0.78486264             1.8299139                 4                11
39627670027243211   17381       0.46667323             9.136572       0.46973577            2.7710958         0.7375257             1.2820904        0.74322593             1.2921442                 4                11
39627690789048629   26843       0.44732478             5.195497       0.44594648            1.7869822         0.7357093               1.20796         0.7334782             1.2042744                 5                11
39627695281145847   22770       0.21985178            7.4032803       0.21985513           0.84066576          0.348808             1.1136082        0.34881973              1.113727                 5                11
39627701031539618   23170       0.43801486            5.8491445       0.43906757            1.3402303         0.6764019             1.4012468         0.6775936              1.403713                 5                11
39627702575043078   27182       0.47294968             6.322607       0.47416905             1.846187        0.72405344             1.3690087        0.72567046             1.3720732                 5                11
39627703137078588   25582       0.57705325            5.1240916       0.58554816            3.7218125         0.9055195             1.8060454         0.9185896             1.8324302                 4                11
39627714927265648   26846        0.6949042            5.5469003        0.6933647            0.9148465         1.0733902              1.709428         1.0715625             1.7066538                 4                11
39627720753154699   27190        0.7886953            4.4995437       0.79238564            1.5732528         1.1071881              1.773739         1.1125295             1.7823209                 4                11
39627726931361961   26874       0.57433814            4.5976515       0.57271695            1.2430793        0.99583966             1.8422568         0.9921845              1.835224                 5                11
39627751187022090   27041       0.63522214             7.062515         0.631589           0.92504865         1.0219741             1.7310627         1.0162596             1.7213202                 5                11
39627758367675205   31393       0.51248544             4.649577       0.51119226            1.4740845        0.92030156              1.246224         0.9182464              1.243726                 5                11
39627775828559337   26260       0.65429604            4.6281986        0.6556657            1.9260031         0.9489775             1.7162926         0.9511386             1.7202446                 5                11
39627782413617711   25939        0.5083716            14.933689        0.5093471            1.2257168         0.7112896             1.4406018         0.7131495             1.4443675                 5                11
39627785097974911   18005        0.6397867             5.112813        0.6399844             1.749702        0.85381156             1.8115039        0.85397017             1.8120984                 4                11
39627805482290470   27392       0.33002523            5.2760415       0.32240465            0.7105613         0.5286258             0.9741854        0.52071494            0.95960057                 5                11
39627806191124904   26206       0.36865926             4.394622       0.36706984            0.9876223        0.67476493             1.2042142        0.67146885             1.1982371                 5                11
39627823597490301   27394        0.5153714            7.8209496        0.5151445            2.0941715        0.87738895             1.8198375        0.87708586             1.8191003                 5                11
39627824050475588   26296       0.54618657            4.4056306        0.5522574            1.2003007        0.76921296             1.0480423         0.7779564             1.0598806                 4                11
39627835538670183   27247        0.5089733            4.1143155       0.50795835            1.5229132        0.84039867             1.7267444        0.84270453             1.7312112                 5                11
39627835538672534   27333        3.8113892             27.56169        3.8128314            11.473215        0.51993185             0.7544324         0.5199327             0.7544336                 4                11
39627841217758187   21882        0.6141452            22.553217         0.619206            1.0759573         1.0130118             1.9645466         1.0213217             1.9806235                 5                11
39627841792376926   27066       0.31702465            4.1005464        0.3185926            1.3931268        0.48621154             0.7462357        0.48829505             0.7494504                 5                11
39627842870313903    8198        0.4637944            4.1095233       0.46382633            1.5449972          0.588402            0.95486146        0.58827406            0.95451885                 4                11
39627853372854738   21877       0.99615806             4.682783        0.9950927            2.1056523         1.3110943             1.7061741         1.3094313             1.7039965                 4                11
39627859987271386   27104         0.852718             8.290379        0.8526726            3.2567976         1.1179242             1.8585533         1.1179563             1.8582861                 4                11
39627866949816418    8226       0.67286426             4.233593       0.67265123            2.2646456         0.8156081             1.6804136         0.8155647             1.6803243                 4                11
39627890333058327   27683       0.39008853            4.2548943       0.38939545            1.0865473         0.6478823             1.1444217         0.6463846             1.1418637                 5                11
39627920599157550   27712       0.69655937            4.9202476        0.6964924            1.9760405         1.0042146             1.6750036         1.0042843             1.6753504                 4                11
39627920959866996   26434       0.59808594            4.1380196        0.6001812            1.3815353         0.8762208             1.7679856          0.879395             1.7744712                 4                11
39627926802532979   26496        1.0195965            11.714091        1.0217545            2.9777873        0.51123863             0.8752846          0.512901             0.8781404                 4                11
39627927075161805   26098       0.45716396             4.694467       0.45529318            0.6680193         0.6835449             1.0091693         0.6806857             1.0049564                 5                11
39627927385543026   31467        1.3129799            15.687575        1.3216143             4.639828        0.46966967             0.8986222        0.46946162            0.89825404                 4                11
39627927716890322   31511        0.3750537            4.4886284        0.3771995            1.2271975         0.5803369             1.1031259        0.58315057             1.1084574                 5                11
39627932993323600   26434        0.5166419            5.6894937        0.5162561            1.6211717        0.79294723             1.3825387        0.79221344             1.3812279                 5                11
```