### PR TITLE
expand velocity dispersion grid to 425 km/s and bump the template version to 1.2.0

### DIFF
--- a/bin/build-fsps-templates
+++ b/bin/build-fsps-templates
@@ -225,11 +225,11 @@ def build_templates(models, logages, agebins, imf='chabrier',
 
 def main(args):
 
-    version = '1.1.1'
+    version = '1.2.0'
 
     # velocity dispersion grid
     vdispmin = 50.
-    vdispmax = 350.
+    vdispmax = 425.
     dvdisp = 25.
     nvdisp = int(np.ceil((vdispmax - vdispmin) / dvdisp)) + 1
     vdisp = np.linspace(vdispmin, vdispmax, nvdisp)

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -98,7 +98,7 @@ def parse(options=None, log=None):
     parser.add_argument('--no-smooth-continuum', action='store_true', help='Do not fit the smooth continuum.')
     parser.add_argument('--percamera-models', action='store_true', help='Return the per-camera (not coadded) model spectra.')
     parser.add_argument('--imf', type=str, default='chabrier', help='Initial mass function.')
-    parser.add_argument('--templateversion', type=str, default='1.1.0', help='Template version number.')
+    parser.add_argument('--templateversion', type=str, default='1.2.0', help='Template version number.')
     parser.add_argument('--templates', type=str, default=None, help='Optional full path and filename to the templates.')
     parser.add_argument('--redrockfile-prefix', type=str, default='redrock-', help='Prefix of the input Redrock file name(s).')
     parser.add_argument('--specfile-prefix', type=str, default='coadd-', help='Prefix of the spectral file(s).')

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1994,7 +1994,7 @@ def select(fastfit, metadata, coadd_type, healpixels=None, tiles=None,
     else:
         return fastfit[keep], metadata[keep]
 
-def get_templates_filename(templateversion='1.1.0', imf='chabrier'):
+def get_templates_filename(templateversion='1.2.0', imf='chabrier'):
     """Get the templates filename. """
     from fastspecfit.io import FTEMPLATES_DIR_NERSC
     templates_dir = os.environ.get('FTEMPLATES_DIR', FTEMPLATES_DIR_NERSC)
@@ -2057,7 +2057,7 @@ def get_qa_filename(metadata, coadd_type, outprefix=None, outdir=None,
     
     return pngfile
 
-def cache_templates(templates=None, templateversion='1.1.0', imf='chabrier',
+def cache_templates(templates=None, templateversion='1.2.0', imf='chabrier',
                     mintemplatewave=None, maxtemplatewave=40e4, vdisp_nominal=125.0,
                     read_linefluxes=False, fastphot=False, log=None):
     """"Read the templates into a dictionary.

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -1202,7 +1202,7 @@ def parse(options=None):
     parser.add_argument('--overwrite', action='store_true', help='Overwrite existing files.')
 
     parser.add_argument('--imf', type=str, default='chabrier', help='Initial mass function.')
-    parser.add_argument('--templateversion', type=str, default='1.1.0', help='Template version number.')
+    parser.add_argument('--templateversion', type=str, default='1.2.0', help='Template version number.')
     parser.add_argument('--templates', type=str, default=None, help='Optional full path and filename to the templates.')
 
     parser.add_argument('--outprefix', default=None, type=str, help='Optional prefix for output filename.')


### PR DESCRIPTION
Some of the more massive ellipticals in the BGS and LRG samples require a larger velocity dispersion grid search.

ToDo: update the unit tests to use this new grid.