### PR TITLE
A simplified idiom for Monte Carlo iteration

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,14 @@ Change Log
 3.1.0 (not released yet)
 ------------------------
 
+* Implement a simplified idiom for Monte Carlo iteration [`PR #191`_].
 * Monte Carlo to estimate model parameters [`PR #189`_].
 * Fix issues with log level retention [`PR #187`_].
 
 .. _`PR #187`: https://github.com/desihub/fastspecfit/pull/187
 .. _`PR #189`: https://github.com/desihub/fastspecfit/pull/189
+.. _`PR #191`: https://github.com/desihub/fastspecfit/pull/191
+
 
 3.0.0 (2024-10-30)
 ------------------

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1070,26 +1070,6 @@ def continuum_fastphot(redshift, objflam, objflamivar, CTools,
              dn4000_model_monte, _) = \
                  do_fit_monte(tauv_guess_monte, objflam_monte)
 
-            """
-            for imonte in range(nmonte):
-                tauv1, _, coeff1, _ = CTools.fit_stellar_continuum(
-                    templates.flux_nomvdisp[agekeep, :], fit_vdisp=False,
-                    tauv_guess=tauv_guess[imonte], objflam=objflam_monte[imonte, :],
-                    objflamistd=objflamistd, synthphot=True, synthspec=False)
-
-                coeff_monte[imonte, :] = coeff1
-                tauv_monte[imonte] = tauv1
-
-                sedmodel_monte[imonte, :] = CTools.optimizer_saved_contmodel
-                sedmodel_nolines_monte[imonte, :] = CTools.build_stellar_continuum(
-                    templates.flux_nolines_nomvdisp[agekeep, :], coeff1,
-                    tauv=tauv1, vdisp=None, dust_emission=False)
-
-                dn4000_model1, _ = Photometry.get_dn4000(
-                    templates.wave, sedmodel_nolines_monte[imonte, :], rest=True)
-                dn4000_model_monte[imonte] = dn4000_model1
-            """
-
             tauv_var = np.var(tauv_monte)
             dn4000_model_var = np.var(dn4000_model_monte)
             if tauv_var > TINY:
@@ -1353,17 +1333,6 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=50,
                 (tauv_monte, vdisp_monte, _, age_monte, _) = \
                     do_fit_vdisp_monte(specflux_monte)
 
-                """
-                for imonte in range(nmonte):
-                    tauv1, vdisp1, coeff1, _ = CTools.fit_stellar_continuum(
-                        templates.flux_nolines[agekeep, :], fit_vdisp=True,
-                        conv_pre=input_conv_pre_nolines, specflux=specflux_monte[imonte, :],
-                        specistd=specistd*fitmask, dust_emission=False, synthspec=True)
-                    tauv_monte[imonte] = tauv1
-                    vdisp_monte[imonte] = vdisp1
-                    age_monte[imonte] = coeff1.dot(templates.info['age']) / np.sum(coeff1) / 1e9 # [Gyr]
-                """
-
                 tauv_sigma = np.std(tauv_monte)
                 age_sigma = np.std(age_monte)
                 vdisp_sigma = np.std(vdisp_monte)
@@ -1525,31 +1494,6 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=50,
          sedmodel_monte, sedmodel_nolines_monte,
          desimodel_nolines_monte, dn4000_model_monte, _) = \
              do_fit_full_monte(tauv_guess, objflam_monte, specflux_monte)
-
-        """
-        for imonte in range(nmonte):
-            tauv1, _, coeff1, _ = CTools.fit_stellar_continuum(
-                input_templateflux, fit_vdisp=False, conv_pre=None,
-                tauv_guess=tauv_guess[imonte],
-                objflam=objflam_monte[imonte, :], objflamistd=objflamistd,
-                specflux=specflux_monte[imonte, :]*median_apercorr,
-                specistd=specistd/median_apercorr,
-                synthphot=True, synthspec=True)
-
-            coeff_monte[imonte, :] = coeff1
-            tauv_monte[imonte] = tauv1
-
-            sedmodel_monte[imonte, :] = CTools.optimizer_saved_contmodel.copy() # copy needed?
-            sedmodel_nolines_monte[imonte, :] = CTools.build_stellar_continuum(
-                input_templateflux_nolines, coeff1, tauv=tauv1,
-                vdisp=None, conv_pre=None, dust_emission=False)
-            desimodel_nolines_monte[imonte, :] = CTools.continuum_to_spectroscopy(
-                sedmodel_nolines_monte[imonte, :])
-
-            dn4000_model1, _ = Photometry.get_dn4000(
-                templates.wave, sedmodel_nolines_monte[imonte, :], rest=True)
-            dn4000_model_monte[imonte] = dn4000_model1
-        """
 
         tauv_var = np.var(tauv_monte)
         dn4000_model_var = np.var(dn4000_model_monte)

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1570,11 +1570,10 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=50,
 
     if desimodel_nolines_monte is not None:
         continuummodel_monte = []
-        for imonte in range(nmonte):
-            continuummodel_monte_one = []
-            for campix in data['camerapix']:
-                continuummodel_monte_one.append(desimodel_nolines_monte[imonte, campix[0]:campix[1]])
-            continuummodel_monte.append(continuummodel_monte_one)
+        for icam, campix in enumerate(data['camerapix']):
+            ss, ee = campix
+            models = np.vstack([desimodel_nolines_monte[imonte, ss:ee] for imonte in range(nmonte)])
+            continuummodel_monte.append(models)
 
     return (coeff, coeff_monte, rchi2_cont, rchi2_phot, median_apercorr, apercorrs,
             tauv, tauv_ivar, vdisp, vdisp_ivar, dn4000, dn4000_ivar, dn4000_model,
@@ -1801,11 +1800,6 @@ def continuum_specfit(data, result, templates, igm, phot,
         continuummodel = [cm / median_apercorr for cm in continuummodel]
         smoothcontinuum = [sc / median_apercorr for sc in smoothcontinuum]
         if continuummodel_monte is not None:
-            continuummodel_monte_renorm = []
-            for imonte in range(nmonte):
-                continuummodel_one = continuummodel_monte[imonte]
-                continuummodel_one = [cm / median_apercorr for cm in continuummodel_one]
-                continuummodel_monte_renorm.append(continuummodel_one)
-            continuummodel_monte = continuummodel_monte_renorm
+            continuummodel_monte = [ cm / median_apercorr for cm in continuummodel_monte ]
 
         return continuummodel, smoothcontinuum, continuummodel_monte, specflux_monte

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1552,9 +1552,8 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
     if specflux_monte is not None:
         nmonte, _ = specflux_monte.shape
         if continuummodel_monte is not None:
-            continuummodelflux_monte = np.zeros((nmonte, len(continuummodelflux)))
-            for imonte in range(nmonte):
-                continuummodelflux_monte[imonte, :] = np.hstack(continuummodel_monte[imonte])
+            continuummodelflux_monte = np.hstack(continuummodel_monte)
+
             emlineflux_monte = (specflux_monte - continuummodelflux_monte - \
                                 smoothcontinuummodelflux[np.newaxis, :])
         else:

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -608,7 +608,7 @@ class EMFitTools(object):
                 bounds[nLineFree+nPatches:]                   = continuum_patches['intercept_bounds']
 
             # least_squares wants two arrays, not a 2D array
-            bounds = ( bounds[:,0], bounds[:,1] )
+            bounds = ( bounds[:, 0], bounds[:, 1] )
 
             fit_info = least_squares(objective, initial_guesses, jac=jac, args=(),
                                      max_nfev=5000, xtol=1e-10, ftol=1e-5, #x_scale='jac' gtol=1e-10,
@@ -906,7 +906,7 @@ class EMFitTools(object):
 
             # Are the pixels based on the original inverse spectrum fully
             # masked? If so, set everything to zero and move onto the next line.
-            if np.sum(oemlineivar_s[line_s:line_e] == 0.) > 0.3 * (line_e - line_s): # use original ivar
+            if (line_s == line_e) or (np.sum(oemlineivar_s[line_s:line_e] == 0.) > 0.3 * (line_e - line_s)):
                 obsamps[line_amp] = 0.
                 values[line_amp]    = 0.
                 values[line_vshift] = 0.

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1064,6 +1064,7 @@ class EMFitTools(object):
                     for imonte in range(nmonte):
                         _linez = redshift + values_monte[imonte, line_vshift] / C_LIGHT
                         _linezwave = restwave * (1. + _linez)
+                        _linesigma = values_monte[imonte, line_sigma] # [km/s]
                         _, _, _linesigma_ang_window, _ = \
                             _preprocess_linesigma(_linesigma, _linezwave, isbroad, isbalmer)
                         _borderindx = _get_continuum_pixels(emlinewave_s, _linezwave, _linesigma_ang_window)


### PR DESCRIPTION
We perform Monte Carlo iteration in several places in continuum fitting.  Previously, these usages were somewhat ad hoc, as they mixed together
  - initialization of Monte Carlo inputs
  - creation of empty arrays to hold Monte Carlo outputs
  - the actual Monte Carlo operations and filling the arrays
 Moreover, there were a few divergences between the operations in basic fitting and the corresponding Monte Carlo iteration, mostly to do with corner case handing.

This change tries to establish a more uniform idiom for Monte Carlo iteration.  The goals are
  - make basic fitting and the corresponding Monte Carlo iteration use the same code, written in just one place
  - avoid the need to create temporary variables for MC that must have names distinct from those used in basic fitting (because lexical scoping is apparently not Pythonic?)
  - minimize noise from MC output array initialization and filling

For each fitting/Monte Carlo iteration pair, we create a core fitting function.  This function is then vectorized using np.vectorize(). The resulting vectorized function implicitly allocates and fills the MC output arrays and loops over the core function.

This idiom works pretty well for most uses of MC iteration in continuum.py, except for kcorr_and_absmag(), which would require an overhaul of this function to separately compute synth_absmag (the part used in iteration) and all the other stuff, which is only used in basic fitting.  It is somewhat limited by the quirks of np.vectorize(), in particular its inability to mix non-vectorized arguments (such as debug flags) with vectorized arguments specified by signature.  

While there may be other idioms that work even better (which we can explore in future), this PR should already improve the readability and maintainability of MC.  It's somewhere between performance-neutral and a slight improvement.  In the future, this work should be extended to iterations in emlines.py.