### PR TITLE
Further listification of Monte Carlo iteration

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,14 @@ Change Log
 3.1.0 (not released yet)
 ------------------------
 
+* Implement a simplified idiom for Monte Carlo iteration [`PR #191`_].
 * Monte Carlo to estimate model parameters [`PR #189`_].
 * Fix issues with log level retention [`PR #187`_].
 
 .. _`PR #187`: https://github.com/desihub/fastspecfit/pull/187
 .. _`PR #189`: https://github.com/desihub/fastspecfit/pull/189
+.. _`PR #191`: https://github.com/desihub/fastspecfit/pull/191
+
 
 3.0.0 (2024-10-30)
 ------------------

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1526,7 +1526,7 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=50,
         for icam, (ss, ee) in enumerate(data['camerapix']):
             I = ((specflux[ss:ee] != 0.) & (specivar[ss:ee] != 0.) & (smoothcontinuum[ss:ee] != 0.))
             if np.count_nonzero(I) > 3: # require three good pixels to compute the mean
-                smoothstats[icam] = np.mean(1. - smoothcontinuum[ss:ee][I] / specflux[ss:ee][I])
+                smoothstats[icam] = median(smoothcontinuum[ss:ee][I] / specflux[ss:ee][I])
 
     log.debug(f'Deriving the smooth continuum took {time.time()-t0:.2f} seconds.')
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1681,8 +1681,7 @@ def continuum_specfit(data, result, templates, igm, phot, nmonte=50, seed=1,
 
         # Get the variance via Monte Carlo.
         if sedmodel_monte is not None:
-
-            res = [do_kcorr(*args) for args in zip(sedmodel_monte, sedmodel_nolines_monte, [False]*nmonte)]
+            res = [do_kcorr(sm, snm, False) for sm, snm in zip(sedmodel_monte, sedmodel_nolines_monte)]
             (synth_absmag_monte, _, _, _, _, _, lums_monte, cfluxes_monte) = tuple(zip(*res))
 
             synth_absmag_var = np.var(synth_absmag_monte, axis=0)

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1070,26 +1070,6 @@ def continuum_fastphot(redshift, objflam, objflamivar, CTools,
              dn4000_model_monte, _) = \
                  do_fit_monte(tauv_guess_monte, objflam_monte)
 
-            """
-            for imonte in range(nmonte):
-                tauv1, _, coeff1, _ = CTools.fit_stellar_continuum(
-                    templates.flux_nomvdisp[agekeep, :], fit_vdisp=False,
-                    tauv_guess=tauv_guess[imonte], objflam=objflam_monte[imonte, :],
-                    objflamistd=objflamistd, synthphot=True, synthspec=False)
-
-                coeff_monte[imonte, :] = coeff1
-                tauv_monte[imonte] = tauv1
-
-                sedmodel_monte[imonte, :] = CTools.optimizer_saved_contmodel
-                sedmodel_nolines_monte[imonte, :] = CTools.build_stellar_continuum(
-                    templates.flux_nolines_nomvdisp[agekeep, :], coeff1,
-                    tauv=tauv1, vdisp=None, dust_emission=False)
-
-                dn4000_model1, _ = Photometry.get_dn4000(
-                    templates.wave, sedmodel_nolines_monte[imonte, :], rest=True)
-                dn4000_model_monte[imonte] = dn4000_model1
-            """
-
             tauv_var = np.var(tauv_monte)
             dn4000_model_var = np.var(dn4000_model_monte)
             if tauv_var > TINY:
@@ -1353,17 +1333,6 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=50,
                 (tauv_monte, vdisp_monte, _, age_monte, _) = \
                     do_fit_vdisp_monte(specflux_monte)
 
-                """
-                for imonte in range(nmonte):
-                    tauv1, vdisp1, coeff1, _ = CTools.fit_stellar_continuum(
-                        templates.flux_nolines[agekeep, :], fit_vdisp=True,
-                        conv_pre=input_conv_pre_nolines, specflux=specflux_monte[imonte, :],
-                        specistd=specistd*fitmask, dust_emission=False, synthspec=True)
-                    tauv_monte[imonte] = tauv1
-                    vdisp_monte[imonte] = vdisp1
-                    age_monte[imonte] = coeff1.dot(templates.info['age']) / np.sum(coeff1) / 1e9 # [Gyr]
-                """
-
                 tauv_sigma = np.std(tauv_monte)
                 age_sigma = np.std(age_monte)
                 vdisp_sigma = np.std(vdisp_monte)
@@ -1525,31 +1494,6 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=50,
          sedmodel_monte, sedmodel_nolines_monte,
          desimodel_nolines_monte, dn4000_model_monte, _) = \
              do_fit_full_monte(tauv_guess, objflam_monte, specflux_monte)
-
-        """
-        for imonte in range(nmonte):
-            tauv1, _, coeff1, _ = CTools.fit_stellar_continuum(
-                input_templateflux, fit_vdisp=False, conv_pre=None,
-                tauv_guess=tauv_guess[imonte],
-                objflam=objflam_monte[imonte, :], objflamistd=objflamistd,
-                specflux=specflux_monte[imonte, :]*median_apercorr,
-                specistd=specistd/median_apercorr,
-                synthphot=True, synthspec=True)
-
-            coeff_monte[imonte, :] = coeff1
-            tauv_monte[imonte] = tauv1
-
-            sedmodel_monte[imonte, :] = CTools.optimizer_saved_contmodel.copy() # copy needed?
-            sedmodel_nolines_monte[imonte, :] = CTools.build_stellar_continuum(
-                input_templateflux_nolines, coeff1, tauv=tauv1,
-                vdisp=None, conv_pre=None, dust_emission=False)
-            desimodel_nolines_monte[imonte, :] = CTools.continuum_to_spectroscopy(
-                sedmodel_nolines_monte[imonte, :])
-
-            dn4000_model1, _ = Photometry.get_dn4000(
-                templates.wave, sedmodel_nolines_monte[imonte, :], rest=True)
-            dn4000_model_monte[imonte] = dn4000_model1
-        """
 
         tauv_var = np.var(tauv_monte)
         dn4000_model_var = np.var(dn4000_model_monte)

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1750,7 +1750,7 @@ def continuum_specfit(data, result, templates, igm, phot,
             else:
                 var_msg = ''
             msg.append(f'{label}={val:.2f}{var_msg}{units}')
-        log.info(', '.join(msg))
+        log.info(' '.join(msg))
 
     log.debug(f'Continuum-fitting took {time.time()-tall:.2f} seconds.')
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -23,7 +23,7 @@ class ContinuumTools(object):
     def __init__(self, data, templates, phot, igm, tauv_guess=0.1,
                  vdisp_guess=250., tauv_bounds=(0., 2.),
                  vdisp_bounds=(75., 500.), vdisp_nbin=5,
-                 fluxnorm=1e-17, massnorm=1e10, fastphot=False,
+                 fluxnorm=1e17, massnorm=1e10, fastphot=False,
                  constrain_age=False):
 
         self.phot = phot

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1639,25 +1639,25 @@ def continuum_specfit(data, result, templates, igm, phot, nmonte=50, seed=1,
     if not np.all(coeff == 0.):
 
         def do_kcorr(sedmodel, sedmodel_nolines, debug_plots=False):
-            synth_absmag, synth_maggies_rest, synth_bestmaggies = phot.synth_absmag(
-                redshift, data['dmodulus'], data['photsys'], CTools.ztemplatewave,
+            synth_absmag, synth_maggies_rest = phot.synth_absmag(
+                redshift, data['dmodulus'], CTools.ztemplatewave,
                 sedmodel)
 
-            kcorr, absmag, ivarabsmag = phot.kcorr_and_absmag(
+            kcorr, absmag, ivarabsmag, synth_bestmaggies = phot.kcorr_and_absmag(
                 data['photometry']['nanomaggies'].value,
                 data['photometry']['nanomaggies_ivar'].value,
                 redshift, data['dmodulus'], data['photsys'],
                 CTools.ztemplatewave, sedmodel, synth_absmag,
-                synth_maggies_rest, synth_bestmaggies)
+                synth_maggies_rest)
 
             lums, cfluxes = CTools.continuum_fluxes(
                 sedmodel_nolines, uniqueid=data['uniqueid'],
                 debug_plots=debug_plots)
 
-            return (synth_absmag, synth_maggies_rest, synth_bestmaggies,
-                    kcorr, absmag, ivarabsmag, lums, cfluxes)
+            return (synth_absmag, synth_maggies_rest, kcorr, absmag,
+                    ivarabsmag, synth_bestmaggies, lums, cfluxes)
 
-        (synth_absmag, synth_maggies_rest, synth_bestmaggies, kcorr, absmag, ivarabsmag, lums, cfluxes) = \
+        (synth_absmag, synth_maggies_rest, kcorr, absmag, ivarabsmag, synth_bestmaggies, lums, cfluxes) = \
             do_kcorr(sedmodel, sedmodel_nolines, debug_plots=debug_plots)
 
         for iband, (band, shift) in enumerate(zip(phot.absmag_bands, phot.band_shift)):
@@ -1683,7 +1683,7 @@ def continuum_specfit(data, result, templates, igm, phot, nmonte=50, seed=1,
         if sedmodel_monte is not None:
 
             res = [do_kcorr(*args) for args in zip(sedmodel_monte, sedmodel_nolines_monte, [False]*nmonte)]
-            (synth_absmag_monte, _, _, _, absmag_monte, _, lums_monte, cfluxes_monte) = tuple(zip(*res))
+            (synth_absmag_monte, _, _, _, _, _, lums_monte, cfluxes_monte) = tuple(zip(*res))
 
             synth_absmag_var = np.var(synth_absmag_monte, axis=0)
             for band, shift, var in zip(phot.absmag_bands, phot.band_shift, synth_absmag_var):

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1000,8 +1000,8 @@ def can_compute_vdisp(redshift, specwave, min_restrange=(3800., 4800.), fit_rest
     return compute_vdisp, (s, e)
 
 
-def continuum_fastphot(redshift, objflam, objflamivar, CTools,
-                       uniqueid=0, nmonte=50, rng=None, debug_plots=False):
+def continuum_fastphot(redshift, objflam, objflamivar, CTools, uniqueid=0,
+                       nmonte=50, rng=None, debug_plots=False):
     """Model the broadband photometry.
 
     """
@@ -1537,9 +1537,10 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=50,
             sedmodel_nolines_monte, continuummodel_monte)
 
 
-def continuum_specfit(data, result, templates, igm, phot, nmonte=50, seed=1,
-                      constrain_age=False, no_smooth_continuum=False,
-                      fitstack=False, fastphot=False, debug_plots=False):
+def continuum_specfit(data, result, templates, igm, phot,
+                      nmonte=50, seed=1, constrain_age=False,
+                      no_smooth_continuum=False, fitstack=False,
+                      fastphot=False, debug_plots=False):
     """Fit the non-negative stellar continuum of a single spectrum.
 
     Parameters
@@ -1588,7 +1589,11 @@ def continuum_specfit(data, result, templates, igm, phot, nmonte=50, seed=1,
                             vdisp_guess=templates.vdisp_nominal,
                             fluxnorm=FLUXNORM, constrain_age=constrain_age)
 
-    rng = np.random.default_rng(seed=seed)
+    # Instantiate the random-number generator.
+    if nmonte > 0:
+        rng = np.random.default_rng(seed=seed)
+    else:
+        rng = None
 
     if fastphot:
         # Photometry-only fitting.
@@ -1619,6 +1624,7 @@ def continuum_specfit(data, result, templates, igm, phot, nmonte=50, seed=1,
             msg.append(f'{cam}={100.*corr:.3f}%')
         log.info(' '.join(msg))
 
+    result['SEED'] = seed
     result['Z'] = redshift
     result['COEFF'][CTools.agekeep] = coeff
     result['RCHI2_PHOT'] = rchi2_phot

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1570,11 +1570,10 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=50,
 
     if desimodel_nolines_monte is not None:
         continuummodel_monte = []
-        for imonte in range(nmonte):
-            continuummodel_monte_one = []
-            for campix in data['camerapix']:
-                continuummodel_monte_one.append(desimodel_nolines_monte[imonte, campix[0]:campix[1]])
-            continuummodel_monte.append(continuummodel_monte_one)
+        for icam, campix in enumerate(data['camerapix']):
+            ss, ee = campix
+            models = np.vstack([desimodel_nolines_monte[imonte, ss:ee] for imonte in range(nmonte)])
+            continuummodel_monte.append(models)
 
     return (coeff, coeff_monte, rchi2_cont, rchi2_phot, median_apercorr, apercorrs,
             tauv, tauv_ivar, vdisp, vdisp_ivar, dn4000, dn4000_ivar, dn4000_model,
@@ -1801,11 +1800,6 @@ def continuum_specfit(data, result, templates, igm, phot,
         continuummodel = [cm / median_apercorr for cm in continuummodel]
         smoothcontinuum = [sc / median_apercorr for sc in smoothcontinuum]
         if continuummodel_monte is not None:
-            continuummodel_monte_renorm = []
-            for imonte in range(nmonte):
-                continuummodel_one = continuummodel_monte[imonte]
-                continuummodel_one = [cm / median_apercorr for cm in continuummodel_one]
-                continuummodel_monte_renorm.append(continuummodel_one)
-            continuummodel_monte = continuummodel_monte_renorm
+            continuummodel_monte = [ cm / median_apercorr for cm in continuummodel_monte ]
 
         return continuummodel, smoothcontinuum, continuummodel_monte, specflux_monte

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1533,9 +1533,7 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
     oemlineivar = np.hstack(data['ivar'])
     specflux = np.hstack(data['flux'])
 
-    continuummodelflux = np.hstack(continuummodel)
-    smoothcontinuummodelflux = np.hstack(smooth_continuum)
-    emlineflux = specflux - continuummodelflux - smoothcontinuummodelflux
+    emlineflux = specflux - continuummodel - smooth_continuum
 
     emlineivar = np.copy(oemlineivar)
     _, emlinegood = ivar2var(emlineivar, clip=1e-3)
@@ -1553,13 +1551,12 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
     if specflux_monte is not None:
         nmonte, _ = specflux_monte.shape
         if continuummodel_monte is not None:
-            continuummodelflux_monte = np.hstack(continuummodel_monte)
 
-            emlineflux_monte = (specflux_monte - continuummodelflux_monte - \
-                                smoothcontinuummodelflux[np.newaxis, :])
+            emlineflux_monte = (specflux_monte - continuummodel_monte - \
+                                smooth_continuum[np.newaxis, :])
         else:
-            emlineflux_monte = (specflux_monte - continuummodelflux[np.newaxis, :] - \
-                                smoothcontinuummodelflux[np.newaxis, :])
+            emlineflux_monte = (specflux_monte - continuummodel[np.newaxis, :] - \
+                                smooth_continuum[np.newaxis, :])
 
     # determine which lines are in range of the camera
     EMFit.compute_inrange_lines(redshift, wavelims=(np.min(emlinewave),
@@ -1657,14 +1654,14 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
     result['DELTA_LINENDOF'] = delta_linendof_balmer  # ndof_nobroad - ndof_broad
 
     # full-fit reduced chi2
-    rchi2 = np.sum(oemlineivar * (specflux - (continuummodelflux + smoothcontinuummodelflux + emmodel))**2)
+    rchi2 = np.sum(oemlineivar * (specflux - (continuummodel + smooth_continuum + emmodel))**2)
     rchi2 /= np.sum(oemlineivar > 0)  # dof??
     result['RCHI2'] = rchi2
 
 
     # Build the output model spectra.
     modelwave, modelcontinuum, modelemspectrum, modelspectra = build_coadded_models(
-        data, emlinewave, emmodel, continuummodelflux, smoothcontinuummodelflux)
+        data, emlinewave, emmodel, continuummodel, smooth_continuum)
 
     # Finally, optionally synthesize photometry (excluding the
     # smoothcontinuum!) and measure Dn(4000) from the line-free spectrum.

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1552,9 +1552,8 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
     if specflux_monte is not None:
         nmonte, _ = specflux_monte.shape
         if continuummodel_monte is not None:
-            continuummodelflux_monte = np.zeros((nmonte, len(continuummodelflux)))
-            for imonte in range(nmonte):
-                continuummodelflux_monte[imonte, :] = np.hstack(continuummodel_monte[imonte])
+            continuummodelflux_monte = np.hstack(continuummodel_monte)
+
             emlineflux_monte = (specflux_monte - continuummodelflux_monte - \
                                 smoothcontinuummodelflux[np.newaxis, :])
         else:

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -608,7 +608,7 @@ class EMFitTools(object):
                 bounds[nLineFree+nPatches:]                   = continuum_patches['intercept_bounds']
 
             # least_squares wants two arrays, not a 2D array
-            bounds = ( bounds[:,0], bounds[:,1] )
+            bounds = ( bounds[:, 0], bounds[:, 1] )
 
             fit_info = least_squares(objective, initial_guesses, jac=jac, args=(),
                                      max_nfev=5000, xtol=1e-10, ftol=1e-5, #x_scale='jac' gtol=1e-10,
@@ -906,7 +906,7 @@ class EMFitTools(object):
 
             # Are the pixels based on the original inverse spectrum fully
             # masked? If so, set everything to zero and move onto the next line.
-            if np.sum(oemlineivar_s[line_s:line_e] == 0.) > 0.3 * (line_e - line_s): # use original ivar
+            if (line_s == line_e) or (np.sum(oemlineivar_s[line_s:line_e] == 0.) > 0.3 * (line_e - line_s)):
                 obsamps[line_amp] = 0.
                 values[line_amp]    = 0.
                 values[line_vshift] = 0.

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1096,7 +1096,7 @@ class EMFitTools(object):
 
                 # FIXME: should we use the value of linesigma returned from this
                 # fcn here (it replaces a zero sigma with a default value)?
-                _, _, linesigma_ang_window, _ = preprocess_linesigma(
+                linesigma, _, linesigma_ang_window, _ = preprocess_linesigma(
                     linesigma, linezwave, isbroad, isbalmer)
 
                 ss, ee = get_boundaries(emlinewave_s,
@@ -1723,5 +1723,6 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
                 log.info(f'Wrote {pngfile}')
 
     log.debug(f'Emission-line fitting took {time.time()-tall:.2f} seconds.')
-
+    for name in result.value.dtype.names:
+        print(name, result[name])
     return spectra_out

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1064,6 +1064,7 @@ class EMFitTools(object):
                     for imonte in range(nmonte):
                         _linez = redshift + values_monte[imonte, line_vshift] / C_LIGHT
                         _linezwave = restwave * (1. + _linez)
+                        _linesigma = values_monte[imonte, line_sigma] # [km/s]
                         _, _, _linesigma_ang_window, _ = \
                             _preprocess_linesigma(_linesigma, _linezwave, isbroad, isbalmer)
                         _borderindx = _get_continuum_pixels(emlinewave_s, _linezwave, _linesigma_ang_window)

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -855,7 +855,7 @@ class EMFitTools(object):
 
         if results_monte is not None:
             values_monte, obsamps_monte, emlineflux_monte, specflux_nolines_monte = results_monte
-            nmonte, _ = values_monte.shape
+            nmonte = len(values_monte)
 
             values_var = np.var(values_monte, axis=0)
             obsamps_var = np.var(obsamps_monte, axis=0)
@@ -954,8 +954,8 @@ class EMFitTools(object):
                     #    result[f'{linename}_MODELAMP_IVAR'] = 1. / modelamp_var
 
                     # Monte Carlo to get the uncertainties
-                    boxflux_monte = np.zeros(nmonte)
-                    use_gausscorr_monte = np.ones(nmonte)
+                    boxflux_monte = np.empty(nmonte)
+                    use_gausscorr_monte = np.empty(nmonte)
                     patchindx_monte = []
                     for imonte in range(nmonte):
                         _linez = redshift + values_monte[imonte, line_vshift] / C_LIGHT
@@ -1011,7 +1011,7 @@ class EMFitTools(object):
 
                     # get the flux uncertainty via Monte Carlo
                     if results_monte is not None:
-                        flux_monte = np.zeros(nmonte)
+                        flux_monte = np.empty(nmonte)
                         for imonte in range(nmonte):
                             (_s, _e), flux_perpixel1 = line_fluxes_monte[imonte].getLine(iline)
                             # can be zero if the amplitude is very tiny
@@ -1060,7 +1060,7 @@ class EMFitTools(object):
                 result[f'{linename}_CONT'] = cont
 
                 if results_monte is not None:
-                    cont_monte = np.zeros(nmonte)
+                    cont_monte = np.empty(nmonte)
                     for imonte in range(nmonte):
                         _linez = redshift + values_monte[imonte, line_vshift] / C_LIGHT
                         _linezwave = restwave * (1. + _linez)
@@ -1160,9 +1160,9 @@ class EMFitTools(object):
 
             if results_monte is not None:
                 # Monte Carlo to get the uncertainties
-                moment1_monte = np.zeros(nmonte)
-                moment2_monte = np.zeros(nmonte)
-                moment3_monte = np.zeros(nmonte)
+                moment1_monte = np.empty(nmonte)
+                moment2_monte = np.empty(nmonte)
+                moment3_monte = np.empty(nmonte)
                 for imonte in range(nmonte):
                     _linezwave = restwave * (1. + redshift + values_monte[imonte, line_vshift] / C_LIGHT)
                     _linesigma = values_monte[imonte, line_sigma] # [km/s]
@@ -1549,7 +1549,7 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
     # Monte Carlo spectrum carried over from continuum-fitting. Assume that the
     # smooth continuum model is the same...
     if specflux_monte is not None:
-        nmonte, _ = specflux_monte.shape
+        nmonte = len(specflux_monte)
         if continuummodel_monte is not None:
 
             emlineflux_monte = (specflux_monte - continuummodel_monte - \
@@ -1621,9 +1621,9 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
         else:
             linemodel_monte = linemodel_nobroad
 
-        values_monte = np.zeros((nmonte, len(finalfit)))
-        obsamps_monte = np.zeros((nmonte, len(finalfit.meta['obsamp'])))
-        finalmodel_monte = np.zeros((nmonte, len(finalmodel)))
+        values_monte = np.empty((nmonte, len(finalfit)))
+        obsamps_monte = np.empty((nmonte, len(finalfit.meta['obsamp'])))
+        finalmodel_monte = np.empty((nmonte, len(finalmodel)))
         for imonte in range(nmonte):
             finalfit1, finalmodel1, _ = linefit(
                 EMFit, linemodel_monte, initial_guesses, param_bounds,

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1723,6 +1723,5 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
                 log.info(f'Wrote {pngfile}')
 
     log.debug(f'Emission-line fitting took {time.time()-tall:.2f} seconds.')
-    for n in result.value.dtype.names:
-        print(n, result[n])
+
     return spectra_out

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -14,7 +14,7 @@ from astropy.table import Table
 
 from fastspecfit.logger import log
 from fastspecfit.photometry import Photometry
-from fastspecfit.util import C_LIGHT, TINY, FLUXNORM, var2ivar
+from fastspecfit.util import C_LIGHT, TINY, SQTINY, FLUXNORM, var2ivar
 from fastspecfit.emline_fit import (EMLine_Objective,
     EMLine_MultiLines, EMLine_find_peak_amplitudes,
     EMLine_build_model, EMLine_ParamsMapping)
@@ -872,7 +872,7 @@ class EMFitTools(object):
                 clipflux = specflux_nolines_s[borderindx]
 
             cont = np.mean(clipflux)
-            return cont
+            return cont, clipflux
 
 
         def get_moments(values, emlineflux_s, isbroad, isbalmer):
@@ -1075,11 +1075,12 @@ class EMFitTools(object):
             # next, get the continuum level and the EW
             borderindx = get_continuum_pixels(emlinewave_s, linezwave, linesigma_ang_window)
             if len(borderindx) >= nminpix: # require at least XX pixels to get the continuum level
-                cont = get_cont(values, specflux_nolines_s)
+                cont, clipflux = get_cont(values, specflux_nolines_s)
                 result[f'{linename}_CONT'] = cont # * u.erg/(u.second*u.cm**2*u.Angstrom)
 
                 if results_monte is not None:
-                    cont_monte = [get_cont(*args) for args in zip(values_monte, specflux_nolines_monte_s)]
+                    res = [get_cont(*args) for args in zip(values_monte, specflux_nolines_monte_s)]
+                    cont_monte, _ = tuple(zip(*res))
 
                     # used in the EW calculation below
                     cont_monte = np.array(cont_monte)

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -266,6 +266,8 @@ def fastspec(fastphot=False, fitstack=False, args=None, comm=None, verbose=False
                       inputz=input_redshifts is not None,
                       nmonte=args.nmonte, seed=args.seed,
                       inputseeds=input_seeds is not None,
+                      uncertainty_floor=args.uncertainty_floor,
+                      minsnr_balmer_broad=args.minsnr_balmer_broad,
                       ignore_photometry=args.ignore_photometry,
                       broadlinefit=args.broadlinefit, constrain_age=args.constrain_age,
                       use_quasarnet=args.use_quasarnet,
@@ -342,7 +344,7 @@ def parse(options=None):
     parser.add_argument('--fphotofile', type=str, default=None, help='Photometric information file.')
     parser.add_argument('--emlinesfile', type=str, default=None, help='Emission line parameter file.')
     parser.add_argument('--specproddir', type=str, default=None, help='Optional directory name for the spectroscopic production.')
-    parser.add_argument('--uncertainty-floor', type=float, default=0.01, help='Minimum fractional uncertainty to add in quadrature to the formal inverse variance spectrum..')
+    parser.add_argument('--uncertainty-floor', type=float, default=0.01, help='Minimum fractional uncertainty to add in quadrature to the formal inverse variance spectrum.')
     parser.add_argument('--minsnr-balmer-broad', type=float, default=2.5, help='Minimum broad Balmer S/N to force broad+narrow-line model.')
     parser.add_argument('--debug-plots', action='store_true', help='Generate a variety of debugging plots (written to $PWD).')
     parser.add_argument('--verbose', action='store_true', help='Be verbose (for debugging purposes).')

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -203,6 +203,14 @@ def fastspec(fastphot=False, fitstack=False, args=None, comm=None, verbose=False
         cameras=cameras, fastphot=fastphot,
         fitstack=fitstack)
 
+    # If using Monte Carlo, generate the random seed(s).
+    if args.nmonte > 0:
+        rng = np.random.default_rng(seed=args.seed)
+        seeds = rng.integers(2**32, size=ntargets, dtype=np.int64)
+        print(seeds)
+    else:
+        seeds = [1] * ntargets
+
     # Fit in parallel
     t0 = time.time()
     fitargs = [{
@@ -219,7 +227,7 @@ def fastspec(fastphot=False, fitstack=False, args=None, comm=None, verbose=False
         'uncertainty_floor':   args.uncertainty_floor,
         'minsnr_balmer_broad': args.minsnr_balmer_broad,
         'nmonte':              args.nmonte,
-        'seed':                args.seed,
+        'seed':                seeds[iobj],
     } for iobj in range(len(meta))]
 
     _out = mp_pool.starmap(fastspec_one, fitargs)

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -264,6 +264,8 @@ def fastspec(fastphot=False, fitstack=False, args=None, comm=None, verbose=False
                       template_file=sc_data.templates.file,
                       emlinesfile=sc_data.emlines.file, fastphot=fastphot,
                       inputz=input_redshifts is not None,
+                      nmonte=args.nmonte, seed=args.seed,
+                      inputseeds=input_seeds is not None,
                       ignore_photometry=args.ignore_photometry,
                       broadlinefit=args.broadlinefit, constrain_age=args.constrain_age,
                       use_quasarnet=args.use_quasarnet,

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1764,6 +1764,7 @@ def get_output_dtype(specprod, phot, linetable, ncoeff,
             out_units[name] = unit
 
     add_field('Z', dtype='f8') # redshift
+    add_field('SEED', dtype=np.int64)
     add_field('COEFF', shape=(ncoeff,), dtype='f4')
 
     if not fastphot:

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1506,7 +1506,8 @@ def read_fastspecfit(fastfitfile, rows=None, columns=None, read_models=False):
 def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
                       coadd_type=None, fphotofile=None, template_file=None,
                       emlinesfile=None, fastphot=False, inputz=False,
-                      no_smooth_continuum=False, ignore_photometry=False, broadlinefit=True,
+                      inputseeds=None, nmonte=50, seed=1, no_smooth_continuum=False,
+                      ignore_photometry=False, broadlinefit=True,
                       use_quasarnet=True, constrain_age=False, verbose=True):
     """Write out.
 
@@ -1547,6 +1548,9 @@ def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
     if coadd_type:
         primhdr.append(('COADDTYP', (coadd_type, 'spectral coadd type')))
     primhdr.append(('INPUTZ', (inputz is True, 'input redshifts provided')))
+    primhdr.append(('INPUTS', (inputseeds is True, 'input seeds provided')))
+    primhdr.append(('NMONTE', (nmonte, 'number of Monte Carlo realizations')))
+    primhdr.append(('SEED', (seed, 'random seed for Monte Carlo reproducibility')))
     primhdr.append(('NOSCORR', (no_smooth_continuum is True, 'no smooth continuum correction')))
     primhdr.append(('NOPHOTO', (ignore_photometry is True, 'no fitting to photometry')))
     primhdr.append(('BRDLFIT', (broadlinefit is True, 'carry out broad-line fitting')))

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1506,9 +1506,11 @@ def read_fastspecfit(fastfitfile, rows=None, columns=None, read_models=False):
 def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
                       coadd_type=None, fphotofile=None, template_file=None,
                       emlinesfile=None, fastphot=False, inputz=False,
-                      inputseeds=None, nmonte=50, seed=1, no_smooth_continuum=False,
-                      ignore_photometry=False, broadlinefit=True,
-                      use_quasarnet=True, constrain_age=False, verbose=True):
+                      inputseeds=None, nmonte=50, seed=1,
+                      uncertainty_floor=0.01, minsnr_balmer_broad=2.5,
+                      no_smooth_continuum=False, ignore_photometry=False,
+                      broadlinefit=True, use_quasarnet=True, constrain_age=False,
+                      verbose=True):
     """Write out.
 
     """
@@ -1549,13 +1551,15 @@ def write_fastspecfit(out, meta, modelspectra=None, outfile=None, specprod=None,
         primhdr.append(('COADDTYP', (coadd_type, 'spectral coadd type')))
     primhdr.append(('INPUTZ', (inputz is True, 'input redshifts provided')))
     primhdr.append(('INPUTS', (inputseeds is True, 'input seeds provided')))
-    primhdr.append(('NMONTE', (nmonte, 'number of Monte Carlo realizations')))
-    primhdr.append(('SEED', (seed, 'random seed for Monte Carlo reproducibility')))
     primhdr.append(('NOSCORR', (no_smooth_continuum is True, 'no smooth continuum correction')))
     primhdr.append(('NOPHOTO', (ignore_photometry is True, 'no fitting to photometry')))
     primhdr.append(('BRDLFIT', (broadlinefit is True, 'carry out broad-line fitting')))
     primhdr.append(('CONSAGE', (constrain_age is True, 'constrain SPS ages')))
     primhdr.append(('USEQNET', (use_quasarnet is True, 'use QuasarNet redshifts')))
+    primhdr.append(('NMONTE', (nmonte, 'number of Monte Carlo realizations')))
+    primhdr.append(('SEED', (seed, 'random seed for Monte Carlo reproducibility')))
+    primhdr.append(('UFLOOR', (uncertainty_floor, 'fractional uncertainty floor')))
+    primhdr.append(('SNRBBALM', (minsnr_balmer_broad, 'minimum broad Balmer S/N')))
 
     primhdr = fitsheader(primhdr)
     add_dependencies(primhdr, module_names=possible_dependencies+['fastspecfit'],

--- a/py/fastspecfit/photometry.py
+++ b/py/fastspecfit/photometry.py
@@ -151,7 +151,7 @@ class Photometry(object):
             self.bands_to_fit *= [False]
 
 
-    def synth_absmag(self, redshift, dmod, photsys, zmodelwave, zmodelflux):
+    def synth_absmag(self, redshift, dmod, zmodelwave, zmodelflux):
         """Synthesize absolute magnitudes from the best-fitting SED.
 
         Parameters
@@ -160,8 +160,6 @@ class Photometry(object):
            Galaxy or QSO redshift.
         dmod : :class:`float`
            Distance modulus corresponding to `redshift`.
-        photsys : :class:`str`
-           Photometric system.
         zmodelwave : `numpy.ndarray`
            Observed-frame (redshifted) model wavelength array.
         zmodelflux : `numpy.ndarray`
@@ -173,8 +171,6 @@ class Photometry(object):
            Absolute magnitudes based on synthesized photometry.
         synth_maggies_rest : `numpy.ndarray`
            Synthesized rest-frame photometry.
-        synth_maggies_obs : `numpy.ndarray`
-           Synthesized observed-frame photometry.
 
         """
         if redshift <= 0.0:
@@ -182,14 +178,7 @@ class Photometry(object):
             nabs = len(self.absmag_filters)
             synth_absmag = np.zeros(nabs, dtype='f8')
             synth_maggies_rest = np.zeros(nabs, dtype='f8')
-            synth_maggies_obs = np.zeros(len(maggies))
-            return synth_absmag, synth_maggies_rest, synth_maggies_obs
-
-        # Input bandpasses, observed frame; maggies and synth_maggies_obs
-        # should be very close.
-        filters_obs = self.filters[photsys]
-        synth_maggies_obs = self.get_ab_maggies_unchecked(
-            filters_obs, zmodelflux / FLUXNORM, zmodelwave)
+            return synth_absmag, synth_maggies_rest
 
         # Multiply by (1+z) to convert the best-fitting model to the "rest frame".
         synth_maggies_rest = self.get_ab_maggies_unchecked(
@@ -197,12 +186,12 @@ class Photometry(object):
             zmodelwave / (1. + redshift))
         synth_absmag = -2.5 * np.log10(synth_maggies_rest) - dmod
 
-        return synth_absmag, synth_maggies_rest, synth_maggies_obs
+        return synth_absmag, synth_maggies_rest
 
 
     def kcorr_and_absmag(self, nanomaggies, ivar_nanomaggies, redshift, dmod,
                          photsys, zmodelwave, zmodelflux, synth_absmag,
-                         synth_maggies_rest, synth_maggies_obs, snrmin=2.):
+                         synth_maggies_rest, snrmin=2.):
         """Compute K-corrected rest-frame photometry.
 
         Parameters
@@ -223,8 +212,6 @@ class Photometry(object):
            Absolute magnitudes based on synthesized photometry.
         synth_maggies_rest : `numpy.ndarray`
            Synthesized rest-frame photometry.
-        synth_maggies_obs : `numpy.ndarray`
-           Synthesized observed-frame photometry.
         snrmin : :class:`float`, defaults to 2.
            Minimum signal-to-noise ratio in the input photometry (`maggies`) in
            order for that bandpass to be used to compute a K-correction.
@@ -238,6 +225,8 @@ class Photometry(object):
            provided) for each bandpass in `absmag_filters`.
         ivarabsmag : `numpy.ndarray`
            Inverse variance corresponding to `absmag`.
+        synth_maggies_obs : `numpy.ndarray`
+           Synthesized observed-frame photometry.
 
         Notes
         -----
@@ -256,14 +245,21 @@ class Photometry(object):
             kcorr = np.zeros(nabs, dtype='f8')
             absmag = np.zeros(nabs, dtype='f8')
             ivarabsmag = np.zeros(nabs, dtype='f8')
-            return kcorr, absmag, ivarabsmag
+            synth_maggies_obs = np.zeros(len(nanomaggies))
+            return kcorr, absmag, ivarabsmag, synth_maggies_obs
 
         maggies = nanomaggies * 1e-9
         ivarmaggies = (ivar_nanomaggies / 1e-9**2) * self.bands_to_fit
 
+        # Input bandpasses, observed frame; maggies and synth_maggies_obs
+        # should be very close.
         filters_obs = self.filters[photsys]
         lambda_obs = filters_obs.effective_wavelengths.value
         lambda_out = self.filters_out.effective_wavelengths.value
+
+        # Synthesize observed-frame photometry (should be close to maggies).
+        synth_maggies_obs = self.get_ab_maggies_unchecked(
+            filters_obs, zmodelflux / FLUXNORM, zmodelwave)
 
         # K-correct from the nearest "good" bandpass (to minimizes the K-correction)
         oband = np.empty(nabs, dtype=np.int16)
@@ -286,7 +282,7 @@ class Photometry(object):
             absmag[I] = -2.5 * np.log10(maggies[oband[I]]) - dmod - kcorr[I]
             ivarabsmag[I] = maggies[oband[I]]**2 * ivarmaggies[oband[I]] * C
 
-        return kcorr, absmag, ivarabsmag
+        return kcorr, absmag, ivarabsmag, synth_maggies_obs
 
 
     @staticmethod

--- a/py/fastspecfit/util.py
+++ b/py/fastspecfit/util.py
@@ -230,6 +230,26 @@ def mwdust_transmission(ebv, filtername):
     return transmission
 
 
+def var2ivar(var, sigma=False):
+    """Simple function to safely turn a (scalar, for now) variance into an
+    inverse variance.
+
+    if sigma=True then assume that `var` is a standard deviation
+
+    """
+    if sigma:
+        if var > SQTINY:
+            ivar = 1. / var**2
+        else:
+            ivar = 0.
+    else:
+        if var > TINY:
+            ivar = 1. / var
+        else:
+            ivar = 0.
+    return ivar
+
+
 def ivar2var(ivar, clip=1e-3, sigma=False, allmasked_ok=False):
     """Safely convert an inverse variance to a variance. Note that we clip at 1e-3
     by default, not zero.


### PR DESCRIPTION
Extend the use of the new list idiom for Monte Carlo to the operations in emlines, and to kcorr_and_absmag.  We have *not* yet merged the base operations with their Monte Carlo versions, as in our previous PR, because there are some issues with divergent flow control that need to be reviewed first.  But this change does simplify several uses of Monte Carlo and avoids having to rename a bunch of local variables in duplicated code.  The merge operations desired in the future are marked with FIXME comments.

Speaking of renaming variables, use an abbreviated idiom for the actual list comprehensions that avoids retyping the names of the variables used in each Monte Carlo iteration, since typos in these names can lead to hard-to-find bugs.  Advice: always use *new* names for the items being iterated over when passing them to the Monte Carlo function.

NB: this change incidentally fixes a bug in Monte Carlo computation of moments.