### PR TITLE
Fix issues with log level retention 

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ Change Log
 3.1.0 (not released yet)
 ------------------------
 
-*
+* Fix issues with log level retention [`PR #187`_].
+
+.. _`PR #187`: https://github.com/desihub/fastspecfit/pull/187
 
 3.0.0 (2024-10-30)
 ------------------

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1514,7 +1514,7 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools,
         snrmsg = f"Median spectral S/N_{data['cameras']}={data['snr'][0]:.2f}"
     else:
         snrmsg = f"Median spectral S/N_{data['cameras'][0]}={data['snr'][0]:.2f}"
-        for icam in np.arange(ncam-1)+1:
+        for icam in np.range(1,ncam):
             snrmsg += f" S/N_{data['cameras'][icam]}={data['snr'][icam]:.2f}"
     log.info(snrmsg)
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1514,7 +1514,7 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools,
         snrmsg = f"Median spectral S/N_{data['cameras']}={data['snr'][0]:.2f}"
     else:
         snrmsg = f"Median spectral S/N_{data['cameras'][0]}={data['snr'][0]:.2f}"
-        for icam in np.range(1,ncam):
+        for icam in range(1,ncam):
             snrmsg += f" S/N_{data['cameras'][icam]}={data['snr'][icam]:.2f}"
     log.info(snrmsg)
 

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -939,13 +939,10 @@ class EMFitTools(object):
 
             ew, ewivar = 0., 0.
             if cmed != 0. and civar != 0.:
-                try:
-                    if flux > 0. and flux_ivar > 0.:
-                        # add the uncertainties in flux and the continuum in quadrature
-                        ew = flux / cmed / (1. + redshift) # rest frame [A]
-                        ewivar = (1. + redshift)**2 / (1. / (cmed**2 * flux_ivar) + flux**2 / (cmed**4 * civar))
-                except:
-                    import pdb ; pdb.set_trace()
+                if flux > 0. and flux_ivar > 0.:
+                    # add the uncertainties in flux and the continuum in quadrature
+                    ew = flux / cmed / (1. + redshift) # rest frame [A]
+                    ewivar = (1. + redshift)**2 / (1. / (cmed**2 * flux_ivar) + flux**2 / (cmed**4 * civar))
 
                 # upper limit on the flux is defined by snrcut*cont_err*sqrt(2*pi)*linesigma
                 fluxlimit = np.sqrt(2. * np.pi) * linesigma_ang / np.sqrt(civar) # * u.erg/(u.second*u.cm**2)

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -101,10 +101,6 @@ def fastspec(fastphot=False, stackfit=False, args=None, comm=None, verbose=False
     if verbose:
         args.verbose = True
 
-    if args.verbose:
-        from fastspecfit.logger import DEBUG
-        log.setLevel(DEBUG)
-
     targetids = None
     input_redshifts = None
 
@@ -127,6 +123,7 @@ def fastspec(fastphot=False, stackfit=False, args=None, comm=None, verbose=False
         'template_file':     args.templates,
         'template_version':  args.templateversion,
         'template_imf':      args.imf,
+        'log_verbose':       args.verbose
     }
 
     sc_data.initialize(**init_sc_args)

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -11,7 +11,7 @@ import numpy as np
 import fitsio
 from astropy.table import Table
 
-from fastspecfit.logger import log, DEBUG
+from fastspecfit.logger import log
 from fastspecfit.singlecopy import sc_data
 from fastspecfit.photometry import Photometry
 from fastspecfit.util import FLUXNORM, ZWarningMask

--- a/py/fastspecfit/linemasker.py
+++ b/py/fastspecfit/linemasker.py
@@ -9,7 +9,7 @@ import time
 import numpy as np
 from astropy.table import Table
 
-from fastspecfit.logger import log, DEBUG
+from fastspecfit.logger import log
 from fastspecfit.util import C_LIGHT, quantile, median
 
 

--- a/py/fastspecfit/logger.py
+++ b/py/fastspecfit/logger.py
@@ -2,7 +2,10 @@
 fastspecfit.logger
 ==================
 
-Unique logger object, allocated at startup and used throughout code base.
+Unique logger object, distinct from the one used by the DESI libraries,
+allocated at startup and used throughout code base.  We need to create
+our own logger to avoid the DESI libraries accidentally changing the
+log level out from under us.
 
 Having just one logger allows us to initialize its level on startup and have
 those changes propagate everywhere.
@@ -10,6 +13,40 @@ those changes propagate everywhere.
 This needs to be in its own file to prevent circular imports with other code.
 
 """
-from desiutil.log import get_logger, DEBUG
+from logging import DEBUG
 
-log = get_logger()#DEBUG)
+def getFastspecLogger():
+    """
+    Create a logging object unique to the fastspec tools.
+    Configure it to send its log messages to stdout and to
+    format them identically to the DESIUtil defaults.
+
+    Note that every call to this function returns the *same*
+    log object, so will reset its properties including log level.
+    Hence, it should really only be called once at the start
+    of the program, as we do here, to create a singleton
+    log object.
+
+    Returns a log object with default level INFO.
+    """
+
+    import logging
+    import sys
+
+    root_name = 'fastspec'
+
+    ch = logging.StreamHandler(sys.stdout)
+    fmtfields = ['%(levelname)s', '%(filename)s', '%(lineno)s', '%(funcName)s']
+    fmtfields.append(' %(message)s')
+    formatter = logging.Formatter(':'.join(fmtfields),
+                                  datefmt='%Y-%m-%dT%H:%M:%S')
+    ch.setFormatter(formatter)
+
+    log = logging.getLogger(root_name)
+    log.addHandler(ch)
+    log.setLevel(logging.INFO)
+
+    return log
+
+
+log = getFastspecLogger()

--- a/py/fastspecfit/photometry.py
+++ b/py/fastspecfit/photometry.py
@@ -10,7 +10,7 @@ import numpy as np
 import fitsio
 from astropy.table import Table
 
-from fastspecfit.logger import log, DEBUG
+from fastspecfit.logger import log
 from fastspecfit.util import trapz, C_LIGHT, FLUXNORM
 
 
@@ -1164,7 +1164,7 @@ def _gather_tractorphot_onebrick(input_cat, legacysurveydir, radius_match, racol
 
 def gather_tractorphot(input_cat, racolumn='TARGET_RA', deccolumn='TARGET_DEC',
                        legacysurveydir=None, dr9dir=None, radius_match=1.0,
-                       restrict_region=None, columns=None, verbose=False):
+                       restrict_region=None, columns=None):
     """Retrieve the Tractor catalog for all the objects in this catalog (one brick).
 
     Args:
@@ -1186,12 +1186,6 @@ def gather_tractorphot(input_cat, racolumn='TARGET_RA', deccolumn='TARGET_DEC',
     """
     from desitarget.targets import decode_targetid
     from desiutil.brick import brickname
-    from desiutil.log import get_logger, DEBUG
-
-    if verbose:
-        log = get_logger(DEBUG)
-    else:
-        log = get_logger()
 
     if len(input_cat) == 0:
         log.warning('No objects in input catalog.')

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -1432,6 +1432,7 @@ def fastqa(args=None, comm=None):
         'template_file':     args.templates,
         'template_version':  args.templateversion,
         'template_imf':      args.imf,
+        'log_verbose':       False,
     }
 
     sc_data.initialize(**init_sc_args)

--- a/py/fastspecfit/singlecopy.py
+++ b/py/fastspecfit/singlecopy.py
@@ -10,7 +10,7 @@ from fastspecfit.igm import Inoue14
 from fastspecfit.photometry import Photometry
 from fastspecfit.linetable import LineTable
 from fastspecfit.templates import Templates
-from fastspecfit.logger import log
+from fastspecfit.logger import log, DEBUG
 
 class Singletons(object):
 
@@ -25,7 +25,13 @@ class Singletons(object):
                    ignore_photometry=False,
                    template_file=None,
                    template_version=None,
-                   template_imf=None):
+                   template_imf=None,
+                   log_verbose=False,
+    ):
+
+        # adjust logging level if requested
+        if log_verbose:
+            log.setLevel(DEBUG)
 
         # templates for continnuum fitting
         self.templates = Templates(template_file=template_file,


### PR DESCRIPTION
fastspec --verbose sets the log level to DEBUG, but this level unexpectedly reverts to INFO when imports from the DESI libraries implicitly invoke get_logger(), which reset the log level.  There seems to be no safe way to avoid this with desiutil.log, since it always returns the same log object that the DESI libraries themselves use internally.  So, make our global 'log' object distinct from desutil's by creating it with a new domain ('fastspec').

While we're at it, make sure the log level is set in the singlecopy initialization code, so that it happens in subprocesses as well as the parent process when running in mp mode.  (This isn't being exercised now because multiprocessing uses fork, but it should futureproof us against Python 3.14+, which will switch to spawn.)