### PR TITLE
incorrect syntax synthesizing photometry for highest-redshift targets

### DIFF
--- a/bin/get-cutouts
+++ b/bin/get-cutouts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """MPI wrapper to get a large number of image cutouts. Only run ahead of a VAC
 release.
@@ -28,16 +28,21 @@ def cutout_one(jpegfile, ra, dec, dry_run, rank, iobj):
     height = int(width / 1.3) # =87 [3:2 aspect ratio]
 
     """
-    import subprocess
+    from cutout import cutout
 
-    cmd = f'cutout --output={jpegfile} --ra={ra} --dec={dec} --width=114 --height=87 --layer=ls-dr9 --pixscale=0.262 --force'
+    width = 114
+    height = 87
+
+    cmdargs = f'--ra={ra} --dec={dec} --output={jpegfile} --width={width} --height={height} --layer=ls-dr9 --pixscale=0.262 --force'
     if dry_run:
         #print(f'rank {rank} workin on object {iobj}')
-        print(cmd)
+        print(f'Rank {rank}, object {iobj}: cutout {cmdargs}')
     else:
-        err = subprocess.call(cmd.split())
-        if err != 0:
-            print(f'Warning: Problem writing {jpegfile}')
+        try:
+            cutout(ra, dec, jpegfile, width=width, height=height, layer='ls-dr9', pixscale=0.262, force=True)
+            print(f'Rank {rank}, object {iobj}: cutout {cmdargs}')
+        except:
+            print(f'WARNING: Rank {rank}, object {iobj}: problem writing {jpegfile}')
 
 def _get_jpegfiles_one(args):
     return get_jpegfiles_one(*args)
@@ -106,6 +111,64 @@ def get_cutout_filename(metadata, coadd_type, outprefix=None, htmldir=None):
         jpegfile = [_one_filename(_metadata) for _metadata in metadata]
     
     return np.array(jpegfile)
+
+def weighted_partition(weights, n, groups_per_node=None):
+    '''
+    Partition `weights` into `n` groups with approximately same sum(weights)
+
+    Args:
+        weights: array-like weights
+        n: number of groups
+
+    Returns list of lists of indices of weights for each group
+
+    Notes:
+        compared to `dist_discrete_all`, this function allows non-contiguous
+        items to be grouped together which allows better balancing.
+    '''
+    #- sumweights will track the sum of the weights that have been assigned
+    #- to each group so far
+    sumweights = np.zeros(n, dtype=float)
+
+    #- Initialize list of lists of indices for each group
+    groups = list()
+    for i in range(n):
+        groups.append(list())
+
+    #- Assign items from highest weight to lowest weight, always assigning
+    #- to whichever group currently has the fewest weights
+    weights = np.asarray(weights)
+    for i in np.argsort(-weights):
+        j = np.argmin(sumweights)
+        groups[j].append(i)
+        sumweights[j] += weights[i]
+
+    assert len(groups) == n
+
+    #- Reorder groups to spread out large items across different nodes
+    #- NOTE: this isn't perfect, e.g. study
+    #-   weighted_partition(np.arange(12), 6, groups_per_node=2)
+    #- even better would be to zigzag back and forth across the nodes instead
+    #- of loop across the nodes.
+    if groups_per_node is None:
+        return groups
+    else:
+        distributed_groups = [None,] * len(groups)
+        num_nodes = (n + groups_per_node - 1) // groups_per_node
+        i = 0
+        for noderank in range(groups_per_node):
+            for inode in range(num_nodes):
+                j = inode*groups_per_node + noderank
+                if i < n and j < n:
+                    distributed_groups[j] = groups[i]
+                    i += 1
+
+        #- do a final check that all groups were assigned
+        for i in range(len(distributed_groups)):
+            assert distributed_groups[i] is not None, 'group {} not set'.format(i)
+
+        return distributed_groups
+
 
 def plan(comm=None, specprod=None, coadd_type='healpix',
          survey=None, program=None, healpix=None, tile=None, night=None, 
@@ -259,19 +322,21 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
         print(f'Missing cutouts for {np.sum(ntargets)} targets.')
         #print('Working on {} files with a total of {} targets.'.format(len(itodo), np.sum(ntargets)))
 
-        indices = np.arange(len(jpegfiles))
-
-        # Assign the sample to ranks to make the jpegfiles distribution per rank ~flat.
-        # https://stackoverflow.com/questions/33555496/split-array-into-equally-weighted-chunks-based-on-order
-        cumuweight = ntargets.cumsum() / ntargets.sum()
-        idx = np.searchsorted(cumuweight, np.linspace(0, 1, size, endpoint=False)[1:])
-        if len(idx) < size: # can happen in corner cases or with 1 rank
-            groups = np.array_split(indices, size) # unweighted
-        else:
-            groups = np.array_split(indices, idx) # weighted
-        for ii in range(size): # sort by weight
-            srt = np.argsort(ntargets[groups[ii]])
-            groups[ii] = groups[ii][srt]
+        groups = weighted_partition(ntargets, size)
+            
+        #indices = np.arange(len(jpegfiles))
+        #
+        ## Assign the sample to ranks to make the jpegfiles distribution per rank ~flat.
+        ## https://stackoverflow.com/questions/33555496/split-array-into-equally-weighted-chunks-based-on-order
+        #cumuweight = ntargets.cumsum() / ntargets.sum()
+        #idx = np.searchsorted(cumuweight, np.linspace(0, 1, size, endpoint=False)[1:])
+        #if len(idx) < size: # can happen in corner cases or with 1 rank
+        #    groups = np.array_split(indices, size) # unweighted
+        #else:
+        #    groups = np.array_split(indices, idx) # weighted
+        #for ii in range(size): # sort by weight
+        #    srt = np.argsort(ntargets[groups[ii]])
+        #    groups[ii] = groups[ii][srt]
     else:
         groups = [np.array([])]
 
@@ -313,8 +378,9 @@ def do_cutouts(args, comm=None, outdir_data='.', outdir_html='.'):
     for ii in groups[rank]:
         print(f'Rank {rank} started at {time.asctime()}')
         sys.stdout.flush()
-
-        mpargs = [(jpegfile, ra, dec, args.dry_run, rank, ii) for jpegfile, ra, dec in zip(jpegfiles[ii], allra[ii], alldec[ii])]
+    
+        mpargs = [(jpegfile, ra, dec, args.dry_run, rank, iobj) for iobj, (jpegfile, ra, dec) in
+                  enumerate(zip(jpegfiles[ii], allra[ii], alldec[ii]))]
         if args.mp > 1:
             with multiprocessing.Pool(args.mp) as P:
                 P.map(_cutout_one, mpargs)

--- a/bin/get-cutouts
+++ b/bin/get-cutouts
@@ -3,27 +3,11 @@
 """MPI wrapper to get a large number of image cutouts. Only run ahead of a VAC
 release.
 
-get-cutouts --survey cmx --mp 16 --dry-run
+shifterimg pull dstndstn/cutouts:dvsro
+shifter --image dstndstn/cutouts:dvsro cutout --output cutout.jpg --ra 234.2915 --dec 16.7684 --size 256 --layer ls-dr9 --pixscale 0.262 --force
 
-shifterimg pull dstndstn/viewer-cutouts:latest
-shifter --image dstndstn/viewer-cutouts cutout --output cutout.jpg --ra 234.2915 --dec 16.7684 --size 256 --layer ls-dr9 --pixscale 0.262 --force
-
-shifter --image dstndstn/viewer-cutouts bash
-/global/u2/i/ioannis/code/desihub/fastspecfit/bin/get-cutouts --survey cmx --program other --mp 128
-
-cd /global/cfs/cdirs/desi/spectro/fastspecfit/fuji/html/healpix
-from glob import glob
-nftot = 0
-for survey in sorted(glob('*')):
-    for program in glob(os.path.join(survey, '*')):
-        nf = 0
-        for hp100 in glob(os.path.join(program, '*')):
-            for hp in glob(os.path.join(hp100, '*')):
-                nf += len(glob(hp+'/tmp*.jpeg'))
-        nftot += nf
-        print(program, nf)
-print()
-print('Total: ', nftot)
+shifter --image dstndstn/cutouts:dvsro bash
+$HOME/code/desihub/fastspecfit/bin/get-cutouts --survey cmx --program other --mp 1 --dry-run
 
 """
 import pdb # for debugging
@@ -37,7 +21,7 @@ from glob import glob
 def _cutout_one(args):
     return cutout_one(*args)
 
-def cutout_one(jpegfile, ra, dec, dry_run):
+def cutout_one(jpegfile, ra, dec, dry_run, rank, iobj):
     """
     pixscale = 0.262
     width = int(30 / pixscale)   # =114
@@ -46,14 +30,14 @@ def cutout_one(jpegfile, ra, dec, dry_run):
     """
     import subprocess
 
-    cmd = 'cutout --output={} --ra={} --dec={} --width=114 --height=87 --layer=ls-dr9 --pixscale=0.262 --force'.format(
-        jpegfile, ra, dec)
+    cmd = f'cutout --output={jpegfile} --ra={ra} --dec={dec} --width=114 --height=87 --layer=ls-dr9 --pixscale=0.262 --force'
     if dry_run:
+        #print(f'rank {rank} workin on object {iobj}')
         print(cmd)
     else:
         err = subprocess.call(cmd.split())
         if err != 0:
-            print('Warning: Problem writing {}'.format(jpegfile))
+            print(f'Warning: Problem writing {jpegfile}')
 
 def _get_jpegfiles_one(args):
     return get_jpegfiles_one(*args)
@@ -72,7 +56,7 @@ def get_jpegfiles_one(fastspecfile, coadd_type, htmldir_root, overwrite, verbose
         J = ~I
         if np.sum(J) > 0:
             if verbose:
-                print('Skipping {} existing QA file(s) from fastspecfile {}.'.format(np.sum(J), fastspecfile))
+                print(f'Skipping {np.sum(J)} existing QA file(s) from fastspecfile {fastspecfile}.')
             jpegfiles = jpegfiles[I]
             allra = allra[I]
             alldec = alldec[I]
@@ -83,7 +67,7 @@ def get_cutout_filename(metadata, coadd_type, outprefix=None, htmldir=None):
     """Build the cutout filename.
 
     """
-    import astropy
+    import astropy.table
 
     if htmldir is None:
         htmldir = '.'
@@ -147,7 +131,7 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
 
         # figure out which tiles belong to the SV programs
         if tile is None:
-            tilefile = os.path.join(desi_root, 'spectro', 'redux', specprod, 'tiles-{}.csv'.format(specprod))
+            tilefile = os.path.join(desi_root, 'spectro', 'redux', specprod, 'tiles-{specprod}.csv')
             alltileinfo = Table.read(tilefile)
             tileinfo = alltileinfo[['sv' in survey for survey in alltileinfo['SURVEY']]]
 
@@ -170,7 +154,7 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
             thesefiles = []
             for onesurvey in np.atleast_1d(survey):
                 for oneprogram in np.atleast_1d(program):
-                    print('Building file list for survey={} and program={}'.format(onesurvey, oneprogram))
+                    print(f'Building file list for survey={onesurvey} and program={oneprogram}')
                     if healpix is not None:
                         for onepix in healpixels:
                             _thesefiles = glob(os.path.join(filedir, onesurvey, oneprogram, str(int(onepix)//100), onepix,
@@ -196,7 +180,8 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
                     if len(nightdirs) > 0:
                         # for a given tile, take just the most recent night
                         thisnightdir = nightdirs[-1]
-                        thesefiles.append(glob(os.path.join(thisnightdir, '{}-[0-9]-{}-thru????????.{}'.format(prefix, onetile, fitssuffix))))
+                        thesefiles.append(glob(os.path.join(thisnightdir, '{}-[0-9]-{}-thru????????.{}'.format(
+                            prefix, onetile, fitssuffix))))
                 if len(thesefiles) > 0:
                     thesefiles = np.array(sorted(set(np.hstack(thesefiles))))
         elif coadd_type == 'pernight':
@@ -205,7 +190,8 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
                 for onetile in tile:
                     for onenight in night:
                         thesefiles.append(glob(os.path.join(
-                            filedir, 'pernight', str(onetile), str(onenight), '{}-[0-9]-{}-{}.{}'.format(prefix, onetile, onenight, fitssuffix))))
+                            filedir, 'pernight', str(onetile), str(onenight), '{}-[0-9]-{}-{}.{}'.format(
+                                prefix, onetile, onenight, fitssuffix))))
                 if len(thesefiles) > 0:
                     thesefiles = np.array(sorted(set(np.hstack(thesefiles))))
             elif tile is not None and night is None:
@@ -218,7 +204,8 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
                     prefix, onenight, fitssuffix))) for onenight in night]))))
             else:
                 thesefiles = np.array(sorted(set(glob(os.path.join(
-                    filedir, '?????', '????????', '{}-[0-9]-?????-????????.{}'.format(prefix, fitssuffix))))))
+                    filedir, '?????', '????????', '{}-[0-9]-?????-????????.{}'.format(
+                        prefix, fitssuffix))))))
         elif coadd_type == 'perexp':
             if tile is not None:
                 thesefiles = np.array(sorted(set(np.hstack([glob(os.path.join(
@@ -226,7 +213,8 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
                     prefix, onetile, fitssuffix))) for onetile in tile]))))
             else:
                 thesefiles = np.array(sorted(set(glob(os.path.join(
-                    filedir, 'perexp', '?????', '????????', '{}-[0-9]-?????-exp????????.{}'.format(prefix, fitssuffix))))))
+                    filedir, 'perexp', '?????', '????????', '{}-[0-9]-?????-exp????????.{}'.format(
+                        prefix, fitssuffix))))))
         else:
             pass
         return thesefiles
@@ -240,7 +228,7 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
             print('No fastspecfiles found!')
         return list(), list(), list(), list
 
-    print('Found {} fastspecfiles.'.format(nfile))
+    print(f'Found {nfile} fastspecfiles.')
 
     verbose = False
     mpargs = [(fastspecfile, coadd_type, htmldir, overwrite, verbose)
@@ -259,7 +247,7 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
         
     iempty = np.where(ntargets == 0)[0]
     if len(iempty) > 0:
-        print('Skipping {} fastspecfiles with no jpeg files to make.'.format(len(iempty)))
+        print(f'Skipping {len(iempty)} fastspecfiles with no jpeg files to make.')
 
     itodo = np.where(ntargets > 0)[0]
     if len(itodo) > 0:
@@ -268,7 +256,7 @@ def plan(comm=None, specprod=None, coadd_type='healpix',
         alldec = alldec[itodo]
         ntargets = ntargets[itodo]
 
-        print('Missing cutouts for {} targets.'.format(np.sum(ntargets)))
+        print(f'Missing cutouts for {np.sum(ntargets)} targets.')
         #print('Working on {} files with a total of {} targets.'.format(len(itodo), np.sum(ntargets)))
 
         indices = np.arange(len(jpegfiles))
@@ -305,7 +293,7 @@ def do_cutouts(args, comm=None, outdir_data='.', outdir_html='.'):
                 healpix=args.healpix, tile=args.tile, night=args.night,
                 outdir_data=outdir_data, outdir_html=outdir_html,
                 overwrite=args.overwrite, mp=args.mp)
-        print('Planning took {:.2f} sec'.format(time.time() - t0))
+        print(f'Planning took {(time.time() - t0):.2f} sec')
     else:
         jpegfiles, allra, alldec, groups = [], [], [], []
 
@@ -323,24 +311,24 @@ def do_cutouts(args, comm=None, outdir_data='.', outdir_html='.'):
     assert(len(groups) == size)
 
     for ii in groups[rank]:
-        print('Rank {} started at {}'.format(rank, time.asctime()))
+        print(f'Rank {rank} started at {time.asctime()}')
         sys.stdout.flush()
 
-        mpargs = [(jpegfile, ra, dec, args.dry_run) for jpegfile, ra, dec in zip(jpegfiles[ii], allra[ii], alldec[ii])]
+        mpargs = [(jpegfile, ra, dec, args.dry_run, rank, ii) for jpegfile, ra, dec in zip(jpegfiles[ii], allra[ii], alldec[ii])]
         if args.mp > 1:
             with multiprocessing.Pool(args.mp) as P:
                 P.map(_cutout_one, mpargs)
         else:
             [cutout_one(*mparg) for mparg in mpargs]
 
-    print('  rank {} is done'.format(rank))
+    print(f'  rank {rank} is done')
     sys.stdout.flush()
 
     if comm is not None:
         comm.barrier()
 
     if rank == 0 and not args.dry_run:
-        print('All done at {}'.format(time.asctime()))
+        print(f'All done at {time.asctime()}')
         
 def main():
     """Main wrapper.

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -178,6 +178,9 @@ def main():
     parser.add_argument('--mergedir', type=str, help='Output directory for merged catalogs.')
     parser.add_argument('--merge-suffix', type=str, help='Filename suffix for merged catalogs.')
     parser.add_argument('--mergeall', action='store_true', help='Merge all the individual merged catalogs into a single merged catalog.')
+    parser.add_argument('--mergeall-main', action='store_true', help='Merge all the main catalogs.')
+    parser.add_argument('--mergeall-sv', action='store_true', help='Merge all the SV catalogs.')
+    parser.add_argument('--mergeall-special', action='store_true', help='Merge all the special catalogs.')
     parser.add_argument('--makeqa', action='store_true', help='Build QA in parallel.')
     parser.add_argument('--ntest', type=int, default=None, help='Select ntest healpixels as a test sample drawn randomly from the full specprod (only for coadd-type==healpix).')
     
@@ -239,11 +242,45 @@ def main():
             log.info(f'Selecting {len(I)} test healpixels: {args.healpix}')
             print(tilepix[I])
 
+    if args.mergeall_main or args.mergeall_sv or args.mergeall_special:
+        args.mergeall = True
+
     if args.merge or args.mergeall:
         from fastspecfit.mpi import merge_fastspecfit
+
+        # convenience code to make the super-merge catalogs, e.g., fastspec-iron-{main,special,sv}.fits
+        if args.fastphot:
+            fastprefix = 'fastphot'
+        else:
+            fastprefix = 'fastspec'
+        
+        if args.mergeall_main or args.mergeall_sv or args.mergeall_special:
+            from glob import glob
+            if args.mergedir is None:
+                mergedir = os.path.join(outdir_data, args.specprod, 'catalogs')
+            else:
+                mergedir = args.mergedir
+                
+            if args.mergeall_main:
+                args.merge_suffix = f'{args.specprod}-main'
+                fastfiles_to_merge = glob(os.path.join(mergedir, f'{fastprefix}-{args.specprod}-main-*.fits'))
+            elif args.mergeall_special:
+                args.merge_suffix = f'{args.specprod}-special'
+                fastfiles_to_merge = glob(os.path.join(mergedir, f'{fastprefix}-{args.specprod}-special-*.fits'))
+            elif args.mergeall_sv:
+                args.merge_suffix = f'{args.specprod}-sv'
+                fastfiles_to_merge = list(set(glob(os.path.join(mergedir, f'{fastprefix}-{args.specprod}-*.fits'))) -
+                                          set(glob(os.path.join(mergedir, f'{fastprefix}-{args.specprod}-main.fits'))) -
+                                          set(glob(os.path.join(mergedir, f'{fastprefix}-{args.specprod}-special.fits'))))
+            else:
+                fastfiles_to_merge = None
+        else:
+            fastfiles_to_merge = None
+
         merge_fastspecfit(specprod=args.specprod, specprod_dir=specprod_dir, coadd_type=args.coadd_type,
                           survey=args.survey, program=args.program, healpix=args.healpix,
                           tile=args.tile, night=args.night, outdir_data=outdir_data,
+                          fastfiles_to_merge=fastfiles_to_merge,
                           outsuffix=args.merge_suffix, mergedir=args.mergedir, overwrite=args.overwrite,
                           fastphot=args.fastphot, supermerge=args.mergeall, mp=args.mp)
         return

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 """
 MPI wrapper for fastphot and fastspec.
 

--- a/bin/validate-production
+++ b/bin/validate-production
@@ -30,28 +30,29 @@ def _check_one_catalog(args):
     """Multiprocessing wrapper."""
     return check_one_catalog(*args) 
 
-def check_one_catalog(zcatfile, specprod):
+def check_one_catalog(zcatfile, specprod, version):
+
+    from desitarget import geomask
     
-    fastfile = zcatfile.replace('redux/{}/zcatalog/zpix-'.format(specprod), 'fastspecfit/{0}/catalogs/fastspec-{0}-'.format(specprod))
+    fastfile = zcatfile.replace('redux/{}/zcatalog/zpix-'.format(specprod), 'fastspecfit/{0}/{1}/catalogs/fastspec-{0}-'.format(specprod, version))
     
-    log.info('Reading {}'.format(zcatfile))
+    log.info(f'Reading {zcatfile}')
     zcat = Table(fitsio.read(zcatfile, ext='ZCATALOG', columns=['TARGETID', 'Z', 'ZWARN', 'OBJTYPE']))
-    I = np.where((zcat['Z'] > 0.001) * (zcat['OBJTYPE'] == 'TGT') * (zcat['ZWARN'] & ZWarningMask.NODATA == 0))[0]
-    zcat = zcat[I]
 
+    log.info(f'Reading {fastfile}')
     fast = Table(fitsio.read(fastfile, ext='METADATA', columns=['TARGETID', 'Z', 'Z_RR', 'ZWARN']))
-    srt = np.hstack([np.where(zcat['TARGETID'] == tid)[0] for tid in fast['TARGETID']])
-    zcat = zcat[srt]
 
+    indx_zcat, indx_fast = geomask.match(zcat['TARGETID'], fast['TARGETID'])
+    zcat = zcat[indx_zcat]
+    fast = fast[indx_fast]
     assert(len(zcat) == len(fast))
+    assert(np.all(zcat['TARGETID'] == fast['TARGETID']))
 
-    for fcol, zcol in zip(['TARGETID', 'Z_RR', 'ZWARN'], ['TARGETID', 'Z', 'ZWARN']):
-        try:
-            assert(np.all(fast[fcol] == zcat[zcol]))
-        except:
-            log.warning('Assert failed on column {} in catalog {}'.format(fcol, fastfile))
+    # zcat['Z'] and fast['Z_RR'] should always match but where zcat['Z'] and
+    # fast['Z'] differ should be the QSOs with updated redshifts.
+    assert(np.all(zcat['Z'] == fast['Z_RR']))
 
-    zdiff = fast['Z'] != zcat['Z']
+    zdiff = zcat['Z'] != fast['Z']
     if np.sum(zdiff) > 0:
         log.info('Found {:,d}/{:,d} ({:.4f}%) updated QSO redshifts in catalog {}'.format(
             np.sum(zdiff), len(fast), np.sum(zdiff)/len(fast), fastfile))
@@ -61,13 +62,13 @@ def check_one_catalog(zcatfile, specprod):
 
     return outfile, len(fast), np.sum(zdiff)
 
-def check_catalogs(specprod_dir, fastspecdir, specprod, mp=1):
+def check_catalogs(specprod_dir, fastspecdir, specprod, version, mp=1):
     
     # Read all the zpix catalogs in parallel.
     zcatfiles = sorted(glob(os.path.join(specprod_dir, 'zcatalog', 'zpix-*-*.fits')))
     mpargs = []
     for zcatfile in zcatfiles:
-        mpargs.append([zcatfile, specprod])
+        mpargs.append([zcatfile, specprod, version])
     if mp > 1:
         with multiprocessing.Pool(mp) as P:
             out = P.map(_check_one_catalog, mpargs)
@@ -88,7 +89,7 @@ def check_catalogs(specprod_dir, fastspecdir, specprod, mp=1):
     nrows.append(len(fast))
     nznews.append(np.sum(zdiff))
 
-    headers = ['Catalog', 'Number of Targets', 'Number with Corrected Redshifts']
+    headers = ['Catalog', 'Number of Objects', 'Number with Corrected Redshifts']
     widths = np.array([len(header) for header in headers])
     lines = []
     for fastfile, nrow, nznew in zip(fastfiles, nrows, nznews):
@@ -320,12 +321,13 @@ def main():
 
     p = argparse.ArgumentParser()
     p.add_argument('--specprod', type=str, required=True, help='output file prefix')
+    p.add_argument('--version', type=str, required=True, help='production version')
     p.add_argument('--mp', type=int, default=1, help='number of multiprocessing cores')
     p.add_argument('--statistics', action='store_true', help='Do file statistics.')
     p.add_argument('--validate', action='store_true', help='Validate the files.')
     args = p.parse_args()
 
-    fastspecdir = '/global/cfs/cdirs/desi/spectro/fastspecfit/'+args.specprod
+    fastspecdir = os.path.join(desi_root, 'spectro', 'fastspecfit', args.specprod, args.version)
     specprod_dir = os.path.join(desi_root, 'spectro', 'redux', args.specprod)
 
     if args.specprod == 'fuji':
@@ -350,12 +352,12 @@ def main():
     # Validate files.
     if args.validate:
         # check for infinity and other crap
-        check_infinity(fastspecdir, specprod_dir, args.specprod, mp=args.mp)
+        #check_infinity(fastspecdir, specprod_dir, args.specprod, mp=args.mp)
         #check_infinity(fastspecdir, specprod_dir, args.specprod, mp=args.mp, fastphot=True)
         
         # verify that we have all the targets we expect and also summarize the
         # number of targets with corrected redshifts
-        check_catalogs(specprod_dir, fastspecdir, args.specprod, mp=args.mp)
+        check_catalogs(specprod_dir, fastspecdir, args.specprod, args.version, mp=args.mp)
 
 if __name__ == '__main__':
     main()

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,18 @@
 Change Log
 ==========
 
-2.4.2 (not released yet)
+2.4.3 (not released yet)
 ------------------------
 
 * 
+
+2.4.2 (2023-08-28)
+------------------
+
+* Fix incorrect syntax synthesizing photometry for highest-redshift targets bug
+  [`PR #152`_]. 
+
+.. _`PR #152`: https://github.com/desihub/fastspecfit/pull/152
 
 2.4.1 (2023-08-23)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,7 +7,7 @@ Change Log
 
 * 
 
-2.4.2 (2023-08-28)
+2.4.2 (2023-08-30)
 ------------------
 
 * Fix incorrect syntax synthesizing photometry for highest-redshift targets bug

--- a/doc/fuji.rst
+++ b/doc/fuji.rst
@@ -10,16 +10,15 @@ Overview
 --------
 
 This page describes the ``Fuji`` value-added catalog, which will be publicly
-released as part of the `DESI Early Data Release (DESI/EDR)`_ in
-late-summer 2023.
+released as part of the `DESI Early Data Release (DESI/EDR)`_ in late-2023. 
 
 Please refer to the :ref:`acknowledgments` section for the conditions for using
 this VAC.
 
 .. note::
 
-   We only document the *v2.0* version of this VAC; the *v1.0* version is
-   publicly accessible but has been deprecated and is not documented further.
+   We only document the *v3.0* version of this VAC; the *v1.0* and *v2.0*
+   versions have been deprecated and are not documented further.
 
 Data Content & Access
 ---------------------
@@ -27,9 +26,9 @@ Data Content & Access
 Data from the ``Fuji`` VAC can be accessed at any of the following links:
 
 ============================ ============================================================
-Data url                     https://data.desi.lbl.gov/desi/spectro/fastspecfit/fuji/v2.0
+Data url                     https://data.desi.lbl.gov/desi/spectro/fastspecfit/fuji/v3.0
 Interactive web-app          https://fastspecfit.desi.lbl.gov
-`NERSC`_ (for collaborators) ``/global/cfs/cdirs/desi/spectro/fastspecfit/fuji/v2.0``
+`NERSC`_ (for collaborators) ``/global/cfs/cdirs/desi/spectro/fastspecfit/fuji/v3.0``
 ============================ ============================================================
 
 For more information regarding the content and organization of the VAC, please
@@ -56,19 +55,19 @@ catalog.
 =============================== ========= =================
 File Name                       File Size Number of Targets
 =============================== ========= =================
-fastspec-fuji-cmx-other.fits    11.6 MB   2,771
-fastspec-fuji-special-dark.fits 145 MB    35,647
-fastspec-fuji-sv1-backup.fits   15.5 MB   3,683
-fastspec-fuji-sv1-bright.fits   524 MB    126,677
-fastspec-fuji-sv1-dark.fits     976 MB    235,881
-fastspec-fuji-sv1-other.fits    141 MB    34,150
-fastspec-fuji-sv2-backup.fits   602 KB    107
-fastspec-fuji-sv2-bright.fits   193 MB    46,510
-fastspec-fuji-sv2-dark.fits     218 MB    52,771
-fastspec-fuji-sv3-backup.fits   6.62 MB   1,564
-fastspec-fuji-sv3-bright.fits   1.08 GB   265,324
-fastspec-fuji-sv3-dark.fits     2.41 GB   592,394
-fastspec-fuji.fits              5.7 GB    1,397,479
+fastspec-fuji-cmx-other.fits    12.8 MB   2,771
+fastspec-fuji-special-dark.fits 161 MB    35,649
+fastspec-fuji-sv1-backup.fits   17.1 MB   3,683
+fastspec-fuji-sv1-bright.fits   579 MB    126,678
+fastspec-fuji-sv1-dark.fits     1.05 GB   235,942
+fastspec-fuji-sv1-other.fits    156 MB    34,152
+fastspec-fuji-sv2-backup.fits   664 KB    107
+fastspec-fuji-sv2-bright.fits   213 MB    46,510
+fastspec-fuji-sv2-dark.fits     241 MB    52,781
+fastspec-fuji-sv3-backup.fits   7.31 MB   1,564
+fastspec-fuji-sv3-bright.fits   1.19 GB   265,325
+fastspec-fuji-sv3-dark.fits     2.66 GB   592,441
+fastspec-fuji.fits              6.29 GB   1,397,603
 =============================== ========= =================
 
 The following table summarizes the number of QSO targets whose redshift has been
@@ -76,42 +75,31 @@ updated using the procedure documented :ref:`here<qso redshifts>`.
 
 .. rst-class:: columns
 
-=============================== ================= ===============================
-Catalog                         Number of Targets Number with Corrected Redshifts
-=============================== ================= ===============================
-fastspec-fuji-cmx-other.fits    2,771             56
-fastspec-fuji-special-dark.fits 35,647            311
-fastspec-fuji-sv1-backup.fits   3,683             100
-fastspec-fuji-sv1-bright.fits   126,677           64
-fastspec-fuji-sv1-dark.fits     235,881           3,749
-fastspec-fuji-sv1-other.fits    34,150            168
-fastspec-fuji-sv2-backup.fits   107               0
-fastspec-fuji-sv2-bright.fits   46,510            8
-fastspec-fuji-sv2-dark.fits     52,771            1,019
-fastspec-fuji-sv3-backup.fits   1,564             0
-fastspec-fuji-sv3-bright.fits   265,324           132
-fastspec-fuji-sv3-dark.fits     592,394           3,397
-fastspec-fuji.fits              1,397,479         9,004
-=============================== ================= ===============================
+================================= ================= ===============================
+Catalog                           Number of Objects Number with Corrected Redshifts
+================================= ================= ===============================
+{fastspec}-fuji-cmx-other.fits    2,771             56
+{fastspec}-fuji-special-dark.fits 35,649            313
+{fastspec}-fuji-sv1-backup.fits   3,683             100
+{fastspec}-fuji-sv1-bright.fits   126,678           65
+{fastspec}-fuji-sv1-dark.fits     235,942           3,810
+{fastspec}-fuji-sv1-other.fits    34,152            170
+{fastspec}-fuji-sv2-backup.fits   107               0
+{fastspec}-fuji-sv2-bright.fits   46,510            8
+{fastspec}-fuji-sv2-dark.fits     52,781            1,029
+{fastspec}-fuji-sv3-backup.fits   1,564             0
+{fastspec}-fuji-sv3-bright.fits   265,325           133
+{fastspec}-fuji-sv3-dark.fits     592,441           3,444
+{fastspec}-fuji.fits              1,397,603         9,128
+================================= ================= ===============================
+
+.. _known issues:
 
 Known Issues
 ------------
 
 This section documents any issues or problems which were identified with the VAC
-after its final release.
-
-* The tied amplitudes of [OII]7320,7330 doublet were reversed in the line fitting [`#119`_].
-* The photometry for approximately 1% of targets is not properly propagated into
-  the output metadata table [`#121`_].
-* The signal-to-noise ratio of extremely narrow lines can be under-estimated [`#124`_].
-* There is an unphysical break in the derived stellar masses [`#125`_].
-* The photometry for a small fraction of SV1 targets is incorrect [`#129`_].
-
-.. _`#119`: https://github.com/desihub/fastspecfit/issues/119
-.. _`#121`: https://github.com/desihub/fastspecfit/issues/121
-.. _`#124`: https://github.com/desihub/fastspecfit/issues/124
-.. _`#125`: https://github.com/desihub/fastspecfit/issues/125
-.. _`#129`: https://github.com/desihub/fastspecfit/issues/129
+after its final release. So far, none have been identified!
 
 To report projects or to request new features please `open a ticket`_.
 

--- a/doc/guadalupe.rst
+++ b/doc/guadalupe.rst
@@ -18,18 +18,18 @@ this VAC.
 
 .. note::
 
-   We only document the *v2.0* version of this VAC; the *v1.0* version is
-   publicly accessible but has been deprecated and is not documented further.
+   We only document the *v3.0* version of this VAC; the *v1.0* and *v2.0*
+   versions have been deprecated and are not documented further.
 
 Data Content & Access
 ---------------------
 
 Data from the ``Guadalupe`` VAC can be accessed at any of the following links:
 
-============================ =======================================================================
-Data url                     https://data.desi.lbl.gov/public/dr1/vac/dr1/fastspecfit/guadalupe/v2.0
-`NERSC`_ (for collaborators) /global/cfs/cdirs/desi/public/dr1/vac/dr1/fastspecfit/guadalupe/v2.0
-============================ =======================================================================
+============================ =================================================================
+Data url                     https://data.desi.lbl.gov/desi/spectro/fastspecfit/guadalupe/v3.0
+`NERSC`_ (for collaborators) ``/global/cfs/cdirs/desi/spectro/fastspecfit/guadalupe/v3.0``
+============================ =================================================================
 
 For more information regarding the content and organization of the VAC, please
 click on the following links:
@@ -55,11 +55,11 @@ catalog.
 ====================================== ========= =================
 File Name                              File Size Number of Targets
 ====================================== ========= =================
-fastspec-guadalupe-special-dark.fits   15.7 MB   3,847
-fastspec-guadalupe-special-bright.fits 38.9 MB   9,598
-fastspec-guadalupe-main-bright.fits    4.31 GB   1,092,038
-fastspec-guadalupe-main-dark.fits      4.46 GB   1,131,601
-fastspec-guadalupe.fits                8.83 GB   2,237,084
+fastspec-guadalupe-special-dark.fits   17.4 MB   3,848
+fastspec-guadalupe-special-bright.fits 43.1 MB   9,598
+fastspec-guadalupe-main-bright.fits    4.77 GB   1,092,041
+fastspec-guadalupe-main-dark.fits      4.94 GB   1,131,858
+fastspec-guadalupe.fits                9.79 GB   2,237,345
 ====================================== ========= =================
 
 The following table summarizes the number of QSO targets whose redshift has been
@@ -67,15 +67,15 @@ updated using the procedure documented :ref:`here<qso redshifts>`.
 
 .. rst-class:: columns
 
-====================================== ================= ===============================
-Catalog                                Number of Targets Number with Corrected Redshifts
-====================================== ================= ===============================
-fastspec-guadalupe-main-bright.fits    1,092,038         153
-fastspec-guadalupe-main-dark.fits      1,131,601         26,741
-fastspec-guadalupe-special-bright.fits 9,598             13
-fastspec-guadalupe-special-dark.fits   3,847             121
-fastspec-guadalupe.fits                2,237,084         28,955
-====================================== ================= ===============================
+======================================== ================= ===============================
+Catalog                                  Number of Objects Number with Corrected Redshifts
+======================================== ================= ===============================
+{fastspec}-guadalupe-main-bright.fits    1,092,041         156
+{fastspec}-guadalupe-main-dark.fits      1,131,858         22,445
+{fastspec}-guadalupe-special-bright.fits 9,598             0
+{fastspec}-guadalupe-special-dark.fits   3,848             111
+{fastspec}-guadalupe.fits                2,237,345         22,712
+======================================== ================= ===============================
 
 Known Issues
 ------------

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1628,8 +1628,8 @@ class ContinuumTools(Filters, Inoue14):
                 except:
                     # pad in the case of an object at very high redshift (z>5.5).
                     log.warning('Padding model spectrum due to insufficient wavelength coverage to synthesize photometry.')
-                    padflux, padwave = filters.pad_spectrum(ztemplateflux, ztemplatewave, axis=0, method='edge')
-                    maggies = filters.get_ab_maggies(padflux.T, padwave)
+                    padflux, padwave = filters.pad_spectrum(ztemplateflux.T, ztemplatewave, axis=0, method='edge')
+                    maggies = filters.get_ab_maggies(padflux.T, padwave, axis=0)
                     
                 maggies = np.vstack(maggies.as_array().tolist()).T
                 maggies /= FLUXNORM * self.massnorm

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -357,6 +357,7 @@ def _domerge(outfiles, extname='FASTSPEC', survey=None, program=None,
 def merge_fastspecfit(specprod=None, coadd_type=None, survey=None, program=None,
                       healpix=None, tile=None, night=None, outsuffix=None,
                       fastphot=False, specprod_dir=None, outdir_data='.',
+                      fastfiles_to_merge=None, 
                       mergedir=None, supermerge=False, overwrite=False, mp=1):
     """Merge all the individual catalogs into a single large catalog. Runs only on
     rank 0.
@@ -387,9 +388,10 @@ def merge_fastspecfit(specprod=None, coadd_type=None, survey=None, program=None,
 
     # merge previously merged catalogs into one big catalog (and then return)
     if supermerge:
-        _outfiles = os.path.join(mergedir, '{}-{}-*.fits*'.format(outprefix, outsuffix))
-        outfiles = glob(_outfiles)
-        #print(_outfiles, outfiles)
+        if fastfiles_to_merge is None:
+            outfiles = glob(os.path.join(mergedir, '{}-{}-*.fits*'.format(outprefix, outsuffix)))
+        else:
+            outfiles = fastfiles_to_merge
         if len(outfiles) > 0:
             log.info('Merging {:,d} catalogs'.format(len(outfiles)))
             mergefile = os.path.join(mergedir, '{}-{}.fits'.format(outprefix, outsuffix))


### PR DESCRIPTION
The `Iron/v2` VAC ran nearly to completion with tag `2.4.1` but there was a corner-case bug I had previously fixed, recently messed with, and broke again. The issue only impacts the handful of objects in the sample (spanning approximately 50 healpixels) at the highest redshifts (z>5.3 or so) where I have to extrapolate / pad the best-fitting model while synthesizing photometry and computing K-corrections. The error was in the syntax of the padding / extrapolation with `speclite.filters.pad_spectrum`.

I also added a couple options for generating merged catalogs by survey type (merging over all programs): `main`, `sv={cmx,sv1,sv2,sv3}`, and `special`.

I'm going to do a few more checks and then tag `2.4.2` and finish the `Iron` VAC.