### PR TITLE
update [OIII] and [NII] doublet ratios; update color scheme

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,12 +70,8 @@ jobs:
               run: pytest --cov
             - name: Coveralls
               env:
+                COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                COVERALLS_PARALLEL: true
-                COVERALLS_FLAG_NAME: "${{ matrix.os }},${{ matrix.python-version }},${{ matrix.package_level }}"
-                COVERALLS_SERVICE_NAME: github
-                COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
-                COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
               run: coveralls
 
     docs:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ Change Log
 3.1.0 (not released yet)
 ------------------------
 
+* Update theoretical [NII] 6548,84 and [OIII] 4959,5007 doublet ratios [`PR #195`_].
 * Additional cleanups and speedups to the new Monte Carlo code [`PR #194`_].
 * Implement a simplified idiom for Monte Carlo iteration [`PR #193`_].
 * Merge two multiprocessing loops into one [`PR #192`_].
@@ -16,6 +17,7 @@ Change Log
 .. _`PR #192`: https://github.com/desihub/fastspecfit/pull/192
 .. _`PR #193`: https://github.com/desihub/fastspecfit/pull/193
 .. _`PR #194`: https://github.com/desihub/fastspecfit/pull/194
+.. _`PR #195`: https://github.com/desihub/fastspecfit/pull/195
 
 3.0.0 (2024-10-30)
 ------------------

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -892,6 +892,7 @@ class EMFitTools(object):
                 """ Get all the computed fluxes associated with the current line.  Return the
                 fluxes along with some intermediate quantities if return_extras is True.  (The
                 extras are needed only if we are not using this function in Monte Carlo iteration.)
+
                 """
                 linez = redshift + values[line_vshift] / C_LIGHT
                 linezwave = restwave * (1. + linez)
@@ -937,16 +938,16 @@ class EMFitTools(object):
                                 clipflux = specflux_nolines_s[borderindx]
                             cont = np.mean(clipflux)
 
-                    # needed by all code, including Monte Carlo
-                    res = (boxflux, flux, cont)
+                # needed by all code, including Monte Carlo
+                res = (boxflux, flux, cont)
 
-                    if return_extras:
-                        # needed by non-Monte Carlo code
-                        extras = (linez, linesigma, linesigma_ang,
-                                  patchindx, flux_gauss_ivar, clipflux)
-                        return (res, extras)
-                    else:
-                        return res
+                if return_extras:
+                    # needed by non-Monte Carlo code
+                    extras = (linez, linesigma, linesigma_ang, patchindx,
+                              flux_gauss_ivar, clipflux)
+                    return (res, extras)
+                else:
+                    return res
 
 
             # zero out out-of-range lines
@@ -957,8 +958,10 @@ class EMFitTools(object):
                 values[line_sigma] = 0.
                 continue
 
-            (boxflux, flux, cont), extras = \
-                get_fluxes(values, emlineflux_s, line_profiles, specflux_nolines_s, return_extras=True)
+            (boxflux, flux, cont), extras = get_fluxes(
+                values, emlineflux_s, line_profiles,
+                specflux_nolines_s, return_extras=True)
+
             result[f'{linename}_BOXFLUX'] = boxflux # * u.erg/(u.second*u.cm**2)
             result[f'{linename}_FLUX'] = flux
             result[f'{linename}_CONT'] = cont # * u.erg/(u.second*u.cm**2*u.Angstrom)
@@ -1725,6 +1728,9 @@ def emline_specfit(data, result, continuummodel, smooth_continuum,
                 log.info(f'Wrote {pngfile}')
 
     log.debug(f'Emission-line fitting took {time.time()-tall:.2f} seconds.')
-    for name in result.value.dtype.names:
-        print(name, result[name])
+
+    if debug_plots:
+        for name in result.value.dtype.names:
+            print(name, result[name])
+
     return spectra_out

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -279,14 +279,16 @@ class EMFitTools(object):
                         """
                         [O3] (4-->2): airwave: 4958.9097 vacwave: 4960.2937 emissivity: 1.172e-21
                         [O3] (4-->3): airwave: 5006.8417 vacwave: 5008.2383 emissivity: 3.497e-21
+                        https://ui.adsabs.harvard.edu/abs/2007AIPC..895..313D/abstract
                         """
-                        tie_line(tying_info, line_params, 'oiii_5007', amp_factor = 1.0 / 2.9839)
+                        tie_line(tying_info, line_params, 'oiii_5007', amp_factor = 1.0 / 2.993)
                     case 'nii_6548':
                         """
                         [N2] (4-->2): airwave: 6548.0488 vacwave: 6549.8578 emissivity: 2.02198e-21
                         [N2] (4-->3): airwave: 6583.4511 vacwave: 6585.2696 emissivity: 5.94901e-21
+                        https://ui.adsabs.harvard.edu/abs/2023AdSpR..71.1219D/abstract
                         """
-                        tie_line(tying_info, line_params, 'nii_6584', amp_factor = 1.0 / 2.9421)
+                        tie_line(tying_info, line_params, 'nii_6584', amp_factor = 1.0 / 3.049)
                     case 'oii_7330':
                         """
                         [O2] (5-->2): airwave: 7318.9185 vacwave: 7320.9350 emissivity: 8.18137e-24

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -179,10 +179,11 @@ def qa_fastspec(data, templates, fastspec, metadata, coadd_type='healpix',
         col1 = [colors.to_hex(col) for col in ['violet']]
         col2 = [colors.to_hex(col) for col in ['purple']]
     else:
-        col1 = [colors.to_hex(col) for col in ['dodgerblue', 'darkseagreen', 'orangered']]
-        col2 = [colors.to_hex(col) for col in ['darkblue', 'darkgreen', 'darkred']]
+        # https://xkcd.com/color/rgb/
+        col2 = ["#003f91", "#007f5f", "#9b2226"]
+        col1 = ["#468fcc", "#4caf81", "#e07a75"]
 
-    photcol1 = colors.to_hex('darkorange')
+    photcol1 = colors.to_hex('navy') # darkorange
 
     @ticker.FuncFormatter
     def major_formatter(x, pos):
@@ -649,11 +650,11 @@ def qa_fastspec(data, templates, fastspec, metadata, coadd_type='healpix',
 
         sz = img.shape
         cutax.add_artist(Circle((sz[1] / 2, sz[0] / 2), radius=1.5/2/pixscale, facecolor='none', # DESI fiber=1.5 arcsec diameter
-                                edgecolor='red', ls='-', alpha=0.8))#, label='3" diameter'))
+                                edgecolor='yellow', ls='-', alpha=0.8))#, label='3" diameter'))
         cutax.add_artist(Circle((sz[1] / 2, sz[0] / 2), radius=10/2/pixscale, facecolor='none',
-                                edgecolor='red', ls='--', alpha=0.8))#, label='15" diameter'))
-        handles = [Line2D([0], [0], color='red', lw=2, ls='-', label='1.5 arcsec'),
-                   Line2D([0], [0], color='red', lw=2, ls='--', label='10 arcsec')]
+                                edgecolor='yellow', ls='--', alpha=0.8))#, label='15" diameter'))
+        handles = [Line2D([0], [0], color='yellow', lw=2, ls='-', label='1.5 arcsec'),
+                   Line2D([0], [0], color='yellow', lw=2, ls='--', label='10 arcsec')]
 
         cutax.legend(handles=handles, loc='lower left', fontsize=fontsize1, facecolor='lightgray')
 
@@ -694,14 +695,15 @@ def qa_fastspec(data, templates, fastspec, metadata, coadd_type='healpix',
                     spec_ymax = np.max(modelflux) * 1.25
                 #print(spec_ymin, spec_ymax)
 
-            #specax.fill_between(wave, flux-sigma, flux+sigma, color=col1[icam], alpha=0.2)
             if nsmoothspec > 1:
                 from scipy.ndimage import gaussian_filter
-                specax.plot(wave/1e4, gaussian_filter(flux, nsmoothspec), color=col1[icam], alpha=0.8)
-                specax.plot(wave/1e4, gaussian_filter(modelflux, nsmoothspec), color=col2[icam], lw=2, alpha=0.8)
+                specax.plot(wave/1e4, gaussian_filter(flux, nsmoothspec), color=col1[icam], lw=1,
+                            alpha=0.7, drawstyle='steps-mid')
+                specax.plot(wave/1e4, gaussian_filter(modelflux, nsmoothspec), color=col2[icam],
+                            lw=2, alpha=0.9)
             else:
-                specax.plot(wave/1e4, flux, color=col1[icam], alpha=0.8)
-                specax.plot(wave/1e4, modelflux, color=col2[icam], lw=2, alpha=0.8)
+                specax.plot(wave/1e4, flux, color=col1[icam], lw=1, alpha=0.7, drawstyle='steps-mid')
+                specax.plot(wave/1e4, modelflux, color=col2[icam], lw=2, alpha=0.9)
 
         fullmodelspec = np.hstack(desimodelspec)
 
@@ -738,10 +740,11 @@ def qa_fastspec(data, templates, fastspec, metadata, coadd_type='healpix',
         else:
             factor = 10**(0.4 * 48.6) * sedwave**2 / (C_LIGHT * 1e13) / FLUXNORM / CTools.massnorm # [erg/s/cm2/A --> maggies]
             sedmodel_abmag = -2.5*np.log10(sedmodel * factor)
-            sedax.plot(sedwave / 1e4, sedmodel_abmag, color='slategrey', alpha=0.9, zorder=1)
+            sedax.plot(sedwave / 1e4, sedmodel_abmag, color='grey', # ='~tan'
+                       alpha=0.9, zorder=1)
 
-        sedax.scatter(sedphot['lambda_eff']/1e4, sedphot['abmag'], marker='s',
-                      s=400, color='k', facecolor='none', linewidth=2, alpha=1.0, zorder=2)
+        sedax.scatter(sedphot['lambda_eff']/1e4, sedphot['abmag'], marker='D',
+                      s=450, color='k', facecolor='none', linewidth=2, alpha=1.0, zorder=2)
 
         if not fastphot:
             #factor = 10**(0.4 * 48.6) * fullwave**2 / (C_LIGHT * 1e13) / FLUXNORM # [erg/s/cm2/A --> maggies]
@@ -1013,7 +1016,8 @@ def qa_fastspec(data, templates, fastspec, metadata, coadd_type='healpix',
                     indx = np.where((emlinewave > wmin) * (emlinewave < wmax))[0]
                     if len(indx) > 1:
                         removelabels[iax] = False
-                        xx.plot(emlinewave[indx]/1e4, emlineflux[indx], color=col1[icam], alpha=0.5)
+                        xx.plot(emlinewave[indx]/1e4, emlineflux[indx], color=col1[icam], lw=1,
+                                alpha=0.7, drawstyle='steps-mid')
                         #if nsmoothspec > 1:
                         #    xx.plot(emlinewave[indx]/1e4, gaussian_filter(emlineflux[indx], nsmoothspec), color=col1[icam], alpha=0.5)
                         #else:
@@ -1028,9 +1032,9 @@ def qa_fastspec(data, templates, fastspec, metadata, coadd_type='healpix',
                                 # Halpha on sv1-bright-22923-39627731570268174),
                                 # the wavelengths are out of order.
                                 srt = np.argsort(fullwave)
-                                xx.plot(fullwave[srt] / 1e4, plotline[srt], lw=1, alpha=0.8, color=col2[icam])
+                                xx.plot(fullwave[srt] / 1e4, plotline[srt], lw=1, alpha=0.9, color=col2[icam])
 
-                        xx.plot(emlinewave[indx]/1e4, emlinemodel[indx], color=col2[icam], lw=2, alpha=0.8)
+                        xx.plot(emlinewave[indx]/1e4, emlinemodel[indx], color=col2[icam], lw=2, alpha=0.9)
                         #if nsmoothspec > 1:
                         #    xx.plot(emlinewave[indx]/1e4, emlinemodel[indx], color=col2[icam], lw=2, alpha=0.8)
                         #else:

--- a/py/fastspecfit/util.py
+++ b/py/fastspecfit/util.py
@@ -53,7 +53,6 @@ class MPPool(object):
     rather than a list of positional arguments.
 
     """
-
     def __init__(self, nworkers, initializer=None, init_argdict=None):
         """
         create a pool with nworkers workers, using the current
@@ -84,7 +83,6 @@ class MPPool(object):
         as a list of keyword argument dictionaries.
 
         """
-
         # we cannot pickle a local function, so we must pass
         # both func and the argument dictionary to the subprocess
         # worker and have it apply one to the other.
@@ -101,8 +99,8 @@ class MPPool(object):
     def close(self):
         """
         close our multiprocess pool if we created one
-        """
 
+        """
         if self.pool is not None:
             self.pool.close()
 


### PR DESCRIPTION
As posted in the #fastspecfit channel:

"I’ve been using an [NII] 6584 / [NII] 6548 doublet ratio of 2.9421 based on the atomic data and 
emissivities in PyNeb, but @arjundey brought [this paper](https://arxiv.org/pdf/2204.10036) to my attention, which recommends a ratio of 3.049 based on both high signal-to-noise ratio SDSS spectroscopy and a theoretical calculation which includes relativistic corrections to the magnetic dipole operator. 

Similarly, I’m going to update the [OIII] 5007 / [OIII] 4959 doublet ratio from 2.9839 (current ratio, again from PyNeb) to 2.993 (0.3% higher) and cite [this paper](https://arxiv.org/pdf/astro-ph/0610848)."

This PR includes this change as well as a fix for a bug introduced in #194 and some other small cosmetic changes, particularly the colors used in QA.