### PR TITLE
New resolution matrix implementation

### DIFF
--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -32,7 +32,6 @@ class ContinuumTools(object):
         self.massnorm = 1e10  # stellar mass normalization factor [Msun]
         self.ebv_guess = 0.05 # [mag]
 
-        self.pixkms_bounds = templates.pixkms_bounds
         self.lg_atten = np.log(10.) * (-0.4 * templates.dust_klambda)
 
         # Cache the redshift-dependent factors (incl. IGM attenuation),
@@ -341,7 +340,7 @@ class ContinuumTools(object):
 
 
     def templates2data(self, templateflux, templatewave, redshift=0., dluminosity=None,
-                       vdisp=None, cameras=['b','r','z'], specwave=None, specres=None,
+                       vdisp=None, cameras=np.array(['b','r','z']), specwave=None, specres=None,
                        specmask=None, coeff=None, photsys=None, synthphot=True,
                        stack_cameras=False, flamphot=False, debug=False, get_abmag=False):
         """Deprecated. Work-horse method for turning input templates into data-like
@@ -748,13 +747,13 @@ class ContinuumTools(object):
         -------
         modelflux : :class:`numpy.ndarray` [nwave]
             Observed-frame model spectrum at the instrumental resolution and
-            wavelength sampling given by `specwave` and `specres`.
+            wavelength sampling given by `specres` and `specwave`.
 
         """
         camerapix = self.data['camerapix']
         specwave  = self.data['wave']
         specres   = self.data['res']
-
+        
         modelflux = np.empty(self.wavelen)
         
         for icam, (s, e) in enumerate(camerapix):

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -70,9 +70,7 @@ class ContinuumTools(object):
             self.wavelen = np.sum([len(w) for w in self.data['wave']])
 
             # get preprocessing data to accelerate resampling
-            rspre = []
-            for wave in self.data['wave']:
-                rspre.append(trapz_rebin_pre(wave))
+            rspre = [ trapz_rebin_pre(w) for w in self.data['wave'] ]
             self.spec_pre = tuple(rspre)
 
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -13,8 +13,8 @@ from fastspecfit.logger import log
 from fastspecfit.photometry import Photometry
 from fastspecfit.templates import Templates
 from fastspecfit.util import (C_LIGHT, FLUXNORM,
-    trapz_rebin, trapz_rebin_pre, quantile,
-    median, sigmaclip)
+    trapz_rebin, trapz_rebin_pre,
+    quantile, median, sigmaclip)
 
 
 class ContinuumTools(object):
@@ -756,13 +756,13 @@ class ContinuumTools(object):
         specres   = self.data['res']
 
         modelflux = np.empty(self.wavelen)
-
+        
         for icam, (s, e) in enumerate(camerapix):
             resampflux = trapz_rebin(self.ztemplatewave,
                                      contmodel,
                                      specwave[icam],
                                      pre=self.spec_pre[icam])
-            modelflux[s:e] = specres[icam] @ resampflux
+            specres[icam].dot(resampflux, out=modelflux[s:e])
 
         return modelflux
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -831,8 +831,6 @@ class ContinuumTools(object):
             vdisp         = None
             templatecoeff = params[1:]
 
-        # FIXME: write results directly into resid array instead of
-        # allocating new
         fullmodel = self.build_stellar_continuum(
             templateflux, templatecoeff,
             ebv=ebv, vdisp=vdisp, conv_pre=conv_pre,
@@ -857,17 +855,15 @@ class ContinuumTools(object):
         if synthspec:
             modelflux = self.continuum_to_spectroscopy(fullmodel)
             spec_resid = resid[:resid_split]
-            spec_resid[:]  = specflux
-            spec_resid    -= modelflux
-            spec_resid    *= specistd
-
+            np.subtract(modelflux, specflux, spec_resid)
+            spec_resid *= specistd
+        
         if synthphot:
             modelflam = self.continuum_to_photometry(fullmodel)
             phot_resid = resid[resid_split:]
-            phot_resid[:] = objflam
-            phot_resid   -= modelflam
-            phot_resid   *= objflamistd
-
+            np.subtract(modelflam, objflam, phot_resid)
+            phot_resid *= objflamistd
+        
         return resid
 
 

--- a/py/fastspecfit/emline_fit/__init__.py
+++ b/py/fastspecfit/emline_fit/__init__.py
@@ -6,5 +6,3 @@ from .interface import (
 )
 
 from .params_mapping import ParamsMapping as EMLine_ParamsMapping
-
-from .sparse_rep import ResMatrix as EMLine_Resolution

--- a/py/fastspecfit/emline_fit/interface.py
+++ b/py/fastspecfit/emline_fit/interface.py
@@ -164,14 +164,14 @@ class EMLine_Objective(object):
                                       ibw,
                                       self.redshift,
                                       self.line_wavelengths,
-                                      self.resolution_matrices[icam].ndiag())
+                                      self.resolution_matrices[icam].ndiag)
             
             # ignore any columns corresponding to fixed parameters
             endpts = idealJac[0]
             endpts[self.params_mapping.fixedMask(), :] = 0
         
             jacs.append( mulWMJ(self.obs_weights[s:e],
-                                self.resolution_matrices[icam].data,
+                                self.resolution_matrices[icam].rowdata(),
                                 idealJac) )
             
         nBins = np.sum(np.diff(self.camerapix))
@@ -445,7 +445,7 @@ def _build_model_core(line_parameters,
         
         # convolve model with resolution matrix and store in
         # this camera's subrange of model_fluxes
-        resolution_matrices[icam].matvec(mf, model_fluxes[s:e])
+        resolution_matrices[icam].dot(mf, model_fluxes[s:e])
 
 
 #
@@ -494,11 +494,11 @@ def _build_multimodel_core(line_parameters,
                                             log_obs_bin_edges[s+icam:e+icam+1],
                                             redshift,
                                             ibw,
-                                            resolution_matrices[icam].ndiag())
+                                            resolution_matrices[icam].ndiag)
         
         # convolve each line's waveform with resolution matrix
         endpts, M = mulWMJ(np.ones(e - s),
-                           resolution_matrices[icam].data,
+                           resolution_matrices[icam].rowdata(),
                            line_models)
         
         # adjust endpoints to reflect camera range

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1100,7 +1100,7 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
 
     redshift          = data['redshift']
     camerapix         = data['camerapix']
-    resolution_matrix = data['res_emline']
+    resolution_matrix = data['res']
 
     # Combine pixels across all cameras
     emlinewave  = np.hstack(data['wave'])

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -576,8 +576,8 @@ class EMFitTools(object):
                                    obs_weights,
                                    redshift,
                                    line_wavelengths,
-                                   tuple(resolution_matrices),
-                                   camerapix, # for more efficient iteration
+                                   resolution_matrices,
+                                   camerapix,
                                    params_mapping,
                                    continuum_patches=continuum_patches)
 

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -637,7 +637,7 @@ class DESISpectra(object):
                 Three-element list of `numpy.ndarray` inverse variance spectra, one
                 for each camera.
             res : :class:`list`
-                Three-element list of :class:`desispec.resolution.Resolution`
+                Three-element list of :class:`fastspecfit.resolution.Resolution`
                 objects, one for each camera.
             snr : `numpy.ndarray`
                 Median per-pixel signal-to-noise ratio in the grz cameras.
@@ -681,8 +681,7 @@ class DESISpectra(object):
         from desispec.coaddition import coadd_cameras
         from desispec.io import read_spectra
         from desiutil.dust import SFDMap
-        from desispec.resolution import Resolution
-        from fastspecfit.emline_fit import EMLine_Resolution
+        from fastspecfit.resolution import Resolution
 
         t0 = time.time()
 
@@ -782,7 +781,7 @@ class DESISpectra(object):
                         'coadd_flux': coadd_spec.flux[coadd_cams][iobj, :],
                         'coadd_ivar': coadd_spec.ivar[coadd_cams][iobj, :],
                         'coadd_res': [Resolution(coadd_spec.resolution_data[coadd_cams][iobj, :])],
-                        'coadd_res_emline': [EMLine_Resolution(coadd_spec.resolution_data[coadd_cams][iobj, :])],
+                        'coadd_res_emline': [Resolution(coadd_spec.resolution_data[coadd_cams][iobj, :])],
                         }
 
                     mpargs.append({
@@ -821,8 +820,7 @@ class DESISpectra(object):
         extinction. Also flag pixels which may be affected by emission lines.
 
         """
-        from desispec.resolution import Resolution
-        from fastspecfit.emline_fit import EMLine_Resolution
+        from fastspecfit.resolution import Resolution
         from fastspecfit.util import mwdust_transmission, median
         from fastspecfit.linemasker import LineMasker
 
@@ -949,8 +947,7 @@ class DESISpectra(object):
                         specdata['mask'].append(specdata['mask0'][icam])
 
                         specdata['res'].append(Resolution(res))
-                        specdata['res_emline'].append(EMLine_Resolution(res))
-
+                        
             if len(cameras) == 0:
                 errmsg = 'No good data, which should never happen.'
                 log.critical(errmsg)
@@ -1058,7 +1055,7 @@ class DESISpectra(object):
                 Three-element list of `numpy.ndarray` inverse variance spectra, one
                 for each camera.
             res : :class:`list`
-                Three-element list of :class:`desispec.resolution.Resolution`
+                Three-element list of :class:`fastspecfit.resolution.Resolution`
                 objects, one for each camera.
             snr : `numpy.ndarray`
                 Median per-pixel signal-to-noise ratio in the grz cameras.
@@ -1098,7 +1095,7 @@ class DESISpectra(object):
 
         """
         from astropy.table import vstack
-        from desispec.resolution import Resolution
+        from fastspecfit.resolution import Resolution
 
         if stackfiles is None:
             errmsg = 'At least one stackfiles file is required.'

--- a/py/fastspecfit/linemasker.py
+++ b/py/fastspecfit/linemasker.py
@@ -209,7 +209,7 @@ class LineMasker(object):
         ivar : :class:`numpy.ndarray` [npix]
             Inverse variance spectrum corresponding to `flux`.
         resolution_matrix : :class:`list`
-            List of :class:`fastspecfit.emline_fit.sparse_rep.ResMatrix`
+            List of :class:`fastspecfit.resolution.Resolution`
             objects, one per camera.
         redshift : :class:`float`
             Object redshift.

--- a/py/fastspecfit/resolution.py
+++ b/py/fastspecfit/resolution.py
@@ -1,0 +1,133 @@
+import numpy as np
+from numba import jit
+
+class Resolution(object):
+    """Resolution matrix, in the style of desispec.resolution.Resolution
+
+    The base implementation is analogous to scipy.sparse.dia_matrix,
+    storing a [ndiag x dim] 2D array giving the values on diagonals
+    [ndiag//2 ... -ndiag//2] of a dim x dim matrix.  We reimplement
+    the dot() method in Numba, special-casing for this specific
+    pattern of diagonal offsets; the result is faster than using
+    dia_matrix, even though the latter's dot method is in C.
+
+    We also provide conversion to a 2D array giving the nonzero
+    entries in each *row* of the matrix, which is used by emline
+    fitting code.
+
+    """
+    
+    def __init__(self, data):
+        """
+        Parameters
+        ----------
+        data : :class:`np.ndarray` [ndiag x dim]
+           Array of values for diagonals [ndiag//2 .. -ndiag//2];
+           note that some entries at the ends of rows are ignored.
+           All other diagonals are assumed to be zero.
+        
+        """
+        ndiag, dim = data.shape
+
+        self.shape = (dim, dim)
+        self.ndiag = ndiag
+        self.data  = data
+        
+        self.rows  = None # compute on first use
+
+    
+    def rowdata(self):
+        """
+        Compute sparse row matrix from diagonal representation.
+
+        Returns
+        -------
+        2D array of size [dim x ndiag] with nonzero entries
+        for each row of the matrix.
+        
+        """
+        if self.rows is None:
+            self.rows = self._dia_to_rows(self.data)
+        return self.rows
+
+    
+    def dot(self, v, out=None):
+        """
+        Compute our dot product with vector v, storing
+        result in out (which is created if None).
+
+        Parameters
+        ----------
+        v : :class:`np.ndarray` [dim]
+           vector of values to dot with us.
+        out : :class:`np.ndarray` [dim] or None
+           array to hold output; created if None.
+
+        Returns
+        -------
+        array of length [dim] holding output.
+        
+        """
+        if out is None:
+            out = np.empty(self.shape[0], dtype=v.dtype)
+
+        return self._matvec(self.data, v, out)
+    
+    
+    @staticmethod
+    @jit(nopython=True, fastmath=False, nogil=True)
+    def _matvec(D, v, out):
+        """
+        Compute matrix-vector product of a Resolution matrix A and a vector v.
+            
+        A has shape dim x dim, and its nonzero entries are given by
+        a matrix D of size ndiag x dim, providing values on diagonals
+        [ndiag//2 .. -ndiag//2], inclusive. v is an array of length dim.
+        
+        Return result in array out of size dim.
+        
+        """
+        out[:] = 0.
+        
+        ndiag, dim = D.shape
+        for i in range(ndiag):
+            k = ndiag//2 - i   # diagonal offset
+        
+            i_start = np.maximum(0, -k)
+            j_start = np.maximum(0,  k)
+            j_end   = np.minimum(dim + k, dim)
+            
+            for n in range(j_end - j_start):
+                out[i_start + n] += D[i, j_start + n] * v[j_start + n]
+            
+        return out
+    
+    
+    @staticmethod
+    @jit(nopython=True, fastmath=False, nogil=True)
+    def _dia_to_rows(D):
+        """
+        Convert a diagonally sparse matrix M in the form
+        stored by DESI into a sparse row representation.
+        
+        Input M is represented as a 2D array D of size ndiag x nrow,
+        whose rows are M's diagonals:
+             M[i,j] = D[ndiag//2 - (j - i), j]
+        ndiag is assumed to be odd, and entries in D that would be
+        outside the bounds of M are ignored.
+        """
+
+        ndiag, dim = D.shape
+        hdiag = ndiag//2
+
+        A = np.empty((dim, ndiag), dtype=D.dtype)
+        
+        for i in range(dim):
+            # min and max column for row
+            jmin = np.maximum(i - hdiag,       0)
+            jmax = np.minimum(i + hdiag, dim - 1)
+
+            for j in range(jmin, jmax + 1):
+                A[i, j - (i - hdiag)] = D[hdiag + i - j, j]
+                
+        return A

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -206,8 +206,9 @@ class Templates(object):
         if find_spec("mkl_fft") is not None:
             import mkl_fft._scipy_fft_backend as be
             sc_fft.set_global_backend(be)
-
+            
             self.convolve = sc_sig.convolve
+            log.info('Using mkl_fft library for FFTs')
         else:
             self.convolve = sc_sig.oaconvolve
 

--- a/py/fastspecfit/util.py
+++ b/py/fastspecfit/util.py
@@ -5,7 +5,6 @@ fastspecfit.util
 General utilities.
 
 """
-import os
 import numpy as np
 import numba
 


### PR DESCRIPTION
Reimplement enough of desispec.resolution.Resolution to perform matrix-vector operations, which is all we do with it, with a significant speedup via Numba compared to the scipy.sparse implementation.

Retire the old res_emline version of the matrix, which is slower for dot product than either DESI or our new implementation.  Allow conversion on the fly from our new impl to the internal rep used by res_emline, which is used way down in the guts of emline fitting but not otherwise.  Switching away from res_emline for dot products does result in a small change in the output of emline fitting, which propagates to masking.

In passing, implement several small code cleanups that do not impact the results at all, including more efficient storage of some fields in the data dictionary and avoiding a copy in the _stellar_objective().