### PR TITLE
fix doublet bias

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ Change Log
 3.1.1 (not released yet)
 ------------------------
 
-*
+* Fix <1% bias in fluxes and EWs of tied and free doublet ratios [`PR #198`_].
+
+.. _`PR #198`: https://github.com/desihub/fastspecfit/pull/198
 
 3.1.0 (2024-11-21)
 ------------------

--- a/py/fastspecfit/emline_fit/interface.py
+++ b/py/fastspecfit/emline_fit/interface.py
@@ -3,6 +3,8 @@ from math import erf, erfc
 
 from numba import jit
 
+from fastspecfit.resolution import Resolution
+
 from .params_mapping import ParamsMapping
 from .sparse_rep import EMLineJacobian
 
@@ -330,6 +332,11 @@ class MultiLines(object):
                 for j in range(e-s):
                     M[i,j] = np.maximum(M[i,j], 0.)
 
+        if resolution_matrices is None:
+            # create trivial diagonal resolution matrices
+            rm = [ Resolution(np.ones((1, e - s))) for (s, e) in camerapix ]
+            resolution_matrices = tuple(rm)
+
         self.line_models = []
         _build_multimodel_core(line_parameters,
                                obs_bin_centers,
@@ -343,7 +350,6 @@ class MultiLines(object):
 
         for endpts, M in self.line_models:
             _suppress_negative_fluxes(endpts, M)
-
 
 
     def getLine(self, line):

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -861,7 +861,7 @@ class EMFitTools(object):
             line_wavelengths = self.line_table['restwave'].value
             return EMLine_MultiLines(
                 parameters, emlinewave, redshift, line_wavelengths,
-                resolution_matrices, camerapix)
+                resolution_matrices=None, camerapix=camerapix) # omit per-camera resolution matrix transformations
 
         values = linemodel['value'].value
         obsamps = linemodel.meta['obsamps']


### PR DESCRIPTION
This PR should hopefully address #196.

Briefly, now that we're using Monte Carlo to estimate the variance in `AMP` and `FLUX`, we can simply integrate the Gaussian line-profile to get the flux analytically:

$F = A\sqrt{2\pi} \lambda_0(1+z_{RR} + \Delta v / c)\  \sigma/c$,

where $A$ is the *model* amplitude (`MODELAMP`), $\lambda_0$ is the rest-frame wavelength, $z_{RR}$ is the Redrock redshift, $\Delta v$ (`VSHIFT`) is the velocity center of the line (relative to $z_{RR}$), and $\sigma$ is the intrinsic line-width (`SIGMA`). 

Previously (and currently), we were deriving `FLUX` and `FLUX_IVAR` as a profile-weighted sum of the pixels in each line (see https://github.com/desihub/fastspecfit/pull/96). However, at small line-widths the line was not well-sampled, which is what I think was leading to the bias identified by @dirkscholte in #196.

Using @dirkscholte's test sample, below are the results with this branch.

The theoretical [OIII] 5007 / [OIII] 4959 = 2.993 ratio in `MODELAMP` is always enforced during optimization; however, noise in `SIGMA` leads to scatter in the `FLUX` ratio, as shown in the figure below. @dirkscholte is this result satisfactory?

Thinking about the theory, we *probably* want to enforce the ratio 2.993 to be enforced on the flux ratio; however, this would be much more difficult to do given how the optimization problem in the code is set up (in which `MODELAMP`, `SIGMA`, and `VSHIFT` are the optimized parameters).

<img width="672" alt="Screenshot 2024-11-30 at 2 14 04 PM" src="https://github.com/user-attachments/assets/c10006ed-2a35-4440-9503-9a0cf42736ec">

