### PR TITLE
Update clip level of ivar2var function

### DIFF
--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1452,7 +1452,7 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
     emlineflux = specflux - continuummodel - smooth_continuum
 
     emlineivar = np.copy(oemlineivar)
-    _, emlinegood = ivar2var(emlineivar, clip=1e-3)
+    _, emlinegood = ivar2var(emlineivar, clip=1e-8)
     emlinebad = ~emlinegood
 
     # This is a (dangerous???) hack.

--- a/py/fastspecfit/util.py
+++ b/py/fastspecfit/util.py
@@ -247,7 +247,7 @@ def var2ivar(var, sigma=False):
     return ivar
 
 
-def ivar2var(ivar, clip=1e-3, sigma=False, allmasked_ok=False):
+def ivar2var(ivar, clip=1e-8, sigma=False, allmasked_ok=False):
     """Safely convert an inverse variance to a variance. Note that we clip at 1e-3
     by default, not zero.
 


### PR DESCRIPTION
Update the clip level in the `ivar2var` function from `clip=1e-3` to `clip=1e-8`.

The previous clip level erroneously masked very strong emission lines leading to poor line fits (in a relatively very small number of spectra). Details of the bug are in #227 .