### PR TITLE
handle variable pixel size in camera-overlap region

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,10 +17,10 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10'] 
-                fitsio-version: ['==1.1.7']
+                python-version: ['3.10', '3.11'] 
+                fitsio-version: ['>=1.1.7']
         env:
-            DESIUTIL_VERSION: 3.3.1
+            DESIUTIL_VERSION: 3.4.1
             FASTSPECFIT: ${GITHUB_WORKSPACE}/fastspecfit
             DESI_ROOT: ${FASTSPECFIT}/desi
 
@@ -57,10 +57,10 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
-                fitsio-version: ['==1.1.7']
+                python-version: ['3.10', '3.11']
+                fitsio-version: ['>=1.1.7']
         env:
-            DESIUTIL_VERSION: 3.3.1
+            DESIUTIL_VERSION: 3.4.1
             FASTSPECFIT: ${GITHUB_WORKSPACE}/fastspecfit
             DESI_ROOT: ${FASTSPECFIT}/desi
 
@@ -96,7 +96,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
+                python-version: ['3.10', '3.11']
 
         steps:
             - name: Checkout code
@@ -124,7 +124,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
+                python-version: ['3.10', '3.11']
 
         steps:
             - name: Checkout code

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,11 @@ Change Log
 2.4.3 (not released yet)
 ------------------------
 
+* Handle variable pixel size in camera-overlap region bug [`PR #157`_].
 * Fix minor bug that broke the stackfit functionality [`PR #155`_].
 
 .. _`PR #155`: https://github.com/desihub/fastspecfit/pull/155
+.. _`PR #157`: https://github.com/desihub/fastspecfit/pull/157
 
 2.4.2 (2023-08-30)
 ------------------

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -812,7 +812,7 @@ class EMFitTools(Filters):
             if len(S) > 0:
                 sig_init = initial_guesses[S]
                 sig_final = parameters[Ifree][S]
-                G = (sig_init - sig_final) < 1.
+                G = np.abs(sig_init - sig_final) < 1.
                 if np.any(G):
                     initial_guesses[S[G]] *= 0.9
                     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ matplotlib
 fitsio
 git+https://github.com/desihub/desimodel.git@0.18.0#egg=desimodel
 git+https://github.com/desihub/desitarget.git@2.6.0#egg=desitarget
-git+https://github.com/desihub/desispec.git@0.59.2#egg=desispec
-git+https://github.com/desihub/speclite.git@v0.16#egg=speclite
+git+https://github.com/desihub/desispec.git@0.60.1#egg=desispec
+git+https://github.com/desihub/speclite.git@v0.17#egg=speclite


### PR DESCRIPTION
Fixes #156.

Also adds one more round of fitting if initial line-sigma doesn't change by more than 1 km/s, to help numerical convergence. E.g., consider
```
fastspec /global/cfs/cdirs/desi/spectro/redux/fuji/healpix/sv3/bright/259/25955/redrock-sv3-bright-25955.fits \
  --targetids 39627782325535150 -o fastspec.fits
```
with this branch:
<img width="1319" alt="Screenshot 2023-10-15 at 7 14 16 PM" src="https://github.com/desihub/fastspecfit/assets/1431820/9bbcfd2a-9976-4596-98c6-340f11d2763c">


vs `main`:

<img width="1312" alt="Screenshot 2023-10-15 at 7 15 54 PM" src="https://github.com/desihub/fastspecfit/assets/1431820/2e6bfdb4-8ac9-4eb6-bfd2-31131ee16b48">


In this example with `main`, the initial line-sigma is 121.58 km/s. The Balmer line-width moves to 64 km/s after the initial round of fitting, but the forbidden line-width changes negligibly, to 121.57 km/s and then gets stuck there.

With this branch, we identify the lack of "movement" on line-sigma and therefore multiply the initial value by 0.9 (another magic number, I know). However, that's enough to move things in the right direction, and the Balmer and forbidden line-widths converge on their final, correct values of 26 and 27 km/s, respectively.

I'll need to do more tests to make sure this latter change doesn't make things worse before merging.

