### PR TITLE
add support for processing a custom sample with full MPI

### DIFF
--- a/bin/build-fsps-templates
+++ b/bin/build-fsps-templates
@@ -246,6 +246,7 @@ def build_templates(models, logages, agebins=None, imf='chabrier',
 def main(args):
 
     # velocity dispersion grid
+    vdisp_nominal = 125.
     vdispmin = 50.
     vdispmax = 500.
     dvdisp = 25.
@@ -386,6 +387,7 @@ def main(args):
     hduflux3.header['VDISPMIN'] = (vdispmin, 'minimum velocity dispersion [km/s]')
     hduflux3.header['VDISPMAX'] = (vdispmax, 'maximum velocity dispersion [km/s]')
     hduflux3.header['VDISPRES'] = (dvdisp, 'velocity dispersion spacing [km/s]')
+    hduflux3.header['VDISPNOM'] = (vdisp_nominal, 'nominal (default) velocity dispersion [km/s]')
     hduflux3.header['BUNIT'] = 'erg/(s cm2 Angstrom)'
 
     isplit = np.argmin(np.abs(wave-PIXKMS_WAVESPLIT)) + 1

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -25,7 +25,7 @@ from desiutil.log import get_logger
 log = get_logger()
 
 def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=False,
-                    outdir_data='.', templates=None, templateversion=None):
+                    samplefile=None, outdir_data='.', templates=None, templateversion=None):
 
     import sys
     from desispec.parallel import stdouterr_redirected
@@ -130,7 +130,7 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
                 with stdouterr_redirected(to=logfile, overwrite=args.overwrite):
                     fast(args=cmdargs.split())
             dt1 = time.time() - t1
-            log.info('  rank {} done in {:.2f} sec'.format(rank, dt1))
+            log.info(f'  rank {rank} done in {dt1:.2f} sec')
             if not os.path.exists(outfiles[ii]):
                 log.warning(f'  rank {rank} missing {outfiles[ii]}')
                 raise IOError
@@ -172,6 +172,7 @@ def main():
     parser.add_argument('--program', type=str, default='bright,dark,other,backup', help='Program to process.') # backup not supported
     parser.add_argument('--tile', default=None, type=str, nargs='*', help='Tile(s) to process.')
     parser.add_argument('--night', default=None, type=str, nargs='*', help='Night(s) to process (ignored if coadd-type is cumulative).')
+    parser.add_argument('--samplefile', default=None, type=str, help='Full path to sample (FITS) file with {survey,program,healpix,targetid}.')
     
     parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
     parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
@@ -223,7 +224,7 @@ def main():
         import multiprocessing
         multiprocessing.set_start_method('spawn')
 
-    if args.coadd_type == 'healpix':
+    if args.samplefile is None and args.coadd_type == 'healpix':
         args.survey = args.survey.split(',')
         args.program = args.program.split(',')
 
@@ -301,15 +302,37 @@ def main():
         else:
             rank = comm.rank
         if rank == 0:
-            plan(comm=comm, specprod=args.specprod, specprod_dir=specprod_dir,
-                 coadd_type=args.coadd_type, survey=args.survey, program=args.program,
-                 healpix=args.healpix, tile=args.tile, night=args.night,
-                 makeqa=args.makeqa, mp=args.mp, fastphot=args.fastphot,
-                 outdir_data=outdir_data, overwrite=args.overwrite)
+            if args.samplefile is not None:
+                import fitsio
+                from astropy.table import Table                
+                if not os.path.isfile(args.samplefile):
+                    log.warning(f'{args.samplefile} does not exist.')
+                    return
+                try:
+                    sample = Table(fitsio.read(args.samplefile, columns=['SURVEY', 'PROGRAM', 'HEALPIX', 'TARGETID']))
+                except:
+                    errmsg = f'Sample file {args.samplefile} missing required columns {SURVEY,PROGRAM,HEALPIX,TARGETID}'
+                    self.log.critical(errmsg)
+                    raise ValueError(errmsg)
+                
+                plan(comm=comm, specprod=args.specprod, specprod_dir=specprod_dir,
+                     sample=sample, coadd_type='healpix', makeqa=args.makeqa,
+                     mp=args.mp, fastphot=args.fastphot,
+                     outdir_data=outdir_data, overwrite=args.overwrite)
+            else:
+                plan(comm=comm, specprod=args.specprod, specprod_dir=specprod_dir,
+                     coadd_type=args.coadd_type, survey=args.survey, program=args.program,
+                     healpix=args.healpix, tile=args.tile, night=args.night,
+                     makeqa=args.makeqa, mp=args.mp, fastphot=args.fastphot,
+                     outdir_data=outdir_data, overwrite=args.overwrite)
     else:
+        if args.samplefile is not None and not os.path.isfile(args.samplefile):
+            log.warning(f'{args.samplefile} does not exist.')
+            return
+        
         run_fastspecfit(args, comm=comm, fastphot=args.fastphot, specprod_dir=specprod_dir,
-                        makeqa=args.makeqa, outdir_data=outdir_data, templates=args.templates,
-                        templateversion=args.templateversion)
+                        makeqa=args.makeqa, outdir_data=outdir_data,
+                        templates=args.templates, templateversion=args.templateversion)
 
 if __name__ == '__main__':
     main()

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -249,10 +249,29 @@ def main():
         except ImportError:
             comm = None
 
+    if comm is None:
+        rank = 0
+    else:
+        rank = comm.rank
+            
     # https://docs.nersc.gov/development/languages/python/parallel-python/#use-the-spawn-start-method
     if args.mp > 1 and 'NERSC_HOST' in os.environ:
         import multiprocessing
         multiprocessing.set_start_method('spawn')
+
+    # check the input samplefile
+    if rank == 0 and args.samplefile is not None:
+        import fitsio
+        from astropy.table import Table                
+        if not os.path.isfile(args.samplefile):
+            log.warning(f'{args.samplefile} does not exist.')
+            return
+        try:
+            sample = Table(fitsio.read(args.samplefile, columns=['SURVEY', 'PROGRAM', 'HEALPIX', 'TARGETID']))
+        except:
+            errmsg = f'Sample file {args.samplefile} missing required columns {SURVEY,PROGRAM,HEALPIX,TARGETID}'
+            self.log.critical(errmsg)
+            raise ValueError(errmsg)
 
     if args.samplefile is None and args.coadd_type == 'healpix':
         args.survey = args.survey.split(',')
@@ -318,33 +337,24 @@ def main():
         else:
             fastfiles_to_merge = None
 
-        merge_fastspecfit(specprod=args.specprod, specprod_dir=specprod_dir, coadd_type=args.coadd_type,
-                          survey=args.survey, program=args.program, healpix=args.healpix,
-                          tile=args.tile, night=args.night, outdir_data=outdir_data,
-                          fastfiles_to_merge=fastfiles_to_merge,
-                          outsuffix=args.merge_suffix, mergedir=args.mergedir, overwrite=args.overwrite,
-                          fastphot=args.fastphot, supermerge=args.mergeall, mp=args.mp)
+        if args.samplefile is not None:
+            merge_fastspecfit(specprod=args.specprod, specprod_dir=specprod_dir, coadd_type='healpix',
+                              sample=sample, merge_suffix=args.merge_suffix,
+                              outdir_data=outdir_data, fastfiles_to_merge=fastfiles_to_merge,
+                              outsuffix=args.merge_suffix, mergedir=args.mergedir, overwrite=args.overwrite,
+                              fastphot=args.fastphot, supermerge=args.mergeall, mp=args.mp)
+        else:
+            merge_fastspecfit(specprod=args.specprod, specprod_dir=specprod_dir, coadd_type=args.coadd_type,
+                              survey=args.survey, program=args.program, healpix=args.healpix,
+                              tile=args.tile, night=args.night, outdir_data=outdir_data,
+                              fastfiles_to_merge=fastfiles_to_merge,
+                              outsuffix=args.merge_suffix, mergedir=args.mergedir, overwrite=args.overwrite,
+                              fastphot=args.fastphot, supermerge=args.mergeall, mp=args.mp)
         return
 
     if args.plan and args.makeqa is False:
-        if comm is None:
-            rank = 0
-        else:
-            rank = comm.rank
         if rank == 0:
             if args.samplefile is not None:
-                import fitsio
-                from astropy.table import Table                
-                if not os.path.isfile(args.samplefile):
-                    log.warning(f'{args.samplefile} does not exist.')
-                    return
-                try:
-                    sample = Table(fitsio.read(args.samplefile, columns=['SURVEY', 'PROGRAM', 'HEALPIX', 'TARGETID']))
-                except:
-                    errmsg = f'Sample file {args.samplefile} missing required columns {SURVEY,PROGRAM,HEALPIX,TARGETID}'
-                    self.log.critical(errmsg)
-                    raise ValueError(errmsg)
-                
                 plan(comm=comm, specprod=args.specprod, specprod_dir=specprod_dir,
                      sample=sample, coadd_type='healpix', makeqa=args.makeqa,
                      mp=args.mp, fastphot=args.fastphot,
@@ -356,10 +366,6 @@ def main():
                      makeqa=args.makeqa, mp=args.mp, fastphot=args.fastphot,
                      outdir_data=outdir_data, overwrite=args.overwrite)
     else:
-        if args.samplefile is not None and not os.path.isfile(args.samplefile):
-            log.warning(f'{args.samplefile} does not exist.')
-            return
-        
         run_fastspecfit(args, comm=comm, fastphot=args.fastphot, specprod_dir=specprod_dir,
                         makeqa=args.makeqa, outdir_data=outdir_data, samplefile=args.samplefile,
                         templates=args.templates, templateversion=args.templateversion)

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -1,19 +1,6 @@
 #!/usr/bin/env python
-
 """
 MPI wrapper for fastphot and fastspec.
-
-mpi-fastspecfit --mp 32 --coadd-type cumulative --tile 80608 --night 20201220 --plan --nompi
-mpi-fastspecfit --fastphot --mp 32 --tile 80608
-
-mpi-fastspecfit --specprod fuji
-mpi-fastspecfit --specprod fuji --fastphot
-
-mpi-fastspecfit --merge --specprod fuji
-mpi-fastspecfit --merge --specprod fuji --fastphot
-
-mpi-fastspecfit --mp 32 --makeqa --specprod fuji --dry-run
-mpi-fastspecfit --mp 32 --makeqa --specprod fuji --fastphot --dry-run
 
 """
 import pdb # for debugging
@@ -25,7 +12,8 @@ from desiutil.log import get_logger
 log = get_logger()
 
 def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=False,
-                    samplefile=None, outdir_data='.', templates=None, templateversion=None):
+                    samplefile=None, input_redshifts=False, outdir_data='.', templates=None,
+                    templateversion=None):
 
     import sys
     from desispec.parallel import stdouterr_redirected
@@ -45,9 +33,15 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
                 log.warning(f'{args.samplefile} does not exist.')
                 return
             try:
-                sample = Table(fitsio.read(args.samplefile, columns=['SURVEY', 'PROGRAM', 'HEALPIX', 'TARGETID']))
+                readcols = ['SURVEY', 'PROGRAM', 'HEALPIX', 'TARGETID']
+                if input_redshifts:
+                    readcols += ['Z']
+                sample = Table(fitsio.read(args.samplefile, columns=readcols))
             except:
-                errmsg = f'Sample file {args.samplefile} missing required columns {SURVEY,PROGRAM,HEALPIX,TARGETID}'
+                if input_redshifts:
+                    errmsg = f'Sample file {args.samplefile} with --input-redshifts set missing required columns {SURVEY,PROGRAM,HEALPIX,TARGETID,Z}'
+                else:
+                    errmsg = f'Sample file {args.samplefile} missing required columns {SURVEY,PROGRAM,HEALPIX,TARGETID}'
                 self.log.critical(errmsg)
                 raise ValueError(errmsg)
 
@@ -122,9 +116,12 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
             # assume healpix coadds; find the targetids to process
             _, survey, program, healpix = os.path.basename(zbestfiles[ii]).split('-')
             healpix = int(healpix.split('.')[0])
-            targetids = ','.join(sample[(sample['SURVEY'] == survey) * (sample['PROGRAM'] == program) *
-                                        (sample['HEALPIX'] == healpix)]['TARGETID'].astype(str))
+            I = (sample['SURVEY'] == survey) * (sample['PROGRAM'] == program) * (sample['HEALPIX'] == healpix)
+            targetids = ','.join(sample[I]['TARGETID'].astype(str))
             cmdargs += f' --targetids {targetids}'
+            if input_redshifts:
+                inputz = ','.join(sample[I]['Z'].astype(str))
+                cmdargs += f' --input-redshifts {inputz}'
         else:
             if args.targetids is not None:
                 cmdargs += f' --targetids {args.targetids}'
@@ -202,7 +199,9 @@ def main():
     parser.add_argument('--program', type=str, default='bright,dark,other,backup', help='Program to process.') # backup not supported
     parser.add_argument('--tile', default=None, type=str, nargs='*', help='Tile(s) to process.')
     parser.add_argument('--night', default=None, type=str, nargs='*', help='Night(s) to process (ignored if coadd-type is cumulative).')
+
     parser.add_argument('--samplefile', default=None, type=str, help='Full path to sample (FITS) file with {survey,program,healpix,targetid}.')
+    parser.add_argument('--input-redshifts', action='store_true', help='Only used with --samplefile; if set, fit with redshift "Z" values.')
     
     parser.add_argument('--mp', type=int, default=1, help='Number of multiprocessing processes per MPI rank or node.')
     parser.add_argument('-n', '--ntargets', type=int, help='Number of targets to process in each file.')
@@ -368,7 +367,8 @@ def main():
     else:
         run_fastspecfit(args, comm=comm, fastphot=args.fastphot, specprod_dir=specprod_dir,
                         makeqa=args.makeqa, outdir_data=outdir_data, samplefile=args.samplefile,
-                        templates=args.templates, templateversion=args.templateversion)
+                        input_redshifts=args.input_redshifts, templates=args.templates,
+                        templateversion=args.templateversion)
 
 if __name__ == '__main__':
     main()

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -38,14 +38,35 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
 
     t0 = time.time()
     if rank == 0:
-        _, zbestfiles, outfiles, groups, ntargets = plan(
-            comm=comm, specprod=args.specprod, specprod_dir=specprod_dir,
-            coadd_type=args.coadd_type, survey=args.survey, program=args.program,
-            healpix=args.healpix, tile=args.tile, night=args.night,
-            makeqa=args.makeqa, mp=args.mp, fastphot=fastphot, outdir_data=outdir_data, 
-            overwrite=args.overwrite)
+        if args.samplefile is not None:
+            import fitsio
+            from astropy.table import Table                
+            if not os.path.isfile(args.samplefile):
+                log.warning(f'{args.samplefile} does not exist.')
+                return
+            try:
+                sample = Table(fitsio.read(args.samplefile, columns=['SURVEY', 'PROGRAM', 'HEALPIX', 'TARGETID']))
+            except:
+                errmsg = f'Sample file {args.samplefile} missing required columns {SURVEY,PROGRAM,HEALPIX,TARGETID}'
+                self.log.critical(errmsg)
+                raise ValueError(errmsg)
+
+            _, zbestfiles, outfiles, groups, ntargets = plan(
+                comm=comm, specprod=args.specprod, specprod_dir=specprod_dir,
+                sample=sample, coadd_type='healpix', makeqa=args.makeqa,
+                mp=args.mp, fastphot=args.fastphot,
+                outdir_data=outdir_data, overwrite=args.overwrite)
+        else:
+            sample = None
+            _, zbestfiles, outfiles, groups, ntargets = plan(
+                comm=comm, specprod=args.specprod, specprod_dir=specprod_dir,
+                coadd_type=args.coadd_type, survey=args.survey, program=args.program,
+                healpix=args.healpix, tile=args.tile, night=args.night,
+                makeqa=args.makeqa, mp=args.mp, fastphot=fastphot, outdir_data=outdir_data, 
+                overwrite=args.overwrite)
         log.info('Planning took {:.2f} sec'.format(time.time() - t0))
     else:
+        sample = None
         zbestfiles, outfiles, groups, ntargets = [], [], [], []
 
     if comm:
@@ -53,6 +74,7 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
         outfiles = comm.bcast(outfiles, root=0)
         groups = comm.bcast(groups, root=0)
         ntargets = comm.bcast(ntargets, root=0)
+        sample = comm.bcast(sample, root=0)
 
     sys.stdout.flush()
     
@@ -95,9 +117,17 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
                 
         if args.firsttarget is not None:
             cmdargs += f' --firsttarget {args.firsttarget}'
-                
-        if args.targetids is not None:
-            cmdargs += f' --targetids {args.targetids}'
+
+        if sample is not None:
+            # assume healpix coadds; find the targetids to process
+            _, survey, program, healpix = os.path.basename(zbestfiles[ii]).split('-')
+            healpix = int(healpix.split('.')[0])
+            targetids = ','.join(sample[(sample['SURVEY'] == survey) * (sample['PROGRAM'] == program) *
+                                        (sample['HEALPIX'] == healpix)]['TARGETID'].astype(str))
+            cmdargs += f' --targetids {targetids}'
+        else:
+            if args.targetids is not None:
+                cmdargs += f' --targetids {args.targetids}'
                 
         if args.makeqa:
             logfile = os.path.join(zbestfiles[ii], os.path.basename(outfiles[ii]).replace('.gz', '').replace('.fits', '.log'))
@@ -331,7 +361,7 @@ def main():
             return
         
         run_fastspecfit(args, comm=comm, fastphot=args.fastphot, specprod_dir=specprod_dir,
-                        makeqa=args.makeqa, outdir_data=outdir_data,
+                        makeqa=args.makeqa, outdir_data=outdir_data, samplefile=args.samplefile,
                         templates=args.templates, templateversion=args.templateversion)
 
 if __name__ == '__main__':

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ Change Log
 2.5.2 (not released yet)
 ------------------------
 
-* 
+* Add support for processing a custom sample with full MPI [`PR #168`_]. 
+
+.. _`PR #168`: https://github.com/desihub/fastspecfit/pull/168
 
 2.5.1 (2024-01-18)
 ------------------

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -217,6 +217,14 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
         if np.count_nonzero(todo) > 0:
             redrockfiles = redrockfiles[todo]
             outfiles = outfiles[todo]
+            if sample is not None:
+                ntargets = ntargets[todo]
+        else: # all done!
+            redrockfiles = []
+            outfiles = []
+            if sample is not None:
+                ntargets = np.array([])
+                
         log.info(f'Found {len(redrockfiles)}/{nfile} redrockfiles (left) to do.')
 
         # we already counted ntargets

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -45,9 +45,9 @@ def get_ntargets_one(specfile, htmldir_root, outdir_root, coadd_type='healpix',
     return ntargets
 
 def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
-         survey=None, program=None, healpix=None, tile=None, night=None, 
-         outdir_data='.', mp=1, merge=False, makeqa=False, fastphot=False,
-         overwrite=False):
+         survey=None, program=None, healpix=None, tile=None, night=None,
+         sample=None, outdir_data='.', mp=1, merge=False, makeqa=False,
+         fastphot=False, overwrite=False):
 
     import fitsio
     from astropy.table import Table, vstack
@@ -79,7 +79,7 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
 
         # figure out which tiles belong to the SV programs
         if tile is None:
-            tilefile = os.path.join(desi_root, 'spectro', 'redux', specprod, 'tiles-{}.csv'.format(specprod))
+            tilefile = os.path.join(desi_root, 'spectro', 'redux', specprod, f'tiles-{specprod}.csv')
             alltileinfo = Table.read(tilefile)
             tileinfo = alltileinfo[['sv' in survey for survey in alltileinfo['SURVEY']]]
 
@@ -99,26 +99,45 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
     outdir = os.path.join(outdir_data, specprod, subdir)
     htmldir = os.path.join(outdir_data, specprod, 'html', subdir)
 
-    def _findfiles(filedir, prefix='redrock', survey=None, program=None, healpix=None, tile=None, night=None, gzip=False):
+    def _findfiles(filedir, prefix='redrock', survey=None, program=None, healpix=None,
+                   tile=None, night=None, gzip=False, sample=None):
         if gzip:
             fitssuffix = 'fits.gz'
         else:
             fitssuffix = 'fits'
             
-        if coadd_type == 'healpix':
+        if sample is not None: # special case of an input catalog
+            thesefiles, ntargets = [], []
+            for onesurvey in sorted(set(sample['SURVEY'].data)):
+                S = np.where(onesurvey == sample['SURVEY'])[0]
+                for oneprogram in sorted(set(sample['PROGRAM'][S].data)):
+                    log.info(f'Building file list for survey={onesurvey} and program={oneprogram}')
+                    P = np.where(oneprogram == sample['PROGRAM'][S])[0]
+                    uhealpix, _ntargets = np.unique(sample['HEALPIX'][S][P].astype(str), return_counts=True)
+                    ntargets.append(_ntargets)
+                    for onepix in uhealpix:
+                        #ntargets.append(np.sum(onepix == sample['HEALPIX'][S][P].astype(str)))
+                        thesefiles.append(os.path.join(filedir, onesurvey, oneprogram, str(int(onepix)//100), onepix,
+                                                       f'{prefix}-{onesurvey}-{oneprogram}-{onepix}.{fitssuffix}'))
+            if len(thesefiles) > 0:
+                #thesefiles = np.array(sorted(np.unique(np.hstack(thesefiles))))
+                thesefiles = np.hstack(thesefiles)
+                ntargets = np.hstack(ntargets)
+            return thesefiles, ntargets
+        elif coadd_type == 'healpix':
             thesefiles = []
             for onesurvey in np.atleast_1d(survey):
                 for oneprogram in np.atleast_1d(program):
-                    log.info('Building file list for survey={} and program={}'.format(onesurvey, oneprogram))
+                    log.info(f'Building file list for survey={onesurvey} and program={oneprogram}')
                     if healpix is not None:
                         for onepix in healpixels:
                             _thesefiles = glob(os.path.join(filedir, onesurvey, oneprogram, str(int(onepix)//100), onepix,
-                                                            '{}-{}-{}-*.{}'.format(prefix, onesurvey, oneprogram, fitssuffix)))
+                                                            f'{prefix}-{onesurvey}-{oneprogram}-{onepix}.{fitssuffix}'))
                             thesefiles.append(_thesefiles)
                     else:
                         allpix = glob(os.path.join(filedir, onesurvey, oneprogram, '*'))
                         for onepix in allpix:
-                            _thesefiles = glob(os.path.join(onepix, '*', '{}-{}-{}-*.{}'.format(prefix, onesurvey, oneprogram, fitssuffix)))
+                            _thesefiles = glob(os.path.join(onepix, '*', f'{prefix}-{onesurvey}-{oneprogram}-*.{fitssuffix}'))
                             thesefiles.append(_thesefiles)
             if len(thesefiles) > 0:
                 thesefiles = np.array(sorted(np.unique(np.hstack(thesefiles))))
@@ -135,7 +154,7 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
                     if len(nightdirs) > 0:
                         # for a given tile, take just the most recent night
                         thisnightdir = nightdirs[-1]
-                        thesefiles.append(glob(os.path.join(thisnightdir, '{}-[0-9]-{}-thru????????.{}'.format(prefix, onetile, fitssuffix))))
+                        thesefiles.append(glob(os.path.join(thisnightdir, f'{prefix}-[0-9]-{onetile}-thru????????.{fitssuffix}')))
                 if len(thesefiles) > 0:
                     thesefiles = np.array(sorted(set(np.hstack(thesefiles))))
         elif coadd_type == 'pernight':
@@ -144,28 +163,25 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
                 for onetile in tile:
                     for onenight in night:
                         thesefiles.append(glob(os.path.join(
-                            filedir, 'pernight', str(onetile), str(onenight), '{}-[0-9]-{}-{}.{}'.format(prefix, onetile, onenight, fitssuffix))))
+                            filedir, 'pernight', str(onetile), str(onenight), f'{prefix}-[0-9]-{onetile}-{onenight}.{fitssuffix}')))
                 if len(thesefiles) > 0:
                     thesefiles = np.array(sorted(set(np.hstack(thesefiles))))
             elif tile is not None and night is None:
                 thesefiles = np.array(sorted(set(np.hstack([glob(os.path.join(
-                    filedir, 'pernight', str(onetile), '????????', '{}-[0-9]-{}-????????.{}'.format(
-                    prefix, onetile, fitssuffix))) for onetile in tile]))))
+                    filedir, 'pernight', str(onetile), '????????', f'{prefix}-[0-9]-{onetile}-????????.{fitssuffix}')) for onetile in tile]))))
             elif tile is None and night is not None:
                 thesefiles = np.array(sorted(set(np.hstack([glob(os.path.join(
-                    filedir, 'pernight', '?????', str(onenight), '{}-[0-9]-?????-{}.{}'.format(
-                    prefix, onenight, fitssuffix))) for onenight in night]))))
+                    filedir, 'pernight', '?????', str(onenight), f'{prefix}-[0-9]-?????-{onenight}.{fitssuffix}')) for onenight in night]))))
             else:
                 thesefiles = np.array(sorted(set(glob(os.path.join(
-                    filedir, '?????', '????????', '{}-[0-9]-?????-????????.{}'.format(prefix, fitssuffix))))))
+                    filedir, '?????', '????????', f'{prefix}-[0-9]-?????-????????.{fitssuffix}')))))
         elif coadd_type == 'perexp':
             if tile is not None:
                 thesefiles = np.array(sorted(set(np.hstack([glob(os.path.join(
-                    filedir, 'perexp', str(onetile), '????????', '{}-[0-9]-{}-exp????????.{}'.format(
-                    prefix, onetile, fitssuffix))) for onetile in tile]))))
+                    filedir, 'perexp', str(onetile), '????????', f'{prefix}-[0-9]-{onetile}-exp????????.{fitssuffix}')) for onetile in tile]))))
             else:
                 thesefiles = np.array(sorted(set(glob(os.path.join(
-                    filedir, 'perexp', '?????', '????????', '{}-[0-9]-?????-exp????????.{}'.format(prefix, fitssuffix))))))
+                    filedir, 'perexp', '?????', '????????', f'{prefix}-[0-9]-?????-exp????????.{fitssuffix}')))))
         else:
             pass
         return thesefiles
@@ -173,18 +189,22 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
     if merge:
         redrockfiles = None
         outfiles = _findfiles(outdir, prefix=outprefix, survey=survey, program=program, healpix=healpix, tile=tile, night=night, gzip=gzip)
-        log.info('Found {} {} files to be merged.'.format(len(outfiles), outprefix))
+        log.info(f'Found {len(outfiles)} {outprefix} files to be merged.')
     elif makeqa:
         redrockfiles = None
         outfiles = _findfiles(outdir, prefix=outprefix, survey=survey, program=program, healpix=healpix, tile=tile, night=night, gzip=gzip)
-        log.info('Found {} {} files for QA.'.format(len(outfiles), outprefix))
+        log.info(f'Found {len(outfiles)} {outprefix} files for QA.')
         ntargs = [(outfile, htmldir, outdir, coadd_type, True, overwrite, fastphot) for outfile in outfiles]
     else:
-        redrockfiles = _findfiles(specprod_dir, prefix='redrock', survey=survey, program=program, healpix=healpix, tile=tile, night=night)
+        if sample is not None: # special case of an input catalog
+            redrockfiles, ntargets = _findfiles(specprod_dir, prefix='redrock', sample=sample)
+        else:
+            redrockfiles = _findfiles(specprod_dir, prefix='redrock', survey=survey, program=program,
+                                      healpix=healpix, tile=tile, night=night)
         nfile = len(redrockfiles)
         outfiles = []
         for redrockfile in redrockfiles:
-            outfile = redrockfile.replace(specprod_dir, outdir).replace('redrock-', '{}-'.format(outprefix))
+            outfile = redrockfile.replace(specprod_dir, outdir).replace('redrock-', f'{outprefix}-')
             if gzip:
                 outfile = outfile.replace('.fits', '.fits.gz')
             outfiles.append(outfile) 
@@ -197,28 +217,35 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
         if np.count_nonzero(todo) > 0:
             redrockfiles = redrockfiles[todo]
             outfiles = outfiles[todo]
-        log.info('Found {}/{} redrockfiles (left) to do.'.format(len(redrockfiles), nfile))
-        ntargs = [(redrockfile, None, None, None, False, False, False) for redrockfile in redrockfiles]
+        log.info(f'Found {len(redrockfiles)}/{nfile} redrockfiles (left) to do.')
+
+        # we already counted ntargets
+        if sample is None:
+            ntargs = [(redrockfile, None, None, None, False, False, False) for redrockfile in redrockfiles]
 
     # create groups weighted by the number of targets
     if merge:
         groups = [np.arange(len(outfiles))]
         ntargets = None
     else:
-        if mp > 1:
-            with multiprocessing.Pool(mp) as P:
-                ntargets = P.map(_get_ntargets_one, ntargs)
-        else:
-            ntargets = [get_ntargets_one(*_ntargs) for _ntargs in ntargs]
-        ntargets = np.array(ntargets)
+        # we already counted ntargets
+        if sample is None:
+            if mp > 1:
+                with multiprocessing.Pool(mp) as P:
+                    ntargets = P.map(_get_ntargets_one, ntargs)
+            else:
+                ntargets = [get_ntargets_one(*_ntargs) for _ntargs in ntargs]
+            ntargets = np.array(ntargets)
 
-        iempty = np.where(ntargets==0)[0]
+        iempty = np.where(ntargets == 0)[0]
         if len(iempty) > 0:
-            log.info('Skipping {} files with no targets.'.format(len(iempty)))
+            log.info(f'Skipping {len(iempty)} files with no targets.')
 
         itodo = np.where(ntargets > 0)[0]
         if len(itodo) > 0:
             ntargets = ntargets[itodo]
+            log.info(f'Number of targets left to do: {np.sum(ntargets):,d}.')
+            
             if redrockfiles is not None:
                 redrockfiles = redrockfiles[itodo]
             if outfiles is not None:
@@ -248,13 +275,13 @@ def plan(comm=None, specprod=None, specprod_dir=None, coadd_type='healpix',
     if merge:
         if len(outfiles) == 0:
             if rank == 0:
-                log.debug('No {} files in {} found!'.format(outprefix, outdir))
+                log.debug(f'No {outprefix} files in {outdir} found!')
             return '', list(), list(), list(), None
         return outdir, redrockfiles, outfiles, None, None
     elif makeqa:
         if len(outfiles) == 0:
             if rank == 0:
-                log.debug('No {} files left to do!'.format(outprefix, outdir))
+                log.debug(f'No {outprefix} files in {outdir} left to do!')
             return '', list(), list(), list(), None
         #  hack--build the output directories and pass them in the 'redrockfiles'
         #  position! for coadd_type==cumulative, strip out the 'lastnight' argument
@@ -274,14 +301,13 @@ def _read_to_merge_one(args):
     return read_to_merge_one(*args)
 
 def read_to_merge_one(filename, extname):
-    #log.info('Reading {}'.format(filename))
     info = fitsio.FITS(filename)
     ext = [_info.get_extname() for _info in info]
     if extname not in ext:
-        log.warning('Missing extension {} in file {}'.format(extname, filename))
+        log.warning(f'Missing extension {extname} in file {filename}')
         return [], []
     if 'METADATA' not in ext:
-        log.warning('Missing extension METADATA in file {}'.format(filename))
+        log.warning(f'Missing extension METADATA in file {filename}')
         return [], []
     out = Table(info[extname].read())
     meta = Table(info['METADATA'].read())
@@ -317,11 +343,9 @@ def _domerge(outfiles, extname='FASTSPEC', survey=None, program=None,
     meta = meta[srt]
 
     if outprefix:
-        log.info('Merging {:,d} objects from {} {} files took {:.2f} min.'.format(
-            len(out), len(outfiles), outprefix, (time.time()-t0)/60.0))
+        log.info(f'Merging {len(out):,d} objects from {len(outfiles)} {outprefix} files took {(time.time()-t0)/60.0:.2f} min.')
     else:
-        log.info('Merging {:,d} objects from {} files took {:.2f} min.'.format(
-            len(out), len(outfiles), (time.time()-t0)/60.0))
+        log.info(f'Merging {len(out):,d} objects from {len(outfiles)} files took {(time.time()-t0)/60.0:.2f} min.')
 
     hdr = fitsio.read_header(outfiles[0])
 
@@ -388,31 +412,31 @@ def merge_fastspecfit(specprod=None, coadd_type=None, survey=None, program=None,
     # merge previously merged catalogs into one big catalog (and then return)
     if supermerge:
         if fastfiles_to_merge is None:
-            _outfiles = os.path.join(mergedir, '{}-{}-*.fits*'.format(outprefix, outsuffix))
+            _outfiles = os.path.join(mergedir, f'{outprefix}-{outsuffix}-*.fits*')
             outfiles = glob(_outfiles)
         else:
             _outfiles = fastfiles_to_merge
             outfiles = _outfiles
         if len(outfiles) > 0:
-            log.info('Merging {:,d} catalogs'.format(len(outfiles)))
-            mergefile = os.path.join(mergedir, '{}-{}.fits'.format(outprefix, outsuffix))
+            log.info(f'Merging {len(outfiles):,d} catalogs')
+            mergefile = os.path.join(mergedir, f'{outprefix}-{outsuffix}.fits')
             _domerge(outfiles, extname=extname, mergefile=mergefile, outprefix=outprefix,
                      specprod=specprod, coadd_type=coadd_type, fastphot=fastphot, mp=mp)
         else:
-            log.info('No catalogs found: {}'.format(_outfiles))
+            log.info(f'No catalogs found: {_outfiles}')
         return
 
     if coadd_type == 'healpix':
         if survey is None or program is None:
-            log.warning('coadd_type={} requires survey and program inputs.'.format(coadd_type))
+            log.warning(f'coadd_type={coadd_type} requires survey and program inputs.')
             return
         surveys = copy(survey)
         programs = copy(program)
         for survey in surveys:
             for program in programs:
-                mergefile = os.path.join(mergedir, '{}-{}-{}-{}.fits'.format(outprefix, specprod, survey, program))
+                mergefile = os.path.join(mergedir, f'{outprefix}-{specprod}-{survey}-{program}.fits')
                 if os.path.isfile(mergefile) and not overwrite:
-                    log.info('Merged output file {} exists!'.format(mergefile))
+                    log.info(f'Merged output file {mergefile} exists!')
                     continue
                 #survey = np.atleast_1d(survey)
                 #program = np.atleast_1d(program)
@@ -424,9 +448,9 @@ def merge_fastspecfit(specprod=None, coadd_type=None, survey=None, program=None,
                              mergefile=mergefile, outprefix=outprefix, specprod=specprod,
                              coadd_type=coadd_type, fastphot=fastphot, mp=mp)
     else:
-        mergefile = os.path.join(mergedir, '{}-{}-{}.fits'.format(outprefix, specprod, coadd_type))
+        mergefile = os.path.join(mergedir, f'{outprefix}-{specprod}-{coadd_type}.fits')
         if os.path.isfile(mergefile) and not overwrite:
-            log.info('Merged output file {} exists!'.format(mergefile))
+            log.info(f'Merged output file {mergefile} exists!')
             return
         _, _, outfiles, _, _ = plan(specprod=specprod, coadd_type=coadd_type, tile=tile, night=night,
                                     merge=True, fastphot=fastphot, specprod_dir=specprod_dir,


### PR DESCRIPTION
This PR adds hooks which allows one to pass a custom / input sample to `mpi-fastspecfit`. Currently, only healpix coadds are supported and one must pass an input `--samplefile` argument which provides the full path to a FITS catalog which contains (at minimum) `SURVEY`, `PROGRAM`, `HEALPIX` and `TARGETID` (all other columns are ignored).

I've used this wrapper successfully on one of @dirkscholte's projects of ~200k objects (spread across more than 14,000 healpix coadds in Iron, but with typically only 30-75 targetids per coadd), but will test on one other small sample (a sample of ~70 spectroscopic lenses in Fuji) before merging.
