### PR TITLE
update line-list (drop broad HeI lines) and rest wavelengths

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,13 @@ Change Log
 3.0.0 (not released yet)
 ------------------------
 
+* Update line-list (drop broad HeI lines) and rest wavelengths [`PR #179`_].
 * Near-total rewrite of both the continuum and emission-line fitting engines and
   major updates to the organizational infrastructure of the code, all with the
   goal of maximizing speed and accuracy [`PR #177`_].
 
 .. _`PR #177`: https://github.com/desihub/fastspecfit/pull/177
+.. _`PR #179`: https://github.com/desihub/fastspecfit/pull/179
 
 2.5.2 (2024-04-28)
 ------------------

--- a/doc/fastspec.rst
+++ b/doc/fastspec.rst
@@ -92,7 +92,7 @@ Name                         Type         Units                         Descript
                   FIBER [2]_        int32                               Fiber number.
                   EXPID [3]_        int32                               Exposure ID number.
                            Z      float64                               Stellar continuum redshift.
-                       COEFF float32[168]                               Continuum coefficients.
+                       COEFF   float32[5]                               Continuum coefficients.
                        RCHI2      float32                               Reduced chi-squared of the full-spectrum fit.
                   RCHI2_CONT      float32                               Reduced chi-squared of the fit to the stellar continuum.
                   RCHI2_PHOT      float32                               Reduced chi-squared of the fit to the broadband photometry.
@@ -212,6 +212,23 @@ Name                         Type         Units                         Descript
             LYALPHA_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
                 LYALPHA_CHI2      float32                               Chi-squared of the line-fit.
                 LYALPHA_NPIX        int32                               Number of pixels attributed to the emission line.
+            NV_1240_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission-line amplitude.
+                 NV_1240_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
+            NV_1240_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
+                NV_1240_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
+           NV_1240_FLUX_IVAR      float32           1e+34 cm4 s2 / erg2 Inverse variance of integrated flux.
+             NV_1240_BOXFLUX      float32           1e-17 erg / (cm2 s) Boxcar-integrated emission-line flux.
+        NV_1240_BOXFLUX_IVAR      float32           1e+34 cm4 s2 / erg2 Inverse variance of boxcar-integrated flux.
+              NV_1240_VSHIFT      float32                        km / s Velocity shift relative to Z.
+               NV_1240_SIGMA      float32                        km / s Gaussian emission-line width.
+                NV_1240_CONT      float32  1e-17 erg / (Angstrom cm2 s) Continuum flux at line center.
+           NV_1240_CONT_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of continuum flux.
+                  NV_1240_EW      float32                      Angstrom Rest-frame emission-line equivalent width.
+             NV_1240_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
+          NV_1240_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
+            NV_1240_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
+                NV_1240_CHI2      float32                               Chi-squared of the line-fit.
+                NV_1240_NPIX        int32                               Number of pixels attributed to the emission line.
             OI_1304_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission-line amplitude.
                  OI_1304_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
             OI_1304_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
@@ -337,6 +354,7 @@ Name                         Type         Units                         Descript
               MGII_2796_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
          MGII_2796_FLUX_IVAR      float32           1e+34 cm4 s2 / erg2 Inverse variance of integrated flux.
            MGII_2796_BOXFLUX      float32           1e-17 erg / (cm2 s) Boxcar-integrated emission-line flux.
+      MGII_2796_BOXFLUX_IVAR      float32           1e+34 cm4 s2 / erg2 Inverse variance of boxcar-integrated flux.
             MGII_2796_VSHIFT      float32                        km / s Velocity shift relative to Z.
              MGII_2796_SIGMA      float32                        km / s Gaussian emission-line width.
               MGII_2796_CONT      float32  1e-17 erg / (Angstrom cm2 s) Continuum flux at line center.
@@ -472,6 +490,7 @@ Name                         Type         Units                         Descript
                H6_BROAD_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
           H6_BROAD_FLUX_IVAR      float32           1e+34 cm4 s2 / erg2 Inverse variance of integrated flux.
             H6_BROAD_BOXFLUX      float32           1e-17 erg / (cm2 s) Boxcar-integrated emission-line flux.
+       H6_BROAD_BOXFLUX_IVAR      float32           1e+34 cm4 s2 / erg2 Inverse variance of boxcar-integrated flux.
              H6_BROAD_VSHIFT      float32                        km / s Velocity shift relative to Z.
               H6_BROAD_SIGMA      float32                        km / s Gaussian emission-line width.
                H6_BROAD_CONT      float32  1e-17 erg / (Angstrom cm2 s) Continuum flux at line center.
@@ -754,6 +773,23 @@ Name                         Type         Units                         Descript
             OI_6300_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
                 OI_6300_CHI2      float32                               Chi-squared of the line-fit.
                 OI_6300_NPIX        int32                               Number of pixels attributed to the emission line.
+          SIII_6312_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
+               SIII_6312_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
+          SIII_6312_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
+              SIII_6312_FLUX      float32           1e-17 erg / (cm2 s) Gaussian-integrated emission-line flux.
+         SIII_6312_FLUX_IVAR      float32           1e+34 cm4 s2 / erg2 Inverse variance of integrated flux.
+           SIII_6312_BOXFLUX      float32           1e-17 erg / (cm2 s) Boxcar-integrated emission-line flux.
+      SIII_6312_BOXFLUX_IVAR      float32           1e+34 cm4 s2 / erg2 Inverse variance of boxcar-integrated flux.
+            SIII_6312_VSHIFT      float32                        km / s Velocity shift relative to Z.
+             SIII_6312_SIGMA      float32                        km / s Gaussian emission-line width.
+              SIII_6312_CONT      float32  1e-17 erg / (Angstrom cm2 s) Continuum flux at line center.
+         SIII_6312_CONT_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of continuum flux.
+                SIII_6312_EW      float32                      Angstrom Rest-frame emission-line equivalent width.
+           SIII_6312_EW_IVAR      float32                 1 / Angstrom2 Inverse variance of equivalent width.
+        SIII_6312_FLUX_LIMIT      float32                 erg / (cm2 s) One-sigma upper limit on the emission line flux.
+          SIII_6312_EW_LIMIT      float32                      Angstrom One-sigma upper limit on the emission line equivalent width.
+              SIII_6312_CHI2      float32                               Chi-squared of the line-fit.
+              SIII_6312_NPIX        int32                               Number of pixels attributed to the emission line.
            NII_6548_MODELAMP      float32  1e-17 erg / (Angstrom cm2 s) Model emission line amplitude.
                 NII_6548_AMP      float32  1e-17 erg / (Angstrom cm2 s) Emission line amplitude.
            NII_6548_AMP_IVAR      float32 1e+34 Angstrom2 cm4 s2 / erg2 Inverse variance of line-amplitude.
@@ -966,7 +1002,7 @@ Name                   Type        Units      Description
             FIBER [2]_   int32                Fiber number.
             NIGHT [2]_   int32                Night of observation.
             EXPID [3]_   int32                Exposure ID number.
-           TILEID_LIST    str5                List of tile IDs that went into healpix coadd.
+           TILEID_LIST    str?                List of tile IDs that went into healpix coadd.
                     RA float64            deg Right ascension from target catalog.
                    DEC float64            deg Declination from target catalog.
      COADD_FIBERSTATUS   int64                Fiber status bit.
@@ -998,7 +1034,7 @@ Name                   Type        Units      Description
              TSNR2_QSO float32                Template signal-to-noise ratio squared for QSO targets.
              TSNR2_LYA float32                Template signal-to-noise ratio squared for LYA targets.
                PHOTSYS    str1                Photometric system (*N* or *S*).
-               LS_ID     int64                Unique Legacy Surveys identification number.
+                 LS_ID   int64                Unique Legacy Surveys identification number.
            FIBERFLUX_G float32           nmgy Fiber g-band flux corrected for Galactic extinction.
            FIBERFLUX_R float32           nmgy Fiber r-band flux corrected for Galactic extinction.
            FIBERFLUX_Z float32           nmgy Fiber z-band flux corrected for Galactic extinction.
@@ -1065,9 +1101,9 @@ Required Header Keywords
 Data: FITS image [int32, 7781x3,338]
 
 .. [1] Column only present when fitting healpix coadds.
-       
+
 .. [2] Column only present when fitting cumulative, per-night, or per-expopsure tile-based coadds.
-       
+
 .. [3] Column only present when fitting per-exposure tile-based coadds.
 
 .. [4] Only observed photometry with a minimum signal-to-noise ratio of two is

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1607,12 +1607,16 @@ def continuum_specfit(data, result, templates, igm, phot,
         data['apercorr'] = median_apercorr # needed for the line-fitting
 
         # populate the output table
+        for icam, cam in enumerate(np.atleast_1d(data['cameras'])):
+            result[f'SNR_{cam.upper()}'] = data['snr'][icam]
+
         msg = 'Smooth continuum correction: '
         for cam, corr in zip(np.atleast_1d(data['cameras']), smoothstats):
-            result[f'SMOOTHCORR_{cam.upper()}'] = corr * 100 # [%]
+            result[f'SMOOTHCORR_{cam.upper()}'] = corr * 100. # [%]
             msg += f'{cam}={corr:.3f}% '
         log.info(msg)
 
+    result['Z'] = redshift
     result['COEFF'][CTools.agekeep] = coeff
     result['RCHI2_PHOT'] = rchi2_phot
     result['VDISP'] = vdisp # * u.kilometer/u.second

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -338,16 +338,6 @@ class ContinuumTools(object):
         return lums, cfluxes
 
 
-    # FIXME:
-    # * templatewave, redshift, luminosity, cameras, specres, specmask, photsys
-    #    all come from stored object data now
-    # * specmask ALSO comes from data, but we don't always use it when it exists,
-    #    so it needs to remain an argument
-    # * replace flamphot with phottable to get it out of this file and into qa
-    # * introduce synthspec flag and use it instead of checking for specwave/specres
-    # * don't handle redshift <= 0 here -- caller checks it in fastspecfit, and
-    #     caller should check it in fastqa if not being done now
-    # after we get all of that working, we can consider internal simplifications
     def templates2data(self, templateflux, templatewave, redshift=0., dluminosity=None,
                        vdisp=None, cameras=['b','r','z'], specwave=None, specres=None,
                        specmask=None, coeff=None, photsys=None, synthphot=True,
@@ -398,7 +388,7 @@ class ContinuumTools(object):
             log.critical(errmsg)
             raise ValueError(errmsg)
 
-        # broaden for velocity dispersion but only out to ~1 micron
+        # broaden for velocity dispersion
         if vdisp is not None:
             vd_templateflux = Templates.convolve_vdisp(templateflux, vdisp,
                                                        pixsize_kms=Templates.PIXKMS,
@@ -565,7 +555,7 @@ class ContinuumTools(object):
 
         if debug:
             if xivar > 0:
-                leg = r'${:.1f}\pm{:.1f}$'.format(xbest, 1 / np.sqrt(xivar))
+                leg = r'${:.1f}\pm{:.1f}$'.format(xbest, 1. / np.sqrt(xivar))
                 #leg = r'${:.3f}\pm{:.3f}\ (\chi^2_{{min}}={:.2f})$'.format(xbest, 1/np.sqrt(xivar), chi2min)
             else:
                 leg = r'${:.3f}$'.format(xbest)
@@ -886,19 +876,19 @@ class ContinuumTools(object):
             Model impact of infrared dust emission spectrum. Energy-balance is used
             to compute the normalization of this spectrum.
         objflam: :class: `numpy.ndarray`
-            Measured object photometry (used if fitting photometry)
+            Measured object photometry (used if fitting photometry).
         objflamistd: :class: `numpy.ndarray`
-            Sqrt of inverse variance of objflam (used if fitting photometry)
+            Sqrt of inverse variance of objflam (used if fitting photometry).
         specflux : :class:`numpy.ndarray` [nwave]
             Observed-frame spectrum in 10**-17 erg/s/cm2/A corresponding to
-            `specwave` (used if fitting spectroscopy)
+            `specwave` (used if fitting spectroscopy).
         specfluxistd : :class:`numpy.ndarray` [nwave]
             Sqrt of inverse variance of the observed-frame spectrum
-            (used if fitting spectroscopy)
+            (used if fitting spectroscopy).
         synthphot: :class:`bool`
-            True iff fitting objective includes object photometry
+            True iff fitting objective includes object photometry.
         synthspec: :class:`bool`
-            True iff fitting objective includes observed spectrum
+            True iff fitting objective includes observed spectrum.
 
         Returns
         -------
@@ -910,7 +900,7 @@ class ContinuumTools(object):
         templatecoeff : :class:`numpy.ndarray` [ntemplate]
             Column vector of maximum-likelihood template coefficients.
         resid: :class:`numpy.ndarray`
-            Vector of residuals at final parameter values
+            Vector of residuals at final parameter values.
 
         Notes
         -----

--- a/py/fastspecfit/data/emlines.ecsv
+++ b/py/fastspecfit/data/emlines.ecsv
@@ -49,16 +49,13 @@ name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
    hgamma_broad   4341.684     m   True   False True   True  H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
       oiii_4363   4364.4351    m   False  False False  False H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
        hei_4471   4472.7290    n   True   True  False  False HeI-$\lambda$4471                                            hei_4471
- hei_broad_4471   4472.7290    n   True   True  True   False HeI-$\lambda$4471                                            hei_4471
-      heii_4686   4686.8655    o   True   True  False  False HeII-$\lambda$4686                                           heii_4686
-heii_broad_4686   4686.8655    o   True   True  True   False HeII-$\lambda$4686                                           heii_4686
+      heii_4686   4686.8655    o   False  True  True   False HeII-$\lambda$4686                                           heii_4686
           hbeta   4862.683     p   True   False False  True  H$\beta$-$\lambda$4861                                       hbeta
     hbeta_broad   4862.683     p   True   False True   True  H$\beta$-$\lambda$4861                                       hbeta
       oiii_4959   4960.2937    p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
       oiii_5007   5008.2383    p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
        nii_5755   5756.1887    q   False  False False  False [NII]-$\lambda$5755                                          nii_5755
        hei_5876   5877.2690    r   True   True  False  False HeI-$\lambda$5876                                            hei_5876
- hei_broad_5876   5877.2690    r   True   True  True   False HeI-$\lambda$5876                                            hei_5876
         oi_6300   6302.0435    s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
       siii_6312   6313.8062    s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
        nii_6548   6549.8578    t   False  False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48

--- a/py/fastspecfit/data/emlines.ecsv
+++ b/py/fastspecfit/data/emlines.ecsv
@@ -34,11 +34,11 @@ name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
       ciii_1908   1908.734     f   False  False True   True  AlIII-$\lambda$1857+SiIII]-$\lambda$1892+CIII]-$\lambda$1908 aliii_1857_siliii_1892_ciii_1908
       mgii_2796   2796.3511    g   False  False True   True  MgII-$\lambda\lambda$2796,2803                               mgii_2796_2803
       mgii_2803   2803.5324    g   False  False True   True  MgII-$\lambda\lambda$2796,2803                               mgii_2796_2803
-       nev_3346   3346.7828    h   False  False False  False [NeV]-$\lambda$3346                                          nev_3346
-       nev_3426   3426.8637    h   False  False False  False [NeV]-$\lambda$3426                                          nev_3426
-       oii_3726   3727.0919    i   False  False False  True  [OII]-$\lambda\lambda$3726,29                                oii_3726_29
-       oii_3729   3729.8750    i   False  False False  True  [OII]-$\lambda\lambda$3726,29                                oii_3726_29
-     neiii_3869   3869.8611    j   False  False False  False [NeIII]-$\lambda$3869+H6                                     neiii_3869_h6
+       nev_3346   3346.79      h   False  False False  False [NeV]-$\lambda$3346                                          nev_3346
+       nev_3426   3426.85      h   False  False False  False [NeV]-$\lambda$3426                                          nev_3426
+       oii_3726   3727.10      i   False  False False  True  [OII]-$\lambda\lambda$3726,29                                oii_3726_29
+       oii_3729   3729.86      i   False  False False  True  [OII]-$\lambda\lambda$3726,29                                oii_3726_29
+     neiii_3869   3869.86      j   False  False False  False [NeIII]-$\lambda$3869+H6                                     neiii_3869_h6
              h6   3890.166     j   True   False False  False [NeIII]-$\lambda$3869+H6                                     neiii_3869_h6
        h6_broad   3890.166     j   True   False True   False [NeIII]-$\lambda$3869+H6                                     neiii_3869_h6
        hepsilon   3971.198     k   True   False False  False H$\epsilon$-$\lambda$3970                                    hepsilon
@@ -48,23 +48,23 @@ name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
          hgamma   4341.692     m   True   False False  True  H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
    hgamma_broad   4341.692     m   True   False True   True  H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
       oiii_4363   4364.4351    m   False  False False  False H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
-       hei_4471   4472.7290    n   True   True  False  False HeI-$\lambda$4471                                            hei_4471
+       hei_4471   4472.7350    n   True   True  False  False HeI-$\lambda$4471                                            hei_4471
       heii_4686   4686.8655    o   False  True  True   False HeII-$\lambda$4686                                           heii_4686
           hbeta   4862.71      p   True   False False  True  H$\beta$-$\lambda$4861                                       hbeta
     hbeta_broad   4862.71      p   True   False True   True  H$\beta$-$\lambda$4861                                       hbeta
       oiii_4959   4960.2937    p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
       oiii_5007   5008.2383    p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
        nii_5755   5756.1887    q   False  False False  False [NII]-$\lambda$5755                                          nii_5755
-       hei_5876   5877.2690    r   True   True  False  False HeI-$\lambda$5876                                            hei_5876
+       hei_5876   5877.249     r   True   True  False  False HeI-$\lambda$5876                                            hei_5876
         oi_6300   6302.0435    s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
       siii_6312   6313.8062    s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
        nii_6548   6549.8578    t   False  False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
          halpha   6564.60      t   True   False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
    halpha_broad   6564.60      t   True   False True   True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
        nii_6584   6585.2696    t   False  False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
-       sii_6716   6718.2913    u   False  False False  True  [SII]-$\lambda\lambda$6716,31                                sii_6716_31
-       sii_6731   6732.6705    u   False  False False  True  [SII]-$\lambda\lambda$6716,31                                sii_6716_31
-       oii_7320   7321.731     v   False  False False  False [OII]-$\lambda\lambda$7320,30                                oii_7320_30
-       oii_7330   7332.199     v   False  False False  False [OII]-$\lambda\lambda$7320,30                                oii_7320_30
+       sii_6716   6718.294     u   False  False False  True  [SII]-$\lambda\lambda$6716,31                                sii_6716_31
+       sii_6731   6732.674     u   False  False False  True  [SII]-$\lambda\lambda$6716,31                                sii_6716_31
+       oii_7320   7321.94      v   False  False False  False [OII]-$\lambda\lambda$7320,30                                oii_7320_30
+       oii_7330   7332.21      v   False  False False  False [OII]-$\lambda\lambda$7320,30                                oii_7320_30
       siii_9069   9071.103     w   False  False False  False [SIII]-$\lambda$9069                                         siii_9069
       siii_9532   9533.227     w   False  False False  False [SIII]-$\lambda$9532                                         siii_9532

--- a/py/fastspecfit/data/emlines.ecsv
+++ b/py/fastspecfit/data/emlines.ecsv
@@ -12,15 +12,21 @@
 # - {name: plotgroup, datatype: string}
 # meta: !!omap
 # - {description: 'Emission lines to be fit by fastspec.
-#     Wavelengths are in the vacuum rest-frame in Angstroms.
+#     Wavelengths are in the vacuum, rest-frame Angstroms.
 #
-#     References:
-#       https://github.com/Morisset/PyNeb_devel
-#       http://astronomy.nmsu.edu/drewski/tableofemissionlines.html
-#       https://db.chiantidatabase.org/
-#       https://github.com/cconroy20/fsps/blob/master/data/emlines_info.dat
-#       Shull, Stevans, & Danforth 2018, Table 4 - https://arxiv.org/pdf/1204.3908.pdf
-#       vanden Berk et al. 2001, Table 2 - https://iopscience.iop.org/article/10.1086/321167/pdf'}
+#     Wavelength references:
+#       * NIST - https://physics.nist.gov/PhysRefData/ASD/lines_form.html (observed, not Ritz, except as noted)
+#         * All the Balmer & Lyman lines
+#         * All the HeI lines
+#         * MgII 2796,2803
+#         * [NeV] 3346,3426; [NeIII] 3869; [OII] 3726,29; [SII] 6716,31; and [OII] 7320,30
+#         * (Ritz) - [OI] 6300; [SIII] 6312; and [SIII] 9069,9532
+#       * vanden Berk et al. 2001 - https://iopscience.iop.org/article/10.1086/321167/pdf, Table 2
+#         * [NV] 1240; OI 1304; Si IV 1396; CIV 1549; AlIII 1857; Si III] 1892; CIII] 1908; HeII 1640; and HeII 4686
+#       * Chianti Database - https://db.chiantidatabase.org; https://aas.aanda.org/articles/aas/pdf/1997/13/ds1260.pdf
+#         * [NII] 5755; [NII] 6548,84; [OIII] 4363; and [OIII] 4959,5007
+#         * Note that the Chianti [SIII] 9069,9532 wavelengths are quite wrong.'
+#       }
 # schema: astropy-2.0
 name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
         lyalpha   1215.670     a   False  False True   True  Ly$\alpha$+NV-$\lambda$1240                                  lya_nv
@@ -30,10 +36,10 @@ name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
        civ_1549   1549.06      d   False  False True   True  CIV-$\lambda$1549+HeII-$\lambda$1640                         civ_1549_heii_1640
       heii_1640   1640.42      e   False  True  True   False CIV-$\lambda$1549+HeII-$\lambda$1640                         civ_1549_heii_1640
      aliii_1857   1857.40      f   False  False True   False AlIII-$\lambda$1857+SiIII]-$\lambda$1892+CIII]-$\lambda$1908 aliii_1857_siliii_1892_ciii_1908
-    siliii_1892   1892.030     f   False  False True   False AlIII-$\lambda$1857+SiIII]-$\lambda$1892+CIII]-$\lambda$1908 aliii_1857_siliii_1892_ciii_1908
-      ciii_1908   1908.734     f   False  False True   True  AlIII-$\lambda$1857+SiIII]-$\lambda$1892+CIII]-$\lambda$1908 aliii_1857_siliii_1892_ciii_1908
-      mgii_2796   2796.3511    g   False  False True   True  MgII-$\lambda\lambda$2796,2803                               mgii_2796_2803
-      mgii_2803   2803.5324    g   False  False True   True  MgII-$\lambda\lambda$2796,2803                               mgii_2796_2803
+    siliii_1892   1892.03      f   False  False True   False AlIII-$\lambda$1857+SiIII]-$\lambda$1892+CIII]-$\lambda$1908 aliii_1857_siliii_1892_ciii_1908
+      ciii_1908   1908.73      f   False  False True   True  AlIII-$\lambda$1857+SiIII]-$\lambda$1892+CIII]-$\lambda$1908 aliii_1857_siliii_1892_ciii_1908
+      mgii_2796   2796.352     g   False  False True   True  MgII-$\lambda\lambda$2796,2803                               mgii_2796_2803
+      mgii_2803   2803.530     g   False  False True   True  MgII-$\lambda\lambda$2796,2803                               mgii_2796_2803
        nev_3346   3346.79      h   False  False False  False [NeV]-$\lambda$3346                                          nev_3346
        nev_3426   3426.85      h   False  False False  False [NeV]-$\lambda$3426                                          nev_3426
        oii_3726   3727.10      i   False  False False  True  [OII]-$\lambda\lambda$3726,29                                oii_3726_29
@@ -47,24 +53,24 @@ name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
    hdelta_broad   4102.892     l   True   False True   False H$\delta$-$\lambda$4101                                      hdelta
          hgamma   4341.692     m   True   False False  True  H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
    hgamma_broad   4341.692     m   True   False True   True  H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
-      oiii_4363   4364.4351    m   False  False False  False H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
+      oiii_4363   4364.436     m   False  False False  False H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
        hei_4471   4472.7350    n   True   True  False  False HeI-$\lambda$4471                                            hei_4471
-      heii_4686   4686.8655    o   False  True  True   False HeII-$\lambda$4686                                           heii_4686
+      heii_4686   4687.02      o   False  True  True   False HeII-$\lambda$4686                                           heii_4686
           hbeta   4862.71      p   True   False False  True  H$\beta$-$\lambda$4861                                       hbeta
     hbeta_broad   4862.71      p   True   False True   True  H$\beta$-$\lambda$4861                                       hbeta
-      oiii_4959   4960.2937    p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
-      oiii_5007   5008.2383    p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
-       nii_5755   5756.1887    q   False  False False  False [NII]-$\lambda$5755                                          nii_5755
+      oiii_4959   4960.295     p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
+      oiii_5007   5008.240     p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
+       nii_5755   5756.191     q   False  False False  False [NII]-$\lambda$5755                                          nii_5755
        hei_5876   5877.249     r   True   True  False  False HeI-$\lambda$5876                                            hei_5876
-        oi_6300   6302.0435    s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
-      siii_6312   6313.8062    s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
-       nii_6548   6549.8578    t   False  False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
+        oi_6300   6302.046     s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
+      siii_6312   6313.81      s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
+       nii_6548   6549.861     t   False  False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
          halpha   6564.60      t   True   False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
    halpha_broad   6564.60      t   True   False True   True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
-       nii_6584   6585.2696    t   False  False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
+       nii_6584   6585.273     t   False  False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
        sii_6716   6718.294     u   False  False False  True  [SII]-$\lambda\lambda$6716,31                                sii_6716_31
        sii_6731   6732.674     u   False  False False  True  [SII]-$\lambda\lambda$6716,31                                sii_6716_31
        oii_7320   7321.94      v   False  False False  False [OII]-$\lambda\lambda$7320,30                                oii_7320_30
        oii_7330   7332.21      v   False  False False  False [OII]-$\lambda\lambda$7320,30                                oii_7320_30
-      siii_9069   9071.103     w   False  False False  False [SIII]-$\lambda$9069                                         siii_9069
-      siii_9532   9533.227     w   False  False False  False [SIII]-$\lambda$9532                                         siii_9532
+      siii_9069   9071.1       w   False  False False  False [SIII]-$\lambda$9069                                         siii_9069
+      siii_9532   9533.2       w   False  False False  False [SIII]-$\lambda$9532                                         siii_9532

--- a/py/fastspecfit/data/emlines.ecsv
+++ b/py/fastspecfit/data/emlines.ecsv
@@ -23,7 +23,7 @@
 #       vanden Berk et al. 2001, Table 2 - https://iopscience.iop.org/article/10.1086/321167/pdf'}
 # schema: astropy-2.0
 name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
-        lyalpha   1215.67      a   False  False True   True  Ly$\alpha$+NV-$\lambda$1240                                  lya_nv
+        lyalpha   1215.670     a   False  False True   True  Ly$\alpha$+NV-$\lambda$1240                                  lya_nv
         nv_1240   1240.14      a   False  False True   True  Ly$\alpha$+NV-$\lambda$1240                                  lya_nv
         oi_1304   1304.35      b   False  False True   False OI-$\lambda$1304                                             oi_1304
      siliv_1396   1396.76      c   False  False True   False SiIV-$\lambda$1396                                           siliv_1396
@@ -39,19 +39,19 @@ name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
        oii_3726   3727.0919    i   False  False False  True  [OII]-$\lambda\lambda$3726,29                                oii_3726_29
        oii_3729   3729.8750    i   False  False False  True  [OII]-$\lambda\lambda$3726,29                                oii_3726_29
      neiii_3869   3869.8611    j   False  False False  False [NeIII]-$\lambda$3869+H6                                     neiii_3869_h6
-             h6   3890.1576    j   True   False False  False [NeIII]-$\lambda$3869+H6                                     neiii_3869_h6
-       h6_broad   3890.1576    j   True   False True   False [NeIII]-$\lambda$3869+H6                                     neiii_3869_h6
-       hepsilon   3971.195     k   True   False False  False H$\epsilon$-$\lambda$3970                                    hepsilon
- hepsilon_broad   3971.195     k   True   False True   False H$\epsilon$-$\lambda$3970                                    hepsilon
+             h6   3890.166     j   True   False False  False [NeIII]-$\lambda$3869+H6                                     neiii_3869_h6
+       h6_broad   3890.166     j   True   False True   False [NeIII]-$\lambda$3869+H6                                     neiii_3869_h6
+       hepsilon   3971.198     k   True   False False  False H$\epsilon$-$\lambda$3970                                    hepsilon
+ hepsilon_broad   3971.198     k   True   False True   False H$\epsilon$-$\lambda$3970                                    hepsilon
          hdelta   4102.892     l   True   False False  False H$\delta$-$\lambda$4101                                      hdelta
    hdelta_broad   4102.892     l   True   False True   False H$\delta$-$\lambda$4101                                      hdelta
-         hgamma   4341.684     m   True   False False  True  H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
-   hgamma_broad   4341.684     m   True   False True   True  H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
+         hgamma   4341.692     m   True   False False  True  H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
+   hgamma_broad   4341.692     m   True   False True   True  H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
       oiii_4363   4364.4351    m   False  False False  False H$\gamma$-$\lambda$4340+[OIII]-$\lambda$4363                 hgamma_oiii_4363
        hei_4471   4472.7290    n   True   True  False  False HeI-$\lambda$4471                                            hei_4471
       heii_4686   4686.8655    o   False  True  True   False HeII-$\lambda$4686                                           heii_4686
-          hbeta   4862.683     p   True   False False  True  H$\beta$-$\lambda$4861                                       hbeta
-    hbeta_broad   4862.683     p   True   False True   True  H$\beta$-$\lambda$4861                                       hbeta
+          hbeta   4862.71      p   True   False False  True  H$\beta$-$\lambda$4861                                       hbeta
+    hbeta_broad   4862.71      p   True   False True   True  H$\beta$-$\lambda$4861                                       hbeta
       oiii_4959   4960.2937    p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
       oiii_5007   5008.2383    p   False  False False  True  [OIII]-$\lambda\lambda$4959,5007                             oiii_doublet
        nii_5755   5756.1887    q   False  False False  False [NII]-$\lambda$5755                                          nii_5755
@@ -59,8 +59,8 @@ name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
         oi_6300   6302.0435    s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
       siii_6312   6313.8062    s   False  False False  False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                      oi_6300_siii_6312
        nii_6548   6549.8578    t   False  False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
-         halpha   6564.613     t   True   False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
-   halpha_broad   6564.613     t   True   False True   True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
+         halpha   6564.60      t   True   False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
+   halpha_broad   6564.60      t   True   False True   True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
        nii_6584   6585.2696    t   False  False False  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84                      halpha_nii_6548_48
        sii_6716   6718.2913    u   False  False False  True  [SII]-$\lambda\lambda$6716,31                                sii_6716_31
        sii_6731   6732.6705    u   False  False False  True  [SII]-$\lambda\lambda$6716,31                                sii_6716_31


### PR DESCRIPTION
This PR addresses #175.

In addition, @arjundey pointed out that some of the adopted rest wavelengths don't match [NIST](https://physics.nist.gov/PhysRefData/ASD/lines_form.html), so this PR also includes changes to some rest wavelengths (and updates the reference documentation to be more explicit about which lines came from which wavelength).

Finally, the data model documentation has been updated to match the current line-list and to fix a couple errors.
