### PR TITLE
just two line-fitting rounds and bug fixes

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,17 @@
 Change Log
 ==========
 
-2.4.1 (not released yet)
+2.4.2 (not released yet)
 ------------------------
 
 * 
+
+2.4.1 (2023-08-23)
+------------------
+
+* Just two rounds of emission-line fitting [`PR #151`_].
+
+.. _`PR #151`: https://github.com/desihub/fastspecfit/pull/151
 
 2.4.0 (2023-08-19)
 ------------------

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -2317,8 +2317,9 @@ def continuum_specfit(data, result, templatecache, fphoto=None, emlinesfile=None
         sfr = CTools.get_mean_property(templatecache['templateinfo'], 'sfr', coeff, agekeep,
                                        normalization=1.0/CTools.massnorm, log10=False, log=log)       # [Msun/yr]
 
+    rindx = np.argmin(np.abs(CTools.absmag_filters.effective_wavelengths.value / (1.+CTools.band_shift) - 5600))
     log.info('Mstar={:.4g} Msun, {}={:.2f} mag, A(V)={:.3f}, Age={:.3f} Gyr, SFR={:.3f} Msun/yr, Z/Zsun={:.3f}'.format(
-        logmstar, 'M{}'.format(CTools.absmag_bands[1]), absmag[1], AV, age, sfr, zzsun))
+        logmstar, 'M{}'.format(CTools.absmag_bands[rindx]), absmag[rindx], AV, age, sfr, zzsun))
     #log.info('Mstar={:.4g} Msun, Mr={:.2f} mag, A(V)={:.3f}, Age={:.3f} Gyr, SFR={:.3f} Msun/yr, Z/Zsun={:.3f}, fagn={:.3f}'.format(
     #    logmstar, absmag[np.isin(CTools.absmag_bands, 'sdss_r')][0], AV, age, sfr, zzsun, fagn))
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1629,12 +1629,13 @@ class ContinuumTools(Filters, Inoue14):
             if ((specwave is None and specres is None and coeff is None) or
                (specwave is not None and specres is not None)):
                 try:
-                    maggies = filters.get_ab_maggies(padflux, padwave) # speclite.filters wants an [nmodel,npix] array
+                    maggies = filters.get_ab_maggies(ztemplateflux.T, ztemplatewave) # speclite.filters wants an [nmodel,npix] array
                 except:
                     # pad in the case of an object at very high redshift (z>5.5).
                     log.warning('Padding model spectrum due to insufficient wavelength coverage to synthesize photometry.')
-                    padflux, padwave = filters.pad_spectrum(ztemplateflux.T, ztemplatewave, axis=0, method='edge')
-                    maggies = filters.get_ab_maggies(padflux.T, padwave, axis=0)
+                    padflux, padwave = filters.pad_spectrum(ztemplateflux, ztemplatewave, axis=0, method='edge')
+                    maggies = filters.get_ab_maggies(padflux.T, padwave)
+                    
                 maggies = np.vstack(maggies.as_array().tolist()).T
                 maggies /= FLUXNORM * self.massnorm
                 templatephot = self.parse_photometry(self.bands, maggies, effwave, nanomaggies=False, verbose=debug, log=log)

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -22,8 +22,15 @@ def read_emlines(emlinesfile=None):
     if emlinesfile is None:
         from importlib import resources
         emlinesfile = resources.files('fastspecfit').joinpath('data/emlines.ecsv')
-        
-    linetable = Table.read(emlinesfile, format='ascii.ecsv', guess=False)
+
+    try:
+        linetable = Table.read(emlinesfile, format='ascii.ecsv', guess=False)
+    except: 
+        from desiutil.log import get_logger
+        log = get_logger()
+        errmsg = f'Problem reading emission lines parameter file {emlinesfile}.'
+        log.critical(errmsg)
+        raise ValueError(errmsg)
     
     return linetable    
 

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1057,6 +1057,7 @@ class EMFitTools(Filters):
         for param in finalfit:
             val = param['value']
             obsval = param['obsvalue']
+
             # special case the tied doublets
             if param['param_name'] == 'oii_doublet_ratio':
                 result['OII_DOUBLET_RATIO'] = val
@@ -2414,7 +2415,7 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
     # Initial fit - initial_linemodel_nobroad
     t0 = time.time()
     fit_nobroad = EMFit.optimize(linemodel_nobroad, emlinewave, emlineflux, weights, redshift,
-                                 resolution_matrix, camerapix, log=log, debug=False, get_finalamp=False)
+                                 resolution_matrix, camerapix, log=log, debug=False, get_finalamp=True)
     model_nobroad = EMFit.bestfit(fit_nobroad, redshift, emlinewave, resolution_matrix, camerapix)
     chi2_nobroad, ndof_nobroad, nfree_nobroad = EMFit.chi2(fit_nobroad, emlinewave, emlineflux, emlineivar, model_nobroad, return_dof=True)
     log.info('Line-fitting with no broad lines and {} free parameters took {:.2f} seconds [niter={}, rchi2={:.4f}].'.format(

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -365,24 +365,24 @@ class EMFitTools(Filters):
         # Model 1 -- here, parameters are minimally tied together for the final
         # fit and only lines outside the wavelength range are fixed. Includes
         # broad lines.
-        linemodel = Table()
-        linemodel['param_name'] = param_names
-        linemodel['index'] = np.arange(nparam).astype(np.int32)
-        linemodel['linename'] = np.tile(linenames, 3) # 3 parameters per line
-        linemodel['isbalmer'] = np.zeros(nparam, bool)
-        linemodel['ishelium'] = np.zeros(nparam, bool)
-        linemodel['isbroad'] = np.zeros(nparam, bool)
-        linemodel['tiedfactor'] = np.zeros(nparam, 'f8')
-        linemodel['tiedtoparam'] = np.zeros(nparam, np.int16)-1
-        linemodel['doubletpair'] = np.zeros(nparam, np.int16)-1
-        linemodel['fixed'] = np.zeros(nparam, bool)
-        linemodel['bounds'] = np.zeros((nparam, 2), 'f8')
-        linemodel['initial'] = np.zeros(nparam, 'f8')
-        linemodel['value'] = np.zeros(nparam, 'f8')
-        linemodel['obsvalue'] = np.zeros(nparam, 'f8')
-        linemodel['civar'] = np.zeros(nparam, 'f8') # continuum inverse variance
+        linemodel_broad = Table()
+        linemodel_broad['param_name'] = param_names
+        linemodel_broad['index'] = np.arange(nparam).astype(np.int32)
+        linemodel_broad['linename'] = np.tile(linenames, 3) # 3 parameters per line
+        linemodel_broad['isbalmer'] = np.zeros(nparam, bool)
+        linemodel_broad['ishelium'] = np.zeros(nparam, bool)
+        linemodel_broad['isbroad'] = np.zeros(nparam, bool)
+        linemodel_broad['tiedfactor'] = np.zeros(nparam, 'f8')
+        linemodel_broad['tiedtoparam'] = np.zeros(nparam, np.int16)-1
+        linemodel_broad['doubletpair'] = np.zeros(nparam, np.int16)-1
+        linemodel_broad['fixed'] = np.zeros(nparam, bool)
+        linemodel_broad['bounds'] = np.zeros((nparam, 2), 'f8')
+        linemodel_broad['initial'] = np.zeros(nparam, 'f8')
+        linemodel_broad['value'] = np.zeros(nparam, 'f8')
+        linemodel_broad['obsvalue'] = np.zeros(nparam, 'f8')
+        linemodel_broad['civar'] = np.zeros(nparam, 'f8') # continuum inverse variance
 
-        linemodel['doubletpair'][self.doubletindx] = self.doubletpair
+        linemodel_broad['doubletpair'][self.doubletindx] = self.doubletpair
 
         # Build the relationship of "tied" parameters. In the 'tied' array, the
         # non-zero value is the multiplicative factor by which the parameter
@@ -394,9 +394,9 @@ class EMFitTools(Filters):
         # lines, not just those in range.
     
         for iline, linename in enumerate(linenames):
-            linemodel['isbalmer'][linemodel['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['isbalmer']
-            linemodel['ishelium'][linemodel['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['ishelium']
-            linemodel['isbroad'][linemodel['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['isbroad']
+            linemodel_broad['isbalmer'][linemodel_broad['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['isbalmer']
+            linemodel_broad['ishelium'][linemodel_broad['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['ishelium']
+            linemodel_broad['isbroad'][linemodel_broad['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['isbroad']
             
             # initial values and bounds - broad He+Balmer lines
             if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline]:
@@ -405,8 +405,8 @@ class EMFitTools(Filters):
                                                    [minsigma_balmer_broad, maxsigma_balmer_broad],
                                                    [-vmaxshift_broad, +vmaxshift_broad]],
                                                   [initamp, initsigma_broad, initvshift]):
-                    linemodel['initial'][param_names == linename+'_'+param] = default
-                    linemodel['bounds'][param_names == linename+'_'+param] = bounds
+                    linemodel_broad['initial'][param_names == linename+'_'+param] = default
+                    linemodel_broad['bounds'][param_names == linename+'_'+param] = bounds
 
             # initial values and bounds - narrow He+Balmer lines
             if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] == False:
@@ -414,8 +414,8 @@ class EMFitTools(Filters):
                                                   [[minamp, maxamp], [minsigma_narrow, maxsigma_narrow],
                                                    [-vmaxshift_narrow, +vmaxshift_narrow]],
                                                   [initamp, initsigma_narrow, initvshift]):
-                    linemodel['initial'][param_names == linename+'_'+param] = default
-                    linemodel['bounds'][param_names == linename+'_'+param] = bounds
+                    linemodel_broad['initial'][param_names == linename+'_'+param] = default
+                    linemodel_broad['bounds'][param_names == linename+'_'+param] = bounds
 
             # initial values and bounds - broad UV/QSO lines (non-Balmer)
             if fit_linetable['isbalmer'][iline] == False and fit_linetable['isbroad'][iline]:
@@ -423,8 +423,8 @@ class EMFitTools(Filters):
                                                   [[minamp, maxamp], [minsigma_broad, maxsigma_broad],
                                                    [-vmaxshift_broad, +vmaxshift_broad]],
                                                   [initamp, initsigma_broad, initvshift]):
-                    linemodel['initial'][param_names == linename+'_'+param] = default
-                    linemodel['bounds'][param_names == linename+'_'+param] = bounds
+                    linemodel_broad['initial'][param_names == linename+'_'+param] = default
+                    linemodel_broad['bounds'][param_names == linename+'_'+param] = bounds
 
             # initial values and bounds - forbidden lines
             if fit_linetable['isbalmer'][iline] == False and fit_linetable['isbroad'][iline] == False:
@@ -432,64 +432,64 @@ class EMFitTools(Filters):
                                                   [[minamp, maxamp], [minsigma_narrow, maxsigma_narrow],
                                                    [-vmaxshift_narrow, +vmaxshift_narrow]],
                                                   [initamp, initsigma_narrow, initvshift]):
-                    linemodel['initial'][param_names == linename+'_'+param] = default
-                    linemodel['bounds'][param_names == linename+'_'+param] = bounds
+                    linemodel_broad['initial'][param_names == linename+'_'+param] = default
+                    linemodel_broad['bounds'][param_names == linename+'_'+param] = bounds
 
             # tie parameters
 
             # broad He + Balmer
             if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] and linename != 'halpha_broad':
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_broad_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_broad_'+param)[0]
             #print('Releasing the narrow Balmer lines!')
             # narrow He + Balmer
             if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] == False and linename != 'halpha':
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_'+param)[0]
             # other lines
             if linename == 'mgii_2796':
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'mgii_2803_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'mgii_2803_'+param)[0]
             if linename == 'nev_3346' or linename == 'nev_3426': # should [NeIII] 3869 be tied to [NeV]???
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'neiii_3869_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'neiii_3869_'+param)[0]
             if linename == 'oii_3726':
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oii_3729_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oii_3729_'+param)[0]
             # Tentative! Tie auroral lines to [OIII] 4363 but maybe we shouldn't tie [OI] 6300 here...
             if linename == 'nii_5755' or linename == 'oi_6300' or linename == 'siii_6312':
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_4363_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_4363_'+param)[0]
             if linename == 'oiii_4959':
                 """
                 [O3] (4-->2): airwave: 4958.9097 vacwave: 4960.2937 emissivity: 1.172e-21
                 [O3] (4-->3): airwave: 5006.8417 vacwave: 5008.2383 emissivity: 3.497e-21
                 """
-                linemodel['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 2.9839 # 2.8875
-                linemodel['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'oiii_5007_amp')[0]
+                linemodel_broad['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 2.9839 # 2.8875
+                linemodel_broad['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'oiii_5007_amp')[0]
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_5007_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_5007_'+param)[0]
             if linename == 'nii_6548':
                 """
                 [N2] (4-->2): airwave: 6548.0488 vacwave: 6549.8578 emissivity: 2.02198e-21
                 [N2] (4-->3): airwave: 6583.4511 vacwave: 6585.2696 emissivity: 5.94901e-21
                 """
-                linemodel['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 2.9421 # 2.936
-                linemodel['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'nii_6584_amp')[0]
+                linemodel_broad['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 2.9421 # 2.936
+                linemodel_broad['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'nii_6584_amp')[0]
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'nii_6584_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'nii_6584_'+param)[0]
             if linename == 'sii_6731':
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'sii_6716_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'sii_6716_'+param)[0]
             if linename == 'oii_7330':
                 """
                 [O2] (5-->2): airwave: 7318.9185 vacwave: 7320.9350 emissivity: 8.18137e-24
@@ -497,20 +497,20 @@ class EMFitTools(Filters):
                 [O2] (5-->3): airwave: 7329.6613 vacwave: 7331.6807 emissivity: 1.35614e-23
                 [O2] (4-->3): airwave: 7330.7308 vacwave: 7332.7506 emissivity: 1.27488e-23
                 """
-                linemodel['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 1.2251
-                linemodel['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'oii_7320_amp')[0]
+                linemodel_broad['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 1.2251
+                linemodel_broad['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'oii_7320_amp')[0]
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oii_7320_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oii_7320_'+param)[0]
             if linename == 'siii_9069':
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'siii_9532_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'siii_9532_'+param)[0]
             # Tentative! Tie SiIII] 1892 to CIII] 1908 because they're so close in wavelength.
             if linename == 'siliii_1892':
                 for param in ['sigma', 'vshift']:
-                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'ciii_1908_'+param)[0]
+                    linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'ciii_1908_'+param)[0]
 
             # Stephanie Juneau argues that the narrow *forbidden* line-widths
             # should never be fully untied, so optionally keep them tied to
@@ -521,30 +521,29 @@ class EMFitTools(Filters):
                 # helium lines are separately tied together.
                 if fit_linetable['isbroad'][iline] == False and fit_linetable['isbalmer'][iline] == False and linename != 'oiii_5007':
                     for param in ['sigma']:
-                        linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                        linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_5007_'+param)[0]
+                        linemodel_broad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                        linemodel_broad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_5007_'+param)[0]
                     
         # Finally set the initial values and bounds on the doublet ratio parameters.
         for param, bounds, default in zip(['mgii_doublet_ratio', 'oii_doublet_ratio', 'sii_doublet_ratio'],
                                           [bounds_mgii_doublet, bounds_oii_doublet, bounds_sii_doublet],
                                           [init_mgii_doublet, init_oii_doublet, init_sii_doublet]):
-            linemodel['initial'][linemodel['param_name'] == param] = default
-            linemodel['bounds'][linemodel['param_name'] == param] = bounds
+            linemodel_broad['initial'][linemodel_broad['param_name'] == param] = default
+            linemodel_broad['bounds'][linemodel_broad['param_name'] == param] = bounds
                     
         # Assign fixed=True to parameters which are outside the wavelength range
         # except those that are tied to other lines.
-        _fix_parameters(linemodel, verbose=False)
+        _fix_parameters(linemodel_broad, verbose=False)
 
-        assert(np.all(linemodel['tiedtoparam'][linemodel['tiedfactor'] != 0] != -1))
+        assert(np.all(linemodel_broad['tiedtoparam'][linemodel_broad['tiedfactor'] != 0] != -1))
         # It's OK for the doublet ratios to be bounded at zero.
-        #assert(len(linemodel[np.sum(linemodel['bounds'] == [0.0, 0.0], axis=1) > 0]) == 0)
+        #assert(len(linemodel_broad[np.sum(linemodel_broad['bounds'] == [0.0, 0.0], axis=1) > 0]) == 0)
     
-        #_print_linemodel(linemodel)
-        #linemodel[np.logical_and(linemodel['fixed'] == False, linemodel['tiedtoparam'] == -1)]
+        #_print_linemodel(linemodel_broad)
+        #linemodel_broad[np.logical_and(linemodel_broad['fixed'] == False, linemodel_broad['tiedtoparam'] == -1)]
 
-        # Model 2 - like linemodel, but broad lines have been fixed at
-        # zero.
-        linemodel_nobroad = linemodel.copy()
+        # Model 2 - like linemodel, but broad lines have been fixed at zero.
+        linemodel_nobroad = linemodel_broad.copy()
         linemodel_nobroad['fixed'] = False # reset
 
         for iline, linename in enumerate(linenames):
@@ -560,10 +559,9 @@ class EMFitTools(Filters):
         #linemodel_nobroad[np.logical_and(linemodel_nobroad['fixed'] == False, linemodel_nobroad['tiedtoparam'] == -1)]
 
         _fix_parameters(linemodel_nobroad, verbose=False)
-
         assert(np.all(linemodel_nobroad['tiedtoparam'][linemodel_nobroad['tiedfactor'] != 0] != -1))
         
-        return linemodel, linemodel_nobroad
+        return linemodel_broad, linemodel_nobroad
 
     def initial_guesses_and_bounds(self, data, emlinewave, emlineflux, log):
         """For all lines in the wavelength range of the data, get a good initial guess
@@ -2393,7 +2391,7 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
     weights = np.sqrt(emlineivar)
 
     # Build all the emission-line models for this object.
-    linemodel, linemodel_nobroad = EMFit.build_linemodels(
+    linemodel_broad, linemodel_nobroad = EMFit.build_linemodels(
         redshift, wavelims=(np.min(emlinewave)+5, np.max(emlinewave)-5),
         verbose=False, strict_finalmodel=True)
 
@@ -2403,73 +2401,66 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
     initial_guesses, param_bounds = EMFit.initial_guesses_and_bounds(
         data, emlinewave, emlineflux, log)
 
-    #for linemodel in [initial_linemodel, initial_linemodel_nobroad]:
-    #    EMFit.populate_linemodel(linemodel, initial_guesses, param_bounds, log)
-    for linemodel in [final_linemodel, final_linemodel_nobroad]:
+    for linemodel in [linemodel_broad, linemodel_nobroad]:
         EMFit.populate_linemodel(linemodel, initial_guesses, param_bounds, log)
 
     # Initial fit - initial_linemodel_nobroad
     t0 = time.time()
-    initfit = EMFit.optimize(final_linemodel_nobroad,
-                             #initial_linemodel_nobroad,
-                             emlinewave, emlineflux, 
-                             weights, redshift, resolution_matrix, camerapix, 
-                             log=log, debug=False, get_finalamp=False)
-    initmodel = EMFit.bestfit(initfit, redshift, emlinewave, resolution_matrix, camerapix)
-    initchi2, initndof, nfree = EMFit.chi2(initfit, emlinewave, emlineflux, emlineivar, initmodel, return_dof=True)
-    log.info('Initial line-fitting with {} free parameters took {:.2f} seconds [niter={}, rchi2={:.4f}].'.format(
-        nfree, time.time()-t0, initfit.meta['nfev'], initchi2))
+    fit_nobroad = EMFit.optimize(linemodel_nobroad, emlinewave, emlineflux, weights, redshift,
+                                 resolution_matrix, camerapix, log=log, debug=False, get_finalamp=False)
+    model_nobroad = EMFit.bestfit(fit_nobroad, redshift, emlinewave, resolution_matrix, camerapix)
+    chi2_nobroad, ndof_nobroad, nfree_nobroad = EMFit.chi2(fit_nobroad, emlinewave, emlineflux, emlineivar, model_nobroad, return_dof=True)
+    log.info('Line-fitting with no broad lines and {} free parameters took {:.2f} seconds [niter={}, rchi2={:.4f}].'.format(
+        nfree_nobroad, time.time()-t0, fit_nobroad.meta['nfev'], chi2_nobroad))
 
     # Now try adding broad Balmer and helium lines and see if we improve the
     # chi2.
     if broadlinefit:
         # Gather the pixels around the broad Balmer lines and the corresponding
         # linemodel table.
-        balmer_pix, balmer_linemodel, balmer_linemodel_nobroad = [], [], []
+        balmer_pix, balmer_linemodel_broad, balmer_linemodel_nobroad = [], [], []
         for icam in np.arange(len(data['cameras'])):
             pixoffset = int(np.sum(data['npixpercamera'][:icam]))
             if len(data['linename'][icam]) > 0:
-                I = (final_linemodel['isbalmer'] * (final_linemodel['ishelium'] == False) * final_linemodel['isbroad'] * 
-                     np.isin(final_linemodel['linename'], data['linename'][icam]))
-                _balmer_linemodel = final_linemodel[I]
-                _balmer_linemodel_nobroad = final_linemodel_nobroad[I]
-                balmer_linemodel.append(_balmer_linemodel)
+                I = (linemodel_nobroad['isbalmer'] * (linemodel_nobroad['ishelium'] == False) *
+                     linemodel_nobroad['isbroad'] * np.isin(linemodel_nobroad['linename'], data['linename'][icam]))
+                _balmer_linemodel_broad = linemodel_broad[I]
+                _balmer_linemodel_nobroad = linemodel_nobroad[I]
+                balmer_linemodel_broad.append(_balmer_linemodel_broad)
                 balmer_linemodel_nobroad.append(_balmer_linemodel_nobroad)
-                if len(_balmer_linemodel) > 0: # use balmer_linemodel not balmer_linemodel_nobroad
-                    I = np.where(np.isin(data['linename'][icam], _balmer_linemodel['linename']))[0]
+                if len(_balmer_linemodel_broad) > 0: # use balmer_linemodel_broad not balmer_linemodel_nobroad
+                    I = np.where(np.isin(data['linename'][icam], _balmer_linemodel_broad['linename']))[0]
                     for ii in I:
                         #print(data['linename'][icam][ii])
                         balmer_pix.append(data['linepix'][icam][ii] + pixoffset)
                         
         if len(balmer_pix) > 0:
             t0 = time.time()
-            broadfit = EMFit.optimize(final_linemodel,
-                                      #initial_linemodel,
-                                      emlinewave, emlineflux, weights, 
-                                      redshift, resolution_matrix, camerapix, log=log,
-                                      debug=False, get_finalamp=True)
-            broadmodel = EMFit.bestfit(broadfit, redshift, emlinewave, resolution_matrix, camerapix)
-            broadchi2, broadndof, nfree = EMFit.chi2(broadfit, emlinewave, emlineflux, emlineivar, broadmodel, return_dof=True)
-            log.info('Second (broad) line-fitting with {} free parameters took {:.2f} seconds [niter={}, rchi2={:.4f}].'.format(
-                nfree, time.time()-t0, broadfit.meta['nfev'], broadchi2))
+            fit_broad = EMFit.optimize(linemodel_broad, emlinewave, emlineflux, weights, 
+                                       redshift, resolution_matrix, camerapix, log=log,
+                                       debug=False, get_finalamp=True)
+            model_broad = EMFit.bestfit(fit_broad, redshift, emlinewave, resolution_matrix, camerapix)
+            chi2_broad, ndof_broad, nfree_broad = EMFit.chi2(fit_broad, emlinewave, emlineflux, emlineivar, model_broad, return_dof=True)
+            log.info('Line-fitting with broad lines and {} free parameters took {:.2f} seconds [niter={}, rchi2={:.4f}].'.format(
+                nfree_broad, time.time()-t0, fit_broad.meta['nfev'], chi2_broad))
 
             # compute delta-chi2 around just the Balmer lines
             balmer_pix = np.hstack(balmer_pix)
-            balmer_linemodel = vstack(balmer_linemodel)
+            balmer_linemodel_broad = vstack(balmer_linemodel_broad)
 
-            balmer_nfree = (np.count_nonzero((balmer_linemodel['fixed'] == False) *
-                                             (balmer_linemodel['tiedtoparam'] == -1)))
-            balmer_ndof = np.count_nonzero(emlineivar[balmer_pix] > 0) - balmer_nfree
+            balmer_nfree_broad = (np.count_nonzero((balmer_linemodel_broad['fixed'] == False) *
+                                                   (balmer_linemodel_broad['tiedtoparam'] == -1)))
+            balmer_ndof_broad = np.count_nonzero(emlineivar[balmer_pix] > 0) - balmer_nfree_broad
 
             balmer_linemodel_nobroad = vstack(balmer_linemodel_nobroad)
             balmer_nfree_nobroad = (np.count_nonzero((balmer_linemodel_nobroad['fixed'] == False) *
                                                      (balmer_linemodel_nobroad['tiedtoparam'] == -1)))
             balmer_ndof_nobroad = np.count_nonzero(emlineivar[balmer_pix] > 0) - balmer_nfree_nobroad
 
-            linechi2_balmer = np.sum(emlineivar[balmer_pix] * (emlineflux[balmer_pix] - broadmodel[balmer_pix])**2)
-            linechi2_balmer_nobroad = np.sum(emlineivar[balmer_pix] * (emlineflux[balmer_pix] - initmodel[balmer_pix])**2)
-            delta_linechi2_balmer = linechi2_balmer_nobroad - linechi2_balmer
-            delta_linendof_balmer = balmer_ndof_nobroad - balmer_ndof
+            linechi2_balmer_broad = np.sum(emlineivar[balmer_pix] * (emlineflux[balmer_pix] - model_broad[balmer_pix])**2)
+            linechi2_balmer_nobroad = np.sum(emlineivar[balmer_pix] * (emlineflux[balmer_pix] - model_nobroad[balmer_pix])**2)
+            delta_linechi2_balmer = linechi2_balmer_nobroad - linechi2_balmer_broad
+            delta_linendof_balmer = balmer_ndof_nobroad - balmer_ndof_broad
 
             # Choose broad-line model only if:
             # --delta-chi2 > delta-ndof
@@ -2477,56 +2468,54 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
             # --broad_sigma < 250
 
             dchi2test = delta_linechi2_balmer > delta_linendof_balmer
-            Hanarrow = broadfit['param_name'] == 'halpha_sigma' # Balmer lines are tied to H-alpha even if out of range
-            Habroad = broadfit['param_name'] == 'halpha_broad_sigma'
-            Bbroad = broadfit['isbalmer'] * broadfit['isbroad'] * (broadfit['fixed'] == False) * EMFit.amp_balmer_bool
-            broadsnr = broadfit[Bbroad]['value'].data * np.sqrt(broadfit[Bbroad]['civar'].data)
+            Hanarrow = fit_broad['param_name'] == 'halpha_sigma' # Balmer lines are tied to H-alpha even if out of range
+            Habroad = fit_broad['param_name'] == 'halpha_broad_sigma'
+            Bbroad = fit_broad['isbalmer'] * fit_broad['isbroad'] * (fit_broad['fixed'] == False) * EMFit.amp_balmer_bool
+            broadsnr = fit_broad[Bbroad]['value'].data * np.sqrt(fit_broad[Bbroad]['civar'].data)
 
-            sigtest1 = broadfit[Habroad]['value'][0] > EMFit.minsigma_balmer_broad
-            sigtest2 = (broadfit[Habroad]['value'] > broadfit[Hanarrow]['value'])[0]
+            sigtest1 = fit_broad[Habroad]['value'][0] > EMFit.minsigma_balmer_broad
+            sigtest2 = (fit_broad[Habroad]['value'] > fit_broad[Hanarrow]['value'])[0]
             if len(broadsnr) == 0:
                 broadsnrtest = False
                 _broadsnr = 0.
             elif len(broadsnr) == 1:
                 broadsnrtest =  broadsnr[-1] > EMFit.minsnr_balmer_broad
-                _broadsnr = 'S/N ({}) = {:.1f}'.format(broadfit[Bbroad]['linename'][-1], broadsnr[-1])
+                _broadsnr = 'S/N ({}) = {:.1f}'.format(fit_broad[Bbroad]['linename'][-1], broadsnr[-1])
             else:
                 broadsnrtest =  np.any(broadsnr[-2:] > EMFit.minsnr_balmer_broad)
                 _broadsnr = 'S/N ({}) = {:.1f}, S/N ({}) = {:.1f}'.format(
-                    broadfit[Bbroad]['linename'][-2], broadsnr[-2], broadfit[Bbroad]['linename'][-1], broadsnr[-1])
+                    fit_broad[Bbroad]['linename'][-2], broadsnr[-2], fit_broad[Bbroad]['linename'][-1], broadsnr[-1])
 
             if dchi2test and sigtest1 and sigtest2 and broadsnrtest:
                 log.info('Adopting broad-line model:')
                 log.info('  delta-chi2={:.1f} > delta-ndof={:.0f}'.format(delta_linechi2_balmer, delta_linendof_balmer))
-                log.info('  sigma_broad={:.1f} km/s, sigma_narrow={:.1f} km/s'.format(broadfit[Habroad]['value'][0], broadfit[Hanarrow]['value'][0]))
+                log.info('  sigma_broad={:.1f} km/s, sigma_narrow={:.1f} km/s'.format(fit_broad[Habroad]['value'][0], fit_broad[Hanarrow]['value'][0]))
                 if _broadsnr:
                     log.info('  {} > {:.0f}'.format(_broadsnr, EMFit.minsnr_balmer_broad))
-                bestfit = broadfit
-                use_linemodel_broad = True
+                bestfit = fit_broad
             else:
                 if dchi2test == False:
                     log.info('Dropping broad-line model: delta-chi2={:.1f} < delta-ndof={:.0f}'.format(
                         delta_linechi2_balmer, delta_linendof_balmer))
                 elif sigtest1 == False:
                     log.info('Dropping broad-line model: Halpha_broad_sigma {:.1f} km/s < {:.0f} km/s (delta-chi2={:.1f}, delta-ndof={:.0f}).'.format(
-                        broadfit[Habroad]['value'][0], EMFit.minsigma_balmer_broad, delta_linechi2_balmer, delta_linendof_balmer))
+                        fit_broad[Habroad]['value'][0], EMFit.minsigma_balmer_broad, delta_linechi2_balmer, delta_linendof_balmer))
                 elif sigtest2 == False:
                     log.info('Dropping broad-line model: Halpha_broad_sigma {:.1f} km/s < Halpha_narrow_sigma {:.1f} km/s (delta-chi2={:.1f}, delta-ndof={:.0f}).'.format(
-                        broadfit[Habroad]['value'][0], broadfit[Hanarrow]['value'][0], delta_linechi2_balmer, delta_linendof_balmer))
+                        fit_broad[Habroad]['value'][0], fit_broad[Hanarrow]['value'][0], delta_linechi2_balmer, delta_linendof_balmer))
                 elif broadsnrtest == False:
                     log.info('Dropping broad-line model: {} < {:.0f}'.format(_broadsnr, EMFit.minsnr_balmer_broad))
-                bestfit = initfit
-                use_linemodel_broad = False
+                bestfit = fit_nobroad
         else:
             log.info('Insufficient Balmer lines to test the broad-line model.')
-            bestfit = initfit
+            bestfit = initfit_nobroad
             delta_linechi2_balmer, delta_linendof_balmer = 0, np.int32(0)
-            use_linemodel_broad = False
     else:
         log.info('Skipping broad-line fitting (broadlinefit=False).')
-        bestfit = initfit
+        bestfit = fit_nobroad
         delta_linechi2_balmer, delta_linendof_balmer = 0, np.int32(0)
-        use_linemodel_broad = False
+
+    pdb.set_trace()
 
     # Finally, one more fitting loop with all the line-constraints relaxed
     # but starting from the previous best-fitting values.

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -365,24 +365,24 @@ class EMFitTools(Filters):
         # Model 1 -- here, parameters are minimally tied together for the final
         # fit and only lines outside the wavelength range are fixed. Includes
         # broad lines.
-        final_linemodel = Table()
-        final_linemodel['param_name'] = param_names
-        final_linemodel['index'] = np.arange(nparam).astype(np.int32)
-        final_linemodel['linename'] = np.tile(linenames, 3) # 3 parameters per line
-        final_linemodel['isbalmer'] = np.zeros(nparam, bool)
-        final_linemodel['ishelium'] = np.zeros(nparam, bool)
-        final_linemodel['isbroad'] = np.zeros(nparam, bool)
-        final_linemodel['tiedfactor'] = np.zeros(nparam, 'f8')
-        final_linemodel['tiedtoparam'] = np.zeros(nparam, np.int16)-1
-        final_linemodel['doubletpair'] = np.zeros(nparam, np.int16)-1
-        final_linemodel['fixed'] = np.zeros(nparam, bool)
-        final_linemodel['bounds'] = np.zeros((nparam, 2), 'f8')
-        final_linemodel['initial'] = np.zeros(nparam, 'f8')
-        final_linemodel['value'] = np.zeros(nparam, 'f8')
-        final_linemodel['obsvalue'] = np.zeros(nparam, 'f8')
-        final_linemodel['civar'] = np.zeros(nparam, 'f8') # continuum inverse variance
+        linemodel = Table()
+        linemodel['param_name'] = param_names
+        linemodel['index'] = np.arange(nparam).astype(np.int32)
+        linemodel['linename'] = np.tile(linenames, 3) # 3 parameters per line
+        linemodel['isbalmer'] = np.zeros(nparam, bool)
+        linemodel['ishelium'] = np.zeros(nparam, bool)
+        linemodel['isbroad'] = np.zeros(nparam, bool)
+        linemodel['tiedfactor'] = np.zeros(nparam, 'f8')
+        linemodel['tiedtoparam'] = np.zeros(nparam, np.int16)-1
+        linemodel['doubletpair'] = np.zeros(nparam, np.int16)-1
+        linemodel['fixed'] = np.zeros(nparam, bool)
+        linemodel['bounds'] = np.zeros((nparam, 2), 'f8')
+        linemodel['initial'] = np.zeros(nparam, 'f8')
+        linemodel['value'] = np.zeros(nparam, 'f8')
+        linemodel['obsvalue'] = np.zeros(nparam, 'f8')
+        linemodel['civar'] = np.zeros(nparam, 'f8') # continuum inverse variance
 
-        final_linemodel['doubletpair'][self.doubletindx] = self.doubletpair
+        linemodel['doubletpair'][self.doubletindx] = self.doubletpair
 
         # Build the relationship of "tied" parameters. In the 'tied' array, the
         # non-zero value is the multiplicative factor by which the parameter
@@ -394,9 +394,9 @@ class EMFitTools(Filters):
         # lines, not just those in range.
     
         for iline, linename in enumerate(linenames):
-            final_linemodel['isbalmer'][final_linemodel['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['isbalmer']
-            final_linemodel['ishelium'][final_linemodel['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['ishelium']
-            final_linemodel['isbroad'][final_linemodel['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['isbroad']
+            linemodel['isbalmer'][linemodel['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['isbalmer']
+            linemodel['ishelium'][linemodel['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['ishelium']
+            linemodel['isbroad'][linemodel['linename'] == linename] = fit_linetable[fit_linetable['name'] == linename]['isbroad']
             
             # initial values and bounds - broad He+Balmer lines
             if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline]:
@@ -405,8 +405,8 @@ class EMFitTools(Filters):
                                                    [minsigma_balmer_broad, maxsigma_balmer_broad],
                                                    [-vmaxshift_broad, +vmaxshift_broad]],
                                                   [initamp, initsigma_broad, initvshift]):
-                    final_linemodel['initial'][param_names == linename+'_'+param] = default
-                    final_linemodel['bounds'][param_names == linename+'_'+param] = bounds
+                    linemodel['initial'][param_names == linename+'_'+param] = default
+                    linemodel['bounds'][param_names == linename+'_'+param] = bounds
 
             # initial values and bounds - narrow He+Balmer lines
             if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] == False:
@@ -414,8 +414,8 @@ class EMFitTools(Filters):
                                                   [[minamp, maxamp], [minsigma_narrow, maxsigma_narrow],
                                                    [-vmaxshift_narrow, +vmaxshift_narrow]],
                                                   [initamp, initsigma_narrow, initvshift]):
-                    final_linemodel['initial'][param_names == linename+'_'+param] = default
-                    final_linemodel['bounds'][param_names == linename+'_'+param] = bounds
+                    linemodel['initial'][param_names == linename+'_'+param] = default
+                    linemodel['bounds'][param_names == linename+'_'+param] = bounds
 
             # initial values and bounds - broad UV/QSO lines (non-Balmer)
             if fit_linetable['isbalmer'][iline] == False and fit_linetable['isbroad'][iline]:
@@ -423,8 +423,8 @@ class EMFitTools(Filters):
                                                   [[minamp, maxamp], [minsigma_broad, maxsigma_broad],
                                                    [-vmaxshift_broad, +vmaxshift_broad]],
                                                   [initamp, initsigma_broad, initvshift]):
-                    final_linemodel['initial'][param_names == linename+'_'+param] = default
-                    final_linemodel['bounds'][param_names == linename+'_'+param] = bounds
+                    linemodel['initial'][param_names == linename+'_'+param] = default
+                    linemodel['bounds'][param_names == linename+'_'+param] = bounds
 
             # initial values and bounds - forbidden lines
             if fit_linetable['isbalmer'][iline] == False and fit_linetable['isbroad'][iline] == False:
@@ -432,64 +432,64 @@ class EMFitTools(Filters):
                                                   [[minamp, maxamp], [minsigma_narrow, maxsigma_narrow],
                                                    [-vmaxshift_narrow, +vmaxshift_narrow]],
                                                   [initamp, initsigma_narrow, initvshift]):
-                    final_linemodel['initial'][param_names == linename+'_'+param] = default
-                    final_linemodel['bounds'][param_names == linename+'_'+param] = bounds
+                    linemodel['initial'][param_names == linename+'_'+param] = default
+                    linemodel['bounds'][param_names == linename+'_'+param] = bounds
 
             # tie parameters
 
             # broad He + Balmer
             if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] and linename != 'halpha_broad':
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_broad_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_broad_'+param)[0]
             #print('Releasing the narrow Balmer lines!')
             # narrow He + Balmer
             if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] == False and linename != 'halpha':
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_'+param)[0]
             # other lines
             if linename == 'mgii_2796':
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'mgii_2803_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'mgii_2803_'+param)[0]
             if linename == 'nev_3346' or linename == 'nev_3426': # should [NeIII] 3869 be tied to [NeV]???
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'neiii_3869_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'neiii_3869_'+param)[0]
             if linename == 'oii_3726':
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oii_3729_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oii_3729_'+param)[0]
             # Tentative! Tie auroral lines to [OIII] 4363 but maybe we shouldn't tie [OI] 6300 here...
             if linename == 'nii_5755' or linename == 'oi_6300' or linename == 'siii_6312':
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_4363_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_4363_'+param)[0]
             if linename == 'oiii_4959':
                 """
                 [O3] (4-->2): airwave: 4958.9097 vacwave: 4960.2937 emissivity: 1.172e-21
                 [O3] (4-->3): airwave: 5006.8417 vacwave: 5008.2383 emissivity: 3.497e-21
                 """
-                final_linemodel['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 2.9839 # 2.8875
-                final_linemodel['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'oiii_5007_amp')[0]
+                linemodel['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 2.9839 # 2.8875
+                linemodel['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'oiii_5007_amp')[0]
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_5007_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_5007_'+param)[0]
             if linename == 'nii_6548':
                 """
                 [N2] (4-->2): airwave: 6548.0488 vacwave: 6549.8578 emissivity: 2.02198e-21
                 [N2] (4-->3): airwave: 6583.4511 vacwave: 6585.2696 emissivity: 5.94901e-21
                 """
-                final_linemodel['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 2.9421 # 2.936
-                final_linemodel['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'nii_6584_amp')[0]
+                linemodel['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 2.9421 # 2.936
+                linemodel['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'nii_6584_amp')[0]
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'nii_6584_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'nii_6584_'+param)[0]
             if linename == 'sii_6731':
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'sii_6716_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'sii_6716_'+param)[0]
             if linename == 'oii_7330':
                 """
                 [O2] (5-->2): airwave: 7318.9185 vacwave: 7320.9350 emissivity: 8.18137e-24
@@ -497,20 +497,20 @@ class EMFitTools(Filters):
                 [O2] (5-->3): airwave: 7329.6613 vacwave: 7331.6807 emissivity: 1.35614e-23
                 [O2] (4-->3): airwave: 7330.7308 vacwave: 7332.7506 emissivity: 1.27488e-23
                 """
-                final_linemodel['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 1.2251
-                final_linemodel['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'oii_7320_amp')[0]
+                linemodel['tiedfactor'][param_names == linename+'_amp'] = 1.0 / 1.2251
+                linemodel['tiedtoparam'][param_names == linename+'_amp'] = np.where(param_names == 'oii_7320_amp')[0]
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oii_7320_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oii_7320_'+param)[0]
             if linename == 'siii_9069':
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'siii_9532_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'siii_9532_'+param)[0]
             # Tentative! Tie SiIII] 1892 to CIII] 1908 because they're so close in wavelength.
             if linename == 'siliii_1892':
                 for param in ['sigma', 'vshift']:
-                    final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'ciii_1908_'+param)[0]
+                    linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'ciii_1908_'+param)[0]
 
             # Stephanie Juneau argues that the narrow *forbidden* line-widths
             # should never be fully untied, so optionally keep them tied to
@@ -521,99 +521,49 @@ class EMFitTools(Filters):
                 # helium lines are separately tied together.
                 if fit_linetable['isbroad'][iline] == False and fit_linetable['isbalmer'][iline] == False and linename != 'oiii_5007':
                     for param in ['sigma']:
-                        final_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                        final_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_5007_'+param)[0]
+                        linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                        linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_5007_'+param)[0]
                     
         # Finally set the initial values and bounds on the doublet ratio parameters.
         for param, bounds, default in zip(['mgii_doublet_ratio', 'oii_doublet_ratio', 'sii_doublet_ratio'],
                                           [bounds_mgii_doublet, bounds_oii_doublet, bounds_sii_doublet],
                                           [init_mgii_doublet, init_oii_doublet, init_sii_doublet]):
-            final_linemodel['initial'][final_linemodel['param_name'] == param] = default
-            final_linemodel['bounds'][final_linemodel['param_name'] == param] = bounds
+            linemodel['initial'][linemodel['param_name'] == param] = default
+            linemodel['bounds'][linemodel['param_name'] == param] = bounds
                     
         # Assign fixed=True to parameters which are outside the wavelength range
         # except those that are tied to other lines.
-        _fix_parameters(final_linemodel, verbose=False)
+        _fix_parameters(linemodel, verbose=False)
 
-        assert(np.all(final_linemodel['tiedtoparam'][final_linemodel['tiedfactor'] != 0] != -1))
+        assert(np.all(linemodel['tiedtoparam'][linemodel['tiedfactor'] != 0] != -1))
         # It's OK for the doublet ratios to be bounded at zero.
-        #assert(len(final_linemodel[np.sum(final_linemodel['bounds'] == [0.0, 0.0], axis=1) > 0]) == 0)
+        #assert(len(linemodel[np.sum(linemodel['bounds'] == [0.0, 0.0], axis=1) > 0]) == 0)
     
-        #_print_linemodel(final_linemodel)
-        #final_linemodel[np.logical_and(final_linemodel['fixed'] == False, final_linemodel['tiedtoparam'] == -1)]
+        #_print_linemodel(linemodel)
+        #linemodel[np.logical_and(linemodel['fixed'] == False, linemodel['tiedtoparam'] == -1)]
 
-        # Model 2 - like final_linemodel, but broad lines have been fixed at
+        # Model 2 - like linemodel, but broad lines have been fixed at
         # zero.
-        final_linemodel_nobroad = final_linemodel.copy()
-        final_linemodel_nobroad['fixed'] = False # reset
+        linemodel_nobroad = linemodel.copy()
+        linemodel_nobroad['fixed'] = False # reset
 
         for iline, linename in enumerate(linenames):
             if linename == 'halpha_broad':
                 for param in ['amp', 'sigma', 'vshift']:
-                    final_linemodel_nobroad['fixed'][param_names == linename+'_'+param] = True
+                    linemodel_nobroad['fixed'][param_names == linename+'_'+param] = True
 
             if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] and linename != 'halpha_broad':
                 for param in ['amp', 'sigma', 'vshift']:
-                    final_linemodel_nobroad['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    final_linemodel_nobroad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_broad_'+param)[0]
+                    linemodel_nobroad['tiedfactor'][param_names == linename+'_'+param] = 1.0
+                    linemodel_nobroad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_broad_'+param)[0]
 
-        #final_linemodel_nobroad[np.logical_and(final_linemodel_nobroad['fixed'] == False, final_linemodel_nobroad['tiedtoparam'] == -1)]
+        #linemodel_nobroad[np.logical_and(linemodel_nobroad['fixed'] == False, linemodel_nobroad['tiedtoparam'] == -1)]
 
-        _fix_parameters(final_linemodel_nobroad, verbose=False)
+        _fix_parameters(linemodel_nobroad, verbose=False)
 
-        assert(np.all(final_linemodel_nobroad['tiedtoparam'][final_linemodel_nobroad['tiedfactor'] != 0] != -1))
+        assert(np.all(linemodel_nobroad['tiedtoparam'][linemodel_nobroad['tiedfactor'] != 0] != -1))
         
-        # Model 3 - like final_linemodel, but with all the narrow and forbidden
-        # lines tied together and all the broad lines tied together.
-        initial_linemodel = final_linemodel.copy()
-        initial_linemodel['fixed'] = False # reset
-
-        for iline, linename in enumerate(linenames):
-            # Tie all forbidden lines and narrow Balmer & He lines to [OIII] 5007.
-            if fit_linetable['isbroad'][iline] == False and linename != 'oiii_5007':
-                for param in ['sigma', 'vshift']:
-                    initial_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    initial_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'oiii_5007_'+param)[0]
-
-            ## Tie all narrow Balmer+He lines to narrow Halpha.
-            #if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] == False and linename != 'halpha':
-            #    for param in ['sigma', 'vshift']:
-            #        initial_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-            #        initial_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_'+param)[0]
-    
-            # Tie all broad Balmer+He lines to broad Halpha.
-            if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] and linename != 'halpha_broad':
-                for param in ['sigma', 'vshift']:
-                    initial_linemodel['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    initial_linemodel['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_broad_'+param)[0]
-
-        _fix_parameters(initial_linemodel, verbose=False)#True)
-
-        assert(np.all(initial_linemodel['tiedtoparam'][initial_linemodel['tiedfactor'] != 0] != -1))
-
-        # Model 4 - like initial_linemodel, but broad lines have been fixed at
-        # zero.
-        initial_linemodel_nobroad = initial_linemodel.copy()
-        initial_linemodel_nobroad['fixed'] = False # reset        
-
-        for iline, linename in enumerate(linenames):
-            if linename == 'halpha_broad':
-                for param in ['amp', 'sigma', 'vshift']:
-                    initial_linemodel_nobroad['fixed'][param_names == linename+'_'+param] = True
-
-            if fit_linetable['isbalmer'][iline] and fit_linetable['isbroad'][iline] and linename != 'halpha_broad':
-                for param in ['amp', 'sigma', 'vshift']:
-                    initial_linemodel_nobroad['tiedfactor'][param_names == linename+'_'+param] = 1.0
-                    initial_linemodel_nobroad['tiedtoparam'][param_names == linename+'_'+param] = np.where(param_names == 'halpha_broad_'+param)[0]
-
-        _fix_parameters(initial_linemodel_nobroad, verbose=False)
-
-        assert(np.all(initial_linemodel_nobroad['tiedtoparam'][initial_linemodel_nobroad['tiedfactor'] != 0] != -1))
-
-        if verbose:
-            _print_linemodel(initial_linemodel_nobroad)
-
-        return final_linemodel, final_linemodel_nobroad, initial_linemodel, initial_linemodel_nobroad
+        return linemodel, linemodel_nobroad
 
     def initial_guesses_and_bounds(self, data, emlinewave, emlineflux, log):
         """For all lines in the wavelength range of the data, get a good initial guess
@@ -2443,21 +2393,26 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
     weights = np.sqrt(emlineivar)
 
     # Build all the emission-line models for this object.
-    final_linemodel, final_linemodel_nobroad, initial_linemodel, initial_linemodel_nobroad = \
-        EMFit.build_linemodels(redshift, wavelims=(np.min(emlinewave)+5, np.max(emlinewave)-5),
-                               verbose=False, strict_finalmodel=True)
+    linemodel, linemodel_nobroad = EMFit.build_linemodels(
+        redshift, wavelims=(np.min(emlinewave)+5, np.max(emlinewave)-5),
+        verbose=False, strict_finalmodel=True)
 
     # Get initial guesses on the parameters and populate the two "initial"
     # linemodels; the "final" linemodels will be initialized with the
     # best-fitting parameters from the initial round of fitting.
-    initial_guesses, param_bounds = EMFit.initial_guesses_and_bounds(data, emlinewave, emlineflux, log)
+    initial_guesses, param_bounds = EMFit.initial_guesses_and_bounds(
+        data, emlinewave, emlineflux, log)
 
-    for linemodel in [initial_linemodel, initial_linemodel_nobroad]:
+    #for linemodel in [initial_linemodel, initial_linemodel_nobroad]:
+    #    EMFit.populate_linemodel(linemodel, initial_guesses, param_bounds, log)
+    for linemodel in [final_linemodel, final_linemodel_nobroad]:
         EMFit.populate_linemodel(linemodel, initial_guesses, param_bounds, log)
 
     # Initial fit - initial_linemodel_nobroad
     t0 = time.time()
-    initfit = EMFit.optimize(initial_linemodel_nobroad, emlinewave, emlineflux, 
+    initfit = EMFit.optimize(final_linemodel_nobroad,
+                             #initial_linemodel_nobroad,
+                             emlinewave, emlineflux, 
                              weights, redshift, resolution_matrix, camerapix, 
                              log=log, debug=False, get_finalamp=False)
     initmodel = EMFit.bestfit(initfit, redshift, emlinewave, resolution_matrix, camerapix)
@@ -2474,10 +2429,10 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
         for icam in np.arange(len(data['cameras'])):
             pixoffset = int(np.sum(data['npixpercamera'][:icam]))
             if len(data['linename'][icam]) > 0:
-                I = (initial_linemodel['isbalmer'] * (initial_linemodel['ishelium'] == False) * initial_linemodel['isbroad'] * 
-                     np.isin(initial_linemodel['linename'], data['linename'][icam]))
-                _balmer_linemodel = initial_linemodel[I]
-                _balmer_linemodel_nobroad = initial_linemodel_nobroad[I]
+                I = (final_linemodel['isbalmer'] * (final_linemodel['ishelium'] == False) * final_linemodel['isbroad'] * 
+                     np.isin(final_linemodel['linename'], data['linename'][icam]))
+                _balmer_linemodel = final_linemodel[I]
+                _balmer_linemodel_nobroad = final_linemodel_nobroad[I]
                 balmer_linemodel.append(_balmer_linemodel)
                 balmer_linemodel_nobroad.append(_balmer_linemodel_nobroad)
                 if len(_balmer_linemodel) > 0: # use balmer_linemodel not balmer_linemodel_nobroad
@@ -2488,7 +2443,9 @@ def emline_specfit(data, templatecache, result, continuummodel, smooth_continuum
                         
         if len(balmer_pix) > 0:
             t0 = time.time()
-            broadfit = EMFit.optimize(initial_linemodel, emlinewave, emlineflux, weights, 
+            broadfit = EMFit.optimize(final_linemodel,
+                                      #initial_linemodel,
+                                      emlinewave, emlineflux, weights, 
                                       redshift, resolution_matrix, camerapix, log=log,
                                       debug=False, get_finalamp=True)
             broadmodel = EMFit.bestfit(broadfit, redshift, emlinewave, resolution_matrix, camerapix)

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -186,7 +186,7 @@ def fastspec(fastphot=False, stackfit=False, args=None, comm=None, verbose=False
         if len(Spec.specfiles) == 0:
             return
     
-        data = Spec.read_and_unpack(fastphot=fastphot, mp=args.mp)
+        data = Spec.read_and_unpack(fastphot=fastphot, mp=args.mp, verbose=args.verbose)
         
     log.info('Reading and unpacking {} spectra to be fitted took {:.2f} seconds.'.format(
         Spec.ntargets, time.time()-t0))

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -246,9 +246,9 @@ def fastspec(fastphot=False, stackfit=False, args=None, comm=None, verbose=False
                       specprod=Spec.specprod, coadd_type=Spec.coadd_type,
                       fphotofile=Spec.fphotofile, templates=templates,
                       emlinesfile=emlinesfile, fastphot=fastphot,
-                      input_redshifts=input_redshifts, nophoto=args.nophoto,
+                      inputz=input_redshifts is not None, nophoto=args.nophoto,
                       broadlinefit=args.broadlinefit, constrain_age=args.constrain_age,
-                      ignore_quasarnet=args.ignore_quasarnet,
+                      use_quasarnet=args.use_quasarnet,
                       no_smooth_continuum=args.no_smooth_continuum)
 
 def fastphot(args=None, comm=None):

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -102,7 +102,7 @@ def parse(options=None, log=None):
     parser.add_argument('--qnfile-prefix', type=str, default='qso_qn-', help='Prefix of the QuasarNet afterburner file(s).')
     parser.add_argument('--mapdir', type=str, default=None, help='Optional directory name for the dust maps.')
     parser.add_argument('--fphotodir', type=str, default=None, help='Top-level location of the source photometry.')
-    parser.add_argument('--fphotoinfo', type=str, default=None, help='Photometric information file.')
+    parser.add_argument('--fphotofile', type=str, default=None, help='Photometric information file.')
     parser.add_argument('--emlinesfile', type=str, default=None, help='Emission line parameter file.')
     parser.add_argument('--specproddir', type=str, default=None, help='Optional directory name for the spectroscopic production.')
     parser.add_argument('--debug-plots', action='store_true', help='Generate a variety of debugging plots (written to $PWD).')
@@ -170,7 +170,7 @@ def fastspec(fastphot=False, stackfit=False, args=None, comm=None, verbose=False
     # Read the data.
     t0 = time.time()
     Spec = DESISpectra(stackfit=stackfit, fphotodir=args.fphotodir,
-                       fphotoinfo=args.fphotoinfo, mapdir=args.mapdir)
+                       fphotofile=args.fphotofile, mapdir=args.mapdir)
 
     if stackfit:
         data = Spec.read_stacked(args.redrockfiles, firsttarget=args.firsttarget,
@@ -239,7 +239,9 @@ def fastspec(fastphot=False, stackfit=False, args=None, comm=None, verbose=False
 
     write_fastspecfit(out, meta, modelspectra=modelspectra, outfile=args.outfile,
                       specprod=Spec.specprod, coadd_type=Spec.coadd_type,
-                      fastphot=fastphot, input_redshifts=input_redshifts,
+                      fphotofile=Spec.fphotofile, templates=templates,
+                      emlinesfile=args.emlinesfile, fastphot=fastphot,
+                      input_redshifts=input_redshifts, nophoto=args.nophoto,
                       no_smooth_continuum=args.no_smooth_continuum)
 
 def fastphot(args=None, comm=None):

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1795,7 +1795,7 @@ def read_fastspecfit(fastfitfile, rows=None, columns=None, read_models=False):
                 models = models[rows, :, :]
         else:
             models = None
-        log.info('Read {} object(s) from {}'.format(len(fastfit), fastfitfile))
+        log.info('Read {:,d} object(s) from {}'.format(len(fastfit), fastfitfile))
 
         # Add specprod to the metadata table so that we can stack across
         # productions (e.g., Fuji+Guadalupe).
@@ -2132,4 +2132,7 @@ def one_desi_spectrum(survey, program, healpix, targetid, specprod='fuji',
     write_spectra(out_coaddfile, spec)
 
     fastspec(args=f'{out_redrockfile} -o {out_fastfile}'.split())
-    fastqa(args=f'{out_fastfile} --redrockfiles {out_redrockfile} -o {outdir} --overwrite {overwrite}'.split())
+    cmdargs = f'{out_fastfile} --redrockfiles {out_redrockfile} -o {outdir}'
+    if overwrite:
+        cmdargs += '--overwrite'
+    fastqa(args=cmdargs.split())

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1833,7 +1833,8 @@ def read_fastspecfit(fastfitfile, rows=None, columns=None, read_models=False):
 def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
                       coadd_type=None, fphotofile=None, templates=None,
                       emlinesfile=None, fastphot=False, input_redshifts=False,
-                      no_smooth_continuum=False, nophoto=False):
+                      no_smooth_continuum=False, nophoto=False, broadlinefit=True,
+                      ignore_quasarnet=False, constrain_age=False):
     """Write out.
 
     """
@@ -1875,6 +1876,9 @@ def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
     primhdr.append(('INPUTZ', (input_redshifts is not None, 'input redshifts provided')))
     primhdr.append(('NOSCORR', (no_smooth_continuum is True, 'no smooth continuum correction')))
     primhdr.append(('NOPHOTO', (nophoto is True, 'no fitting to photometry')))
+    primhdr.append(('BRDLFIT', (broadlinefit is True, 'carry out broad-line fitting')))
+    primhdr.append(('CONSAGE', (constrain_age is True, 'constrain SPS ages')))
+    primhdr.append(('IGNQNET', (ignore_quasarnet is True, 'ignore QuasarNet redshifts')))
 
     primhdr = fitsheader(primhdr)
     add_dependencies(primhdr, module_names=possible_dependencies+['fastspecfit'],

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1082,7 +1082,8 @@ class DESISpectra(TabulatedDESI):
                         'photsys': photsys[iobj],
                         'dluminosity': dlum[iobj], 'dmodulus': dmod[iobj], 'tuniv': tuniv[iobj],
                         }
-                    unpackargs.append((iobj, specdata, meta[iobj], ebv[iobj], self.fphoto, True, False, log))
+                    unpackargs.append((iobj, specdata, meta[iobj], ebv[iobj], self.fphoto,
+                                       True, False, ignore_photometry, log))
             else:
                 from desispec.resolution import Resolution
                 

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -220,7 +220,7 @@ def unpack_one_spectrum(iobj, specdata, meta, ebv, fphoto, fastphot, synthphot, 
         # coadded spectrum
         coadd_linemask_dict = CTools.build_linemask(specdata['coadd_wave'], specdata['coadd_flux'],
                                                     specdata['coadd_ivar'], redshift=specdata['zredrock'],
-                                                    linetable=CTools.linetable)
+                                                    linetable=CTools.linetable, log=log)
         specdata['coadd_linename'] = coadd_linemask_dict['linename']
         specdata['coadd_linepix'] = [np.where(lpix)[0] for lpix in coadd_linemask_dict['linepix']]
         specdata['coadd_contpix'] = [np.where(cpix)[0] for cpix in coadd_linemask_dict['contpix']]
@@ -373,7 +373,7 @@ def unpack_one_stacked_spectrum(iobj, specdata, meta, fphoto, synthphot, log):
     # coadded spectrum
     coadd_linemask_dict = CTools.build_linemask(specdata['coadd_wave'], specdata['coadd_flux'],
                                                 specdata['coadd_ivar'], redshift=specdata['zredrock'],
-                                                linetable=CTools.linetable)
+                                                linetable=CTools.linetable, log=log)
     specdata['coadd_linename'] = coadd_linemask_dict['linename']
     specdata['coadd_linepix'] = [np.where(lpix)[0] for lpix in coadd_linemask_dict['linepix']]
     specdata['coadd_contpix'] = [np.where(cpix)[0] for cpix in coadd_linemask_dict['contpix']]
@@ -960,7 +960,7 @@ class DESISpectra(TabulatedDESI):
         self.meta = metas # update
         log.info('Gathered photometric metadata in {:.2f} sec'.format(time.time()-t0))
 
-    def read_and_unpack(self, fastphot=False, synthphot=True, mp=1):
+    def read_and_unpack(self, fastphot=False, synthphot=True, verbose=False, mp=1):
         """Read and unpack selected spectra or broadband photometry.
         
         Parameters
@@ -1037,7 +1037,13 @@ class DESISpectra(TabulatedDESI):
         from desispec.coaddition import coadd_cameras
         from desispec.io import read_spectra
         from desiutil.dust import SFDMap
+        from desiutil.log import get_logger, DEBUG
         from fastspecfit.continuum import ContinuumTools
+        
+        if verbose:
+            log = get_logger(DEBUG)
+        else:
+            log = get_logger()
 
         CTools = ContinuumTools(fphoto=self.fphoto)
 

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1832,9 +1832,9 @@ def read_fastspecfit(fastfitfile, rows=None, columns=None, read_models=False):
 
 def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
                       coadd_type=None, fphotofile=None, templates=None,
-                      emlinesfile=None, fastphot=False, input_redshifts=False,
+                      emlinesfile=None, fastphot=False, inputz=False,
                       no_smooth_continuum=False, nophoto=False, broadlinefit=True,
-                      ignore_quasarnet=False, constrain_age=False):
+                      use_quasarnet=True, constrain_age=False):
     """Write out.
 
     """
@@ -1873,12 +1873,12 @@ def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
         primhdr.append(('SPECPROD', (specprod, 'spectroscopic production name')))
     if coadd_type:
         primhdr.append(('COADDTYP', (coadd_type, 'spectral coadd type')))
-    primhdr.append(('INPUTZ', (input_redshifts is not None, 'input redshifts provided')))
+    primhdr.append(('INPUTZ', (inputz is True, 'input redshifts provided')))
     primhdr.append(('NOSCORR', (no_smooth_continuum is True, 'no smooth continuum correction')))
     primhdr.append(('NOPHOTO', (nophoto is True, 'no fitting to photometry')))
     primhdr.append(('BRDLFIT', (broadlinefit is True, 'carry out broad-line fitting')))
     primhdr.append(('CONSAGE', (constrain_age is True, 'constrain SPS ages')))
-    primhdr.append(('IGNQNET', (ignore_quasarnet is True, 'ignore QuasarNet redshifts')))
+    primhdr.append(('USEQNET', (use_quasarnet is True, 'use QuasarNet redshifts')))
 
     primhdr = fitsheader(primhdr)
     add_dependencies(primhdr, module_names=possible_dependencies+['fastspecfit'],

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -295,6 +295,7 @@ def _domerge(outfiles, extname='FASTSPEC', survey=None, program=None,
 
     """
     from astropy.table import vstack
+    from desiutil.depend import getdep, hasdep
     from fastspecfit.io import write_fastspecfit
     
     t0 = time.time()
@@ -311,20 +312,6 @@ def _domerge(outfiles, extname='FASTSPEC', survey=None, program=None,
     meta = vstack(_out[1])
     del _out
         
-    #for outfile in outfiles:
-    #    info = fitsio.FITS(outfile)
-    #    ext = [_info.get_extname() for _info in info]
-    #    if extname not in ext:
-    #        log.warning('Missing extension {} in file {}'.format(extname, outfile))
-    #        continue
-    #    if 'METADATA' not in ext:
-    #        log.warning('Missing extension METADATA in file {}'.format(outfile))
-    #        continue
-    #    out.append(Table(info[extname].read()))
-    #    meta.append(Table(info['METADATA'].read()))
-    #out = vstack(out)
-    #meta = vstack(meta)
-
     # sort?
     srt = np.argsort(meta['TARGETID'])
     out = out[srt]
@@ -336,9 +323,36 @@ def _domerge(outfiles, extname='FASTSPEC', survey=None, program=None,
     else:
         log.info('Merging {:,d} objects from {} files took {:.2f} min.'.format(
             len(out), len(outfiles), (time.time()-t0)/60.0))
-    
+
+    hdr = fitsio.read_header(outfiles[0])
+
+    # sensible defaults
+    deps = {}
+    deps['INPUTZ'] = False
+    deps['NOSCORR'] = False
+    deps['NOPHOTO'] = False
+    deps['BRDLFIT'] = True
+    deps['CONSAGE'] = False
+    deps['USEQNET'] = True
+    for key in deps.keys():
+        if key in hdr:
+            deps[key] = hdr[key]
+            
+    deps2 = {}
+    deps2['FPHOTO_FILE'] = None
+    deps2['FTEMPLATES_FILE'] = None
+    deps2['EMLINES_FILE'] = None
+    for key in deps2.keys():
+        if hasdep(hdr, key):
+            deps2[key] = getdep(hdr, key)
+
     write_fastspecfit(out, meta, outfile=mergefile, specprod=specprod,
-                      coadd_type=coadd_type, fastphot=fastphot)
+                      coadd_type=coadd_type, fastphot=fastphot,
+                      fphotofile=deps2['FPHOTO_FILE'], templates=deps2['FTEMPLATES_FILE'],
+                      emlinesfile=deps2['EMLINES_FILE'], inputz=deps['INPUTZ'],
+                      nophoto=deps['NOPHOTO'], broadlinefit=deps['BRDLFIT'],
+                      constrain_age=deps['CONSAGE'], use_quasarnet=deps['USEQNET'],
+                      no_smooth_continuum=deps['NOSCORR'])
 
 def merge_fastspecfit(specprod=None, coadd_type=None, survey=None, program=None,
                       healpix=None, tile=None, night=None, outsuffix=None,

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -350,7 +350,7 @@ def _domerge(outfiles, extname='FASTSPEC', survey=None, program=None,
                       coadd_type=coadd_type, fastphot=fastphot,
                       fphotofile=deps2['FPHOTO_FILE'], templates=deps2['FTEMPLATES_FILE'],
                       emlinesfile=deps2['EMLINES_FILE'], inputz=deps['INPUTZ'],
-                      nophoto=deps['NOPHOTO'], broadlinefit=deps['BRDLFIT'],
+                      ignore_photometry=deps['NOPHOTO'], broadlinefit=deps['BRDLFIT'],
                       constrain_age=deps['CONSAGE'], use_quasarnet=deps['USEQNET'],
                       no_smooth_continuum=deps['NOSCORR'])
 

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -1183,7 +1183,7 @@ def parse(options=None):
     parser.add_argument('--qnfile-prefix', type=str, default='qso_qn-', help='Prefix of the QuasarNet afterburner file(s).')
     parser.add_argument('--mapdir', type=str, default=None, help='Optional directory name for the dust maps.')
     parser.add_argument('--fphotodir', type=str, default=None, help='Top-level location of the source photometry.')    
-    parser.add_argument('--fphotoinfo', type=str, default=None, help='Photometric information file.')
+    parser.add_argument('--fphotofile', type=str, default=None, help='Photometric information file.')
 
     parser.add_argument('--emline-snrmin', type=float, default=0.0, help='Minimum emission-line S/N to be displayed.')
     parser.add_argument('--nsmoothspec', type=int, default=0, help='Smoothing pixel value.')
@@ -1305,7 +1305,7 @@ def fastqa(args=None, comm=None):
 
     # Initialize the I/O class.
     Spec = DESISpectra(stackfit=args.stackfit, redux_dir=args.redux_dir, fphotodir=args.fphotodir, 
-                       fphotoinfo=args.fphotoinfo, mapdir=args.mapdir)
+                       fphotofile=args.fphotofile, mapdir=args.mapdir)
 
     templates = get_templates_filename(templateversion=args.templateversion, imf=args.imf)
 

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -19,8 +19,9 @@ def _desiqa_one(args):
 def desiqa_one(data, fastfit, metadata, templates, coadd_type, fphoto,
                minspecwave=3500., maxspecwave=9900., minphotwave=0.1, 
                maxphotwave=35., emline_snrmin=0.0, nsmoothspec=1, 
-               fastphot=False, nophoto=False, stackfit=False, inputz=False, 
-               no_smooth_continuum=False, outdir=None, outprefix=None, log=None):
+               fastphot=False, ignore_photometry=False, stackfit=False,
+               inputz=False, no_smooth_continuum=False, outdir=None,
+               outprefix=None, log=None):
     """Multiprocessing wrapper to generate QA for a single object.
 
     """
@@ -38,6 +39,7 @@ def desiqa_one(data, fastfit, metadata, templates, coadd_type, fphoto,
                 spec_wavelims=(minspecwave, maxspecwave), 
                 phot_wavelims=(minphotwave, maxphotwave), 
                 no_smooth_continuum=no_smooth_continuum,
+                ignore_photometry=ignore_photometry,
                 emline_snrmin=emline_snrmin, nsmoothspec=nsmoothspec,
                 fastphot=fastphot, fphoto=fphoto, stackfit=stackfit, 
                 outprefix=outprefix, outdir=outdir, log=log, cosmo=cosmo)
@@ -45,8 +47,9 @@ def desiqa_one(data, fastfit, metadata, templates, coadd_type, fphoto,
 def qa_fastspec(data, templatecache, fastspec, metadata, coadd_type='healpix',
                 spec_wavelims=(3550, 9900), phot_wavelims=(0.1, 35),
                 fastphot=False, fphoto=None, stackfit=False, outprefix=None,
-                no_smooth_continuum=False, emline_snrmin=0.0, nsmoothspec=1, 
-                outdir=None, log=None, cosmo=None):
+                no_smooth_continuum=False, ignore_photometry=False,
+                emline_snrmin=0.0, nsmoothspec=1, outdir=None, log=None,
+                cosmo=None):
     """QA plot the emission-line spectrum and best-fitting model.
 
     """
@@ -98,7 +101,7 @@ def qa_fastspec(data, templatecache, fastspec, metadata, coadd_type='healpix',
         else:
             return f'{x:.0f}'
 
-    CTools = ContinuumTools(fphoto=fphoto)
+    CTools = ContinuumTools(fphoto=fphoto, ignore_photometry=ignore_photometry)
     if 'legacysurveydr' in fphoto.keys():
         layer = 'ls-{}'.format(fphoto['legacysurveydr'])
     else:
@@ -576,7 +579,6 @@ def qa_fastspec(data, templatecache, fastspec, metadata, coadd_type='healpix',
                 if np.max(modelflux) > spec_ymax:
                     spec_ymax = np.max(modelflux) * 1.25
                 #print(spec_ymin, spec_ymax)
-                #pdb.set_trace()
         
             #specax.fill_between(wave, flux-sigma, flux+sigma, color=col1[icam], alpha=0.2)
             if nsmoothspec > 1:
@@ -637,7 +639,6 @@ def qa_fastspec(data, templatecache, fastspec, metadata, coadd_type='healpix',
                 _wave = data['wave'][icam][good]/1e4
                 _flux = -2.5*np.log10(desimodelspec[icam][good]*factor[good])
                 sedax.plot(_wave, _flux, color=col2[icam], alpha=0.8)
-                #pdb.set_trace()
 
         # we have to set the limits *before* we call errorbar, below!
         dm = 1.5
@@ -941,8 +942,6 @@ def qa_fastspec(data, templatecache, fastspec, metadata, coadd_type='healpix',
                         if _line_ymin < line_ymin[iax]:
                             line_ymin[iax] = _line_ymin
                         #print(linename, line_ymin[iax], line_ymax[iax])
-                        #if linename == '[OII] $\lambda\lambda$3726,29':
-                        #    pdb.set_trace()
             
                         xx.set_xlim(wmin/1e4, wmax/1e4)
 
@@ -1198,7 +1197,6 @@ def parse(options=None):
     parser.add_argument('--firsttarget', type=int, default=0, help='Index of first object to to process in each file (0-indexed).')
     parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
     parser.add_argument('--stackfit', action='store_true', help='Generate QA for stacked spectra.')
-    parser.add_argument('--nophoto', action='store_true', help='Do not include the photometry in the model fitting.')
     parser.add_argument('--overwrite', action='store_true', help='Overwrite existing files.')
 
     parser.add_argument('--imf', type=str, default='chabrier', help='Initial mass function.')
@@ -1269,17 +1267,18 @@ def fastqa(args=None, comm=None):
         log.critical(errmsg)
         raise IOError(errmsg)
 
-    # check for the input redshifts header card
+    # check for various header cards
     hdr = fitsio.read_header(args.fastfitfile[0])
+    inputz = False
+    no_smooth_continuum = False
+    ignore_photometry = False
+    
     if 'INPUTZ' in hdr and hdr['INPUTZ']:
         inputz = True
-    else:
-        inputz = False
-
     if 'NOSCORR' in hdr and hdr['NOSCORR']:
         no_smooth_continuum = True
-    else:
-        no_smooth_continuum = False
+    if 'NOPHOTO' in hdr and hdr['NOPHOTO']:
+        ignore_photometry = True
 
     if args.outdir:
         if not os.path.isdir(args.outdir):
@@ -1316,7 +1315,6 @@ def fastqa(args=None, comm=None):
         if stackfit:
             stackids = fastfit['STACKID'][indx]
             data = Spec.read_stacked(redrockfile, stackids=stackids, mp=args.mp)
-            args.nophoto = True # force nophoto=True
 
             minspecwave = np.min(data[0]['coadd_wave']) - 20
             maxspecwave = np.max(data[0]['coadd_wave']) + 20
@@ -1339,7 +1337,7 @@ def fastqa(args=None, comm=None):
         qaargs = [(data[igal], fastfit[indx[igal]], metadata[indx[igal]],
                    templates, coadd_type, Spec.fphoto, minspecwave, maxspecwave, 
                    args.minphotwave, args.maxphotwave, args.emline_snrmin, 
-                   args.nsmoothspec, fastphot, args.nophoto, stackfit, inputz, 
+                   args.nsmoothspec, fastphot, ignore_photometry, stackfit, inputz, 
                    no_smooth_continuum, args.outdir, args.outprefix, log)
                    for igal in np.arange(len(indx))]
         if args.mp > 1:


### PR DESCRIPTION
The test runs with `2.4.0` revealed a computational inconsistency for objects with broad lines that this PR fixes. Briefly, I was originally doing three rounds of emission-line fitting: 
* First round with narrow lines only with forbidden and Balmer lines tied together;
* Second round with narrow plus broad lines forbidden and narrow Balmer lines tied together and broad Balmer lines (separately) tied together;
* Final round (after choosing between narrow or narrow+broad) where the forbidden and narrow Halpha lines were optimized separately.

The problem with this algorithm is that the final round comes _after_ the broad vs narrow+broad decision has been made so the final numbers don't alway match the numbers used to make the decision. For example, the broad Balmer lines have to be at least 250 km/s, but there are objects that have line-widths less than this threshold because the in the final round the algorithm decides that it likes a narrower line!

So in this PR we only do two rounds of fitting and keep the forbidden and narrow Balmer lines separate in both rounds. Also note that the speed-up is 10%-20% because of the fewer rounds of line-fitting!

I also fixed a few more small bugs and more provenance information is written to the headers such as the name of the emission line and photometry parameter files.

Once tests pass I'm going to tag and regenerate the Fuji VAC.