### PR TITLE
Add unit tests for core modules and streamline CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,6 +35,13 @@ jobs:
                 python -m pip install -e ".[test]"
             - name: Verify Installation
               run: pip list
+            - name: Set template cache path
+              run: echo "FTEMPLATES_CACHE_DIR=$HOME/.cache/fastspecfit-templates" >> $GITHUB_ENV
+            - name: Cache template files
+              uses: actions/cache@v4
+              with:
+                path: ${{ env.FTEMPLATES_CACHE_DIR }}
+                key: fastspecfit-templates-2.0.0
             - name: Run the test
               run: pytest
 
@@ -62,6 +69,13 @@ jobs:
                 sudo apt install libbz2-dev
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install -e ".[coverage]"
+            - name: Set template cache path
+              run: echo "FTEMPLATES_CACHE_DIR=$HOME/.cache/fastspecfit-templates" >> $GITHUB_ENV
+            - name: Cache template files
+              uses: actions/cache@v4
+              with:
+                path: ${{ env.FTEMPLATES_CACHE_DIR }}
+                key: fastspecfit-templates-2.0.0
             - name: Run the test with coverage
               run: pytest --cov
             - name: Coveralls

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,10 +13,10 @@ jobs:
         name: Unit tests
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10', '3.11', '3.12', '3.13']
+                python-version: ['3.10', '3.12', '3.14']
 
         steps:
             - name: Checkout code
@@ -41,7 +41,7 @@ jobs:
               uses: actions/cache@v4
               with:
                 path: ${{ env.FTEMPLATES_CACHE_DIR }}
-                key: fastspecfit-templates-2.0.0
+                key: ${{ runner.os }}-fastspecfit-templates-2.0.0
             - name: Run the test
               run: pytest
 
@@ -49,10 +49,10 @@ jobs:
         name: Test coverage
         runs-on: ${{ matrix.os }}
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10', '3.11', '3.12']
+                python-version: ['3.12']
 
         steps:
             - name: Checkout code
@@ -75,7 +75,7 @@ jobs:
               uses: actions/cache@v4
               with:
                 path: ${{ env.FTEMPLATES_CACHE_DIR }}
-                key: fastspecfit-templates-2.0.0
+                key: ${{ runner.os }}-fastspecfit-templates-2.0.0
             - name: Run the test with coverage
               run: pytest --cov
             - name: Coveralls

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,10 +5,14 @@ Change Log
 3.3.0 (not released yet)
 ------------------------
 
+* Add unit tests for ``emline_fit``, ``resolution``, ``linemasker``, ``continuum``,
+  ``emlines``, and ``io`` modules; cache template download in CI; streamline
+  Python version matrix [`PR #246`_].
 * Rewrite all docstrings to uniform NumPy style for ReadTheDocs rendering [`PR #245`_].
 * Deconvolve the resolution matrix before fitting, as recommended
   by S. Koposov and update config files [`PR #244`_].
 
+.. _`PR #246`: https://github.com/desihub/fastspecfit/pull/246
 .. _`PR #245`: https://github.com/desihub/fastspecfit/pull/245
 .. _`PR #244`: https://github.com/desihub/fastspecfit/pull/244
 

--- a/py/fastspecfit/test/conftest.py
+++ b/py/fastspecfit/test/conftest.py
@@ -4,6 +4,7 @@ fastspecfit.test.conftest
 
 """
 import os
+import pathlib
 import pytest
 from urllib.request import urlretrieve
 
@@ -20,8 +21,13 @@ def outdir(tmp_path_factory):
 
 @pytest.fixture(scope='session')
 def templatedir(outdir, template_version):
-    templatedir = outdir / template_version
-    templatedir.mkdir()
+    cache_dir = os.environ.get('FTEMPLATES_CACHE_DIR')
+    if cache_dir:
+        templatedir = pathlib.Path(cache_dir) / template_version
+        templatedir.mkdir(parents=True, exist_ok=True)
+    else:
+        templatedir = outdir / template_version
+        templatedir.mkdir()
     yield templatedir
 
 
@@ -35,6 +41,6 @@ def templates(templatedir, template_version):
         urlretrieve(url, templates)
     yield templates
 
-    # Optional cleanup
-    if os.path.isfile(templates):
+    # Skip cleanup when using a persistent cache directory.
+    if not os.environ.get('FTEMPLATES_CACHE_DIR') and os.path.isfile(templates):
         os.remove(templates)

--- a/py/fastspecfit/test/test_continuum.py
+++ b/py/fastspecfit/test/test_continuum.py
@@ -1,0 +1,289 @@
+"""
+fastspecfit.test.test_continuum
+================================
+Unit tests for continuum.py covering standalone functions and
+ContinuumTools methods that do not require the template download or
+a fully initialized ContinuumTools instance.
+
+Methods requiring templates (build_stellar_continuum,
+continuum_to_photometry, fit_stellar_continuum, etc.) are exercised
+indirectly by the integration tests in test_fastspecfit.py.
+"""
+import numpy as np
+import pytest
+
+
+# ── can_compute_vdisp ─────────────────────────────────────────────────────────
+
+class TestCanComputeVdisp:
+
+    def _call(self, z, wave, **kwargs):
+        from fastspecfit.continuum import can_compute_vdisp
+        return can_compute_vdisp(z, wave, **kwargs)
+
+    def test_wide_coverage_at_z0(self):
+        """Spectrum covering 3500-7000 Å at z=0 reaches the Ca H&K region."""
+        wave = np.linspace(3500., 7000., 1000)
+        ok, pix = self._call(0., wave)
+        assert ok
+        assert pix != (0, 0)
+
+    def test_too_red_at_z0(self):
+        """Spectrum starting at 5000 Å at z=0 does not reach below 3800 Å."""
+        wave = np.linspace(5000., 9000., 1000)
+        ok, pix = self._call(0., wave)
+        assert not ok
+        assert pix == (0, 0)
+
+    def test_redshifted_coverage(self):
+        """At z=0.5 a 5400-10500 Å spectrum covers 3600-7000 Å rest-frame."""
+        z = 0.5
+        wave = np.linspace(5400., 10500., 2000)
+        ok, pix = self._call(z, wave)
+        assert ok
+
+    def test_pixel_range_within_bounds(self):
+        """Returned pixel range must be valid indices into the wave array."""
+        wave = np.linspace(3500., 7000., 1000)
+        ok, (s, e) = self._call(0., wave)
+        assert ok
+        assert 0 <= s < e <= len(wave)
+
+    def test_just_missing_blue_edge(self):
+        """A spectrum starting just above the minimum rest-frame limit returns False."""
+        min_lo = 3800.
+        wave = np.linspace(min_lo + 1., 9000., 2000)  # starts above threshold
+        ok, pix = self._call(0., wave)
+        assert not ok
+
+
+# ── _younger_than_universe ────────────────────────────────────────────────────
+
+class TestYoungerThanUniverse:
+
+    def _call(self, age_yr, tuniv_gyr, agepad=0.5):
+        from fastspecfit.continuum import ContinuumTools
+        return ContinuumTools._younger_than_universe(age_yr, tuniv_gyr, agepad)
+
+    def test_all_younger(self):
+        """All templates younger than the universe are kept."""
+        age = np.array([1e8, 5e8, 1e9])   # yr — all < 5.5 Gyr
+        tuniv = 5.0                         # Gyr
+        idx = self._call(age, tuniv)
+        assert len(idx) == len(age)
+
+    def test_all_older(self):
+        """No templates older than the universe are kept."""
+        age = np.array([7e9, 10e9, 13e9])  # yr — all > 5.5 Gyr
+        tuniv = 5.0
+        idx = self._call(age, tuniv)
+        assert len(idx) == 0
+
+    def test_mixed_ages(self):
+        """Only templates younger than the threshold are returned."""
+        tuniv = 5.0   # Gyr
+        agepad = 0.5
+        threshold = 1e9 * (tuniv + agepad)  # = 5.5e9 yr
+        age = np.array([1e9, 3e9, 5e9, 6e9, 13e9])
+        idx = self._call(age, tuniv, agepad)
+        expected = np.where(age <= threshold)[0]
+        assert np.array_equal(idx, expected)
+
+
+# ── lums_keys / cfluxes_keys ─────────────────────────────────────────────────
+
+class TestKeyLists:
+
+    def test_lums_keys_length_matches(self):
+        from fastspecfit.continuum import ContinuumTools
+        keys, waves = ContinuumTools.lums_keys()
+        assert len(keys) == len(waves)
+        assert all(isinstance(k, str) for k in keys)
+        assert all(w > 0 for w in waves)
+
+    def test_cfluxes_keys_length_matches(self):
+        from fastspecfit.continuum import ContinuumTools
+        keys, waves = ContinuumTools.cfluxes_keys()
+        assert len(keys) == len(waves)
+        assert all(isinstance(k, str) for k in keys)
+        assert all(w > 0 for w in waves)
+
+
+# ── attenuate_nodust ──────────────────────────────────────────────────────────
+
+class TestAttenuateNoDust:
+
+    def _call(self, M, A, zfactors):
+        from fastspecfit.continuum import ContinuumTools
+        Mc = M.copy().astype(np.float64)
+        ContinuumTools.attenuate_nodust(Mc, A, zfactors)
+        return Mc
+
+    def test_no_op_when_A_and_zfactors_are_one(self):
+        """A=1, zfactors=1: spectrum is unchanged."""
+        M = np.array([1., 2., 3., 4., 5.])
+        result = self._call(M, np.ones_like(M), np.ones_like(M))
+        assert np.allclose(result, M)
+
+    def test_complete_attenuation(self):
+        """A=0 zeroes the spectrum regardless of zfactors."""
+        M = np.array([1., 2., 3.])
+        result = self._call(M, np.zeros_like(M), np.ones_like(M))
+        assert np.all(result == 0.)
+
+    def test_scaling_by_zfactors(self):
+        """zfactors uniformly scales the output."""
+        M = np.array([1., 2., 3.])
+        scale = 2.5
+        r1 = self._call(M, np.ones_like(M), np.ones_like(M))
+        r2 = self._call(M, np.ones_like(M), np.full_like(M, scale))
+        assert np.allclose(r2, scale * r1)
+
+
+# ── attenuate ─────────────────────────────────────────────────────────────────
+
+class TestAttenuate:
+
+    def _call(self, M, A, zfactors, wave, dustflux):
+        from fastspecfit.continuum import ContinuumTools
+        Mc = M.copy().astype(np.float64)
+        ContinuumTools.attenuate(Mc, A, zfactors, wave, dustflux)
+        return Mc
+
+    def test_no_op_when_A_and_zfactors_one_no_dust(self):
+        """A=1, zfactors=1, dustflux=0: lbol_diff=0 so spectrum is unchanged."""
+        M = np.array([1., 2., 3., 4.])
+        wave = np.array([3000., 4000., 5000., 6000.], dtype=np.float64)
+        result = self._call(M, np.ones_like(M), np.ones_like(M), wave,
+                            np.zeros_like(M))
+        assert np.allclose(result, M)
+
+    def test_complete_attenuation_no_dust(self):
+        """A=0, dustflux=0: all flux is absorbed and no dust emission added."""
+        M = np.array([1., 2., 3., 4.])
+        wave = np.array([3000., 4000., 5000., 6000.], dtype=np.float64)
+        result = self._call(M, np.zeros_like(M), np.ones_like(M), wave,
+                            np.zeros_like(M))
+        assert np.all(result == 0.)
+
+    def test_dustflux_zero_matches_nodust(self):
+        """With dustflux=0, attenuate and attenuate_nodust give identical results."""
+        from fastspecfit.continuum import ContinuumTools
+        rng = np.random.default_rng(0)
+        n = 50
+        M     = rng.uniform(0.5, 2., n)
+        A     = rng.uniform(0.3, 1., n)
+        zf    = rng.uniform(0.5, 1.5, n)
+        wave  = np.linspace(3000., 9000., n)
+
+        r_att     = self._call(M, A, zf, wave, np.zeros(n))
+        Mc_nodust = M.copy().astype(np.float64)
+        ContinuumTools.attenuate_nodust(Mc_nodust, A, zf)
+        assert np.allclose(r_att, Mc_nodust)
+
+
+# ── stellar_continuum_chi2 ────────────────────────────────────────────────────
+
+class TestStellarContinuumChi2:
+
+    def _call(self, resid, ncoeff, vdisp_fitted, **kwargs):
+        from fastspecfit.continuum import ContinuumTools
+        # self is never accessed inside this method.
+        return ContinuumTools.stellar_continuum_chi2(
+            None, resid, ncoeff, vdisp_fitted, **kwargs)
+
+    def test_zero_residuals_give_zero_chi2(self):
+        resid = np.zeros(20)
+        rchi2_spec, rchi2_phot, rchi2_tot = self._call(
+            resid, ncoeff=3, vdisp_fitted=False,
+            split=10, ndof_spec=10, ndof_phot=10)
+        assert rchi2_spec == 0.
+        assert rchi2_phot == 0.
+        assert rchi2_tot == 0.
+
+    def test_spec_only(self):
+        """ndof_phot=0: rchi2_phot=0 and rchi2_tot equals rchi2_spec."""
+        resid = np.ones(10)
+        rchi2_spec, rchi2_phot, rchi2_tot = self._call(
+            resid, ncoeff=2, vdisp_fitted=False,
+            split=10, ndof_spec=10, ndof_phot=0)
+        assert rchi2_phot == 0.
+        assert rchi2_tot == rchi2_spec
+
+    def test_phot_only(self):
+        """ndof_spec=0: rchi2_spec=0 and rchi2_tot equals rchi2_phot."""
+        resid = np.ones(5)
+        rchi2_spec, rchi2_phot, rchi2_tot = self._call(
+            resid, ncoeff=2, vdisp_fitted=False,
+            split=0, ndof_spec=0, ndof_phot=5)
+        assert rchi2_spec == 0.
+        assert rchi2_tot == rchi2_phot
+
+    def test_vdisp_fitted_increases_nfree(self):
+        """Fitting vdisp adds one degree of freedom, raising rchi2."""
+        resid = np.ones(20)
+        _, _, rchi2_no  = self._call(resid, ncoeff=3, vdisp_fitted=False,
+                                     split=10, ndof_spec=10, ndof_phot=10)
+        _, _, rchi2_yes = self._call(resid, ncoeff=3, vdisp_fitted=True,
+                                     split=10, ndof_spec=10, ndof_phot=10)
+        assert rchi2_yes > rchi2_no
+
+    def test_split_correctly_separates_spec_and_phot(self):
+        """Residuals before split go to spec chi2; residuals after go to phot."""
+        resid = np.concatenate([np.zeros(10), np.ones(5)])
+        rchi2_spec, rchi2_phot, _ = self._call(
+            resid, ncoeff=2, vdisp_fitted=False,
+            split=10, ndof_spec=10, ndof_phot=5)
+        assert rchi2_spec == 0.
+        assert rchi2_phot > 0.
+
+
+# ── smooth_continuum ──────────────────────────────────────────────────────────
+
+class TestSmoothContinuum:
+
+    @pytest.fixture
+    def flat_spectrum(self):
+        rng = np.random.default_rng(7)
+        n = 1000
+        wave = np.linspace(4000., 8000., n)
+        flux = 5.0 + 0.3 * rng.standard_normal(n)
+        ivar = np.ones(n)
+        linemask = np.zeros(n, bool)
+        camerapix = np.array([[0, n]])
+        return wave, flux, ivar, linemask, camerapix
+
+    def test_output_shape(self, flat_spectrum):
+        from fastspecfit.continuum import ContinuumTools
+        wave, flux, ivar, linemask, camerapix = flat_spectrum
+        result = ContinuumTools.smooth_continuum(wave, flux, ivar, linemask,
+                                                 camerapix)
+        assert result.shape == wave.shape
+
+    def test_linemask_length_mismatch_raises(self, flat_spectrum):
+        from fastspecfit.continuum import ContinuumTools
+        wave, flux, ivar, linemask, camerapix = flat_spectrum
+        bad_mask = np.zeros(len(wave) + 1, bool)
+        with pytest.raises(ValueError, match='Linemask'):
+            ContinuumTools.smooth_continuum(wave, flux, ivar, bad_mask,
+                                            camerapix)
+
+    def test_smooth_of_flat_spectrum_near_mean(self, flat_spectrum):
+        """Smooth continuum of a noisy flat spectrum should be near the mean."""
+        from fastspecfit.continuum import ContinuumTools
+        wave, flux, ivar, linemask, camerapix = flat_spectrum
+        result = ContinuumTools.smooth_continuum(wave, flux, ivar, linemask,
+                                                 camerapix)
+        unmasked = result[result != 0.]
+        assert len(unmasked) > 0
+        assert abs(np.median(unmasked) - 5.0) < 1.0
+
+    def test_all_masked_ivar_returns_zeros(self, flat_spectrum):
+        """With ivar=0 everywhere, the smooth continuum should be all zeros."""
+        from fastspecfit.continuum import ContinuumTools
+        wave, flux, _, linemask, camerapix = flat_spectrum
+        ivar_zero = np.zeros_like(wave)
+        flux_zero = np.zeros_like(wave)
+        result = ContinuumTools.smooth_continuum(wave, flux_zero, ivar_zero,
+                                                 linemask, camerapix)
+        assert np.all(result == 0.)

--- a/py/fastspecfit/test/test_emline_fit.py
+++ b/py/fastspecfit/test/test_emline_fit.py
@@ -1,0 +1,321 @@
+"""
+fastspecfit.test.test_emline_fit
+================================
+Unit tests for the emline_fit subpackage: utilities, emission-line model,
+parameter mapping, and Jacobian.
+"""
+import numpy as np
+import pytest
+
+from fastspecfit.util import C_LIGHT
+
+
+# ── shared fixtures ───────────────────────────────────────────────────────────
+
+@pytest.fixture(scope='module')
+def grid():
+    """Uniform log-lambda bin grid spanning the DESI wavelength range."""
+    nbin = 5000
+    edges = np.exp(np.linspace(np.log(3600.), np.log(9900.), nbin + 1))
+    log_edges = np.log(edges)
+    ibin_widths = 1. / np.diff(log_edges)
+    return {'log_edges': log_edges, 'ibin_widths': ibin_widths, 'nbin': nbin}
+
+
+@pytest.fixture(scope='module')
+def single_line():
+    """One Hα emission line (6563 Å) at z = 0.1 with σ = 150 km/s."""
+    return {
+        'rest_wave': 6563.,
+        'redshift': 0.1,
+        'amplitude': 1.0,
+        'vshift': 0.0,
+        'sigma': 150.0,
+    }
+
+
+def _line_arrays(sl):
+    """Return (line_wavelengths, line_parameters) arrays from a single-line dict."""
+    return (np.array([sl['rest_wave']]),
+            np.array([sl['amplitude'], sl['vshift'], sl['sigma']]))
+
+
+def _mapping(nParms, isFree, tiedSources=None, tiedFactors=None,
+             doubletTargets=None, doubletSources=None):
+    """Construct a ParamsMapping, filling optional args with neutral defaults."""
+    from fastspecfit.emline_fit.params_mapping import ParamsMapping
+    if tiedSources is None:
+        tiedSources = np.full(nParms, -1, dtype=np.int32)
+    else:
+        tiedSources = np.asarray(tiedSources, dtype=np.int32)
+    if tiedFactors is None:
+        tiedFactors = np.zeros(nParms, dtype=np.float64)
+    else:
+        tiedFactors = np.asarray(tiedFactors, dtype=np.float64)
+    if doubletTargets is None:
+        doubletTargets = np.empty(0, dtype=np.int32)
+    else:
+        doubletTargets = np.asarray(doubletTargets, dtype=np.int32)
+    if doubletSources is None:
+        doubletSources = np.empty(0, dtype=np.int32)
+    else:
+        doubletSources = np.asarray(doubletSources, dtype=np.int32)
+    return ParamsMapping(nParms, np.asarray(isFree, dtype=bool),
+                         tiedSources, tiedFactors,
+                         doubletTargets, doubletSources)
+
+
+# ── norm_cdf ──────────────────────────────────────────────────────────────────
+
+class TestNormCDF:
+
+    def test_midpoint(self):
+        from fastspecfit.emline_fit.utils import norm_cdf
+        assert np.isclose(norm_cdf(0.), 0.5)
+
+    def test_symmetry(self):
+        from fastspecfit.emline_fit.utils import norm_cdf
+        for x in (0.5, 1.0, 2.0, 3.0):
+            assert np.isclose(norm_cdf(x) + norm_cdf(-x), 1.0, atol=1e-10)
+
+    def test_extremes(self):
+        from fastspecfit.emline_fit.utils import norm_cdf
+        assert norm_cdf(8.) > 1. - 1e-10
+        assert norm_cdf(-8.) < 1e-10
+
+    def test_monotone(self):
+        from fastspecfit.emline_fit.utils import norm_cdf
+        cdfs = np.array([norm_cdf(x) for x in np.linspace(-5, 5, 50)])
+        assert np.all(np.diff(cdfs) > 0)
+
+
+# ── norm_pdf ──────────────────────────────────────────────────────────────────
+
+class TestNormPDF:
+
+    def test_peak(self):
+        from fastspecfit.emline_fit.utils import norm_pdf
+        assert np.isclose(norm_pdf(0.), 1. / np.sqrt(2 * np.pi))
+
+    def test_symmetry(self):
+        from fastspecfit.emline_fit.utils import norm_pdf
+        for x in (0.5, 1.0, 2.0):
+            assert np.isclose(norm_pdf(x), norm_pdf(-x))
+
+    def test_positive(self):
+        from fastspecfit.emline_fit.utils import norm_pdf
+        assert all(norm_pdf(x) > 0 for x in np.linspace(-5, 5, 20))
+
+
+# ── max_buffer_width ──────────────────────────────────────────────────────────
+
+class TestMaxBufferWidth:
+
+    def test_positive(self, grid):
+        from fastspecfit.emline_fit.utils import max_buffer_width
+        assert max_buffer_width(grid['log_edges'], np.array([100.])) > 0
+
+    def test_wider_sigma_gives_wider_buffer(self, grid):
+        from fastspecfit.emline_fit.utils import max_buffer_width
+        w_narrow = max_buffer_width(grid['log_edges'], np.array([50.]))
+        w_wide   = max_buffer_width(grid['log_edges'], np.array([500.]))
+        assert w_wide > w_narrow
+
+    def test_padding(self, grid):
+        from fastspecfit.emline_fit.utils import max_buffer_width
+        sigmas = np.array([100.])
+        w0 = max_buffer_width(grid['log_edges'], sigmas, padding=0)
+        w5 = max_buffer_width(grid['log_edges'], sigmas, padding=5)
+        assert w5 == w0 + 10  # 2*padding added per call
+
+
+# ── emline_model ──────────────────────────────────────────────────────────────
+
+class TestEmlineModel:
+
+    def test_zero_amplitude_gives_zeros(self, grid, single_line):
+        from fastspecfit.emline_fit.model import emline_model
+        lw, p = _line_arrays(single_line)
+        p = p.copy(); p[0] = 0.
+        model = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
+                             grid['ibin_widths'])
+        assert np.all(model == 0.)
+
+    def test_out_of_range_line_gives_zeros(self, grid):
+        from fastspecfit.emline_fit.model import emline_model
+        lw = np.array([50000.])  # far redward of the grid
+        p  = np.array([1., 0., 100.])
+        model = emline_model(lw, p, grid['log_edges'], 0., grid['ibin_widths'])
+        assert np.all(model == 0.)
+
+    def test_nonnegative(self, grid, single_line):
+        from fastspecfit.emline_fit.model import emline_model
+        lw, p = _line_arrays(single_line)
+        model = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
+                             grid['ibin_widths'])
+        assert np.all(model >= 0.)
+
+    def test_amplitude_scaling(self, grid, single_line):
+        from fastspecfit.emline_fit.model import emline_model
+        lw, p = _line_arrays(single_line)
+        m1 = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
+                          grid['ibin_widths'])
+        p3 = p.copy(); p3[0] *= 3.
+        m3 = emline_model(lw, p3, grid['log_edges'], single_line['redshift'],
+                          grid['ibin_widths'])
+        assert np.allclose(3. * m1, m3)
+
+    def test_flux_conservation(self, grid, single_line):
+        """Integrated model flux matches the expected Gaussian normalization."""
+        from fastspecfit.emline_fit.model import emline_model
+        lw, p = _line_arrays(single_line)
+        model = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
+                             grid['ibin_widths'])
+        total    = np.sum(model / grid['ibin_widths'])
+        sigma    = single_line['sigma'] / C_LIGHT
+        lam_obs  = single_line['rest_wave'] * (1. + single_line['redshift'])
+        expected = (np.sqrt(2 * np.pi) * sigma * np.exp(0.5 * sigma**2)
+                    * single_line['amplitude'] * lam_obs)
+        assert np.isclose(total, expected, rtol=1e-3)
+
+    def test_peak_at_redshifted_wavelength(self, grid, single_line):
+        from fastspecfit.emline_fit.model import emline_model
+        lw, p = _line_arrays(single_line)
+        model = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
+                             grid['ibin_widths'])
+        pk = np.argmax(model)
+        log_edges    = grid['log_edges']
+        peak_lambda  = np.exp(0.5 * (log_edges[pk] + log_edges[pk + 1]))
+        expected_lam = single_line['rest_wave'] * (1. + single_line['redshift'])
+        assert abs(peak_lambda - expected_lam) < 5.  # within 5 Å
+
+    def test_vshift_moves_peak_redward(self, grid, single_line):
+        from fastspecfit.emline_fit.model import emline_model
+        lw, p = _line_arrays(single_line)
+        m0    = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
+                             grid['ibin_widths'])
+        p_red = p.copy(); p_red[1] = 500.  # 500 km/s positive shift
+        m_red = emline_model(lw, p_red, grid['log_edges'], single_line['redshift'],
+                             grid['ibin_widths'])
+        assert np.argmax(m_red) > np.argmax(m0)
+
+    def test_perline_models_match_composite(self, grid, single_line):
+        """Sum of per-line profiles equals the composite model."""
+        from fastspecfit.emline_fit.model import emline_model, emline_perline_models
+        from fastspecfit.emline_fit.utils import max_buffer_width
+        lw, p = _line_arrays(single_line)
+        z     = single_line['redshift']
+        le    = grid['log_edges']
+        ibw   = grid['ibin_widths']
+
+        composite = emline_model(lw, p, le, z, ibw)
+
+        sigmas = np.array([p[2]])  # one line
+        padding = 0
+        endpts, profiles = emline_perline_models(lw, p, le, z, ibw, padding)
+
+        reconstructed = np.zeros_like(composite)
+        for j in range(len(lw)):
+            s, e = endpts[j]
+            reconstructed[s:e] += profiles[j, :e - s]
+
+        assert np.allclose(reconstructed, composite)
+
+
+# ── ParamsMapping ─────────────────────────────────────────────────────────────
+
+class TestParamsMapping:
+
+    def test_all_free_roundtrip(self):
+        pm   = _mapping(3, [True, True, True])
+        free = np.array([1., 2., 3.])
+        assert np.allclose(pm.mapFreeToFull(free), free)
+
+    def test_fixed_parameter_is_zero(self):
+        pm   = _mapping(3, [True, False, True])
+        full = pm.mapFreeToFull(np.array([5., 7.]))
+        assert full[0] == 5. and full[1] == 0. and full[2] == 7.
+
+    def test_fixed_mask(self):
+        pm = _mapping(4, [True, False, True, False])
+        assert np.array_equal(pm.fixedMask(), [False, True, False, True])
+
+    def test_nFreeParms(self):
+        pm = _mapping(5, [True, False, True, True, False])
+        assert pm.nFreeParms == 3
+
+    def test_tied_parameter(self):
+        tiedSrc = [-1, 0, -1]
+        tiedFac = [0., 2.5, 0.]
+        pm   = _mapping(3, [True, False, True], tiedSrc, tiedFac)
+        free = np.array([4., 3.])
+        full = pm.mapFreeToFull(free)
+        assert full[0] == 4.
+        assert np.isclose(full[1], 4. * 2.5)
+        assert full[2] == 3.
+
+    def test_jacobian_matvec_identity(self):
+        """For an all-free mapping, J_S @ v == v."""
+        from fastspecfit.emline_fit.params_mapping import ParamsMapping
+        pm   = _mapping(3, [True, True, True])
+        free = np.array([1., 2., 3.])
+        J_S  = pm.getJacobian(free)
+        w    = np.empty(3)
+        ParamsMapping._matvec(J_S, free, w)
+        assert np.allclose(w, free)
+
+    def test_jacobian_rmatvec_identity(self):
+        """For an all-free mapping, J_S.T @ v == v."""
+        from fastspecfit.emline_fit.params_mapping import ParamsMapping
+        pm  = _mapping(3, [True, True, True])
+        J_S = pm.getJacobian(np.array([1., 2., 3.]))
+        v   = np.array([4., 5., 6.])
+        w   = np.zeros(3)
+        ParamsMapping._add_rmatvec(J_S, v, w)
+        assert np.allclose(w, v)
+
+
+# ── emline_model_jacobian ─────────────────────────────────────────────────────
+
+class TestEmlineModelJacobian:
+
+    def test_amplitude_derivative_exact(self, grid, single_line):
+        """d(model)/d(amplitude) == model / amplitude (model is linear in A)."""
+        from fastspecfit.emline_fit.model import emline_model
+        from fastspecfit.emline_fit.jacobian import emline_model_jacobian
+        lw, p = _line_arrays(single_line)
+        z     = single_line['redshift']
+        model = emline_model(lw, p, grid['log_edges'], z, grid['ibin_widths'])
+        endpts, dd = emline_model_jacobian(p, grid['log_edges'], grid['ibin_widths'],
+                                          z, lw, padding=0)
+        s, e = endpts[0]
+        analytic = np.zeros_like(model)
+        analytic[s:e] = dd[0, :e - s]
+        assert np.allclose(analytic, model / p[0], atol=1e-12)
+
+    def test_numerical_jacobian(self, grid, single_line):
+        """Analytical Jacobian matches central finite differences for all parameters."""
+        from fastspecfit.emline_fit.model import emline_model
+        from fastspecfit.emline_fit.jacobian import emline_model_jacobian
+        lw, p = _line_arrays(single_line)
+        z   = single_line['redshift']
+        le  = grid['log_edges']
+        ibw = grid['ibin_widths']
+        nlines = len(lw)
+
+        endpts, dd = emline_model_jacobian(p, le, ibw, z, lw, padding=0)
+
+        for k in range(len(p)):  # amplitude, vshift, sigma
+            h   = 1e-4 * max(1., abs(p[k]))
+            dp  = p.copy(); dp[k] += h
+            dm  = p.copy(); dm[k] -= h
+            fd  = (emline_model(lw, dp, le, z, ibw) -
+                   emline_model(lw, dm, le, z, ibw)) / (2 * h)
+
+            row = k * nlines
+            s, e = endpts[row]
+            analytic = np.zeros_like(fd)
+            analytic[s:e] = dd[row, :e - s]
+
+            assert np.allclose(analytic, fd, atol=1e-6, rtol=1e-3), \
+                f"Jacobian mismatch for parameter index {k}"

--- a/py/fastspecfit/test/test_emlines.py
+++ b/py/fastspecfit/test/test_emlines.py
@@ -1,0 +1,303 @@
+"""
+fastspecfit.test.test_emlines
+==============================
+Unit tests for emlines.py covering EMFitTools initialization,
+compute_inrange_lines, build_linemodels, the chi2 static method,
+and the build_coadded_models module-level function.
+
+Methods requiring real spectra, resolution matrices, or templates
+(optimize, bestfit, populate_emtable, emline_specfit, etc.) are
+covered indirectly by the integration tests in test_fastspecfit.py.
+"""
+import numpy as np
+import pytest
+from astropy.table import Table
+
+
+# ── shared fixtures ───────────────────────────────────────────────────────────
+
+def _make_emfit(**kwargs):
+    from fastspecfit.linetable import LineTable
+    from fastspecfit.emlines import EMFitTools
+    return EMFitTools(LineTable().table, **kwargs)
+
+
+@pytest.fixture(scope='module')
+def emfit():
+    return _make_emfit()
+
+
+# ── ParamType ─────────────────────────────────────────────────────────────────
+
+class TestParamType:
+
+    def test_values(self):
+        from fastspecfit.emlines import ParamType
+        assert int(ParamType.AMPLITUDE) == 0
+        assert int(ParamType.VSHIFT) == 1
+        assert int(ParamType.SIGMA) == 2
+
+    def test_ordering(self):
+        from fastspecfit.emlines import ParamType
+        assert ParamType.AMPLITUDE < ParamType.VSHIFT < ParamType.SIGMA
+
+
+# ── EMFitTools initialization ─────────────────────────────────────────────────
+
+class TestEMFitToolsInit:
+
+    def test_param_table_length(self, emfit):
+        assert len(emfit.param_table) == 3 * len(emfit.line_table)
+
+    def test_line_map_complete(self, emfit):
+        for name in emfit.line_table['name']:
+            assert name in emfit.line_map
+
+    def test_line_map_values_are_valid_indices(self, emfit):
+        nlines = len(emfit.line_table)
+        for idx in emfit.line_map.values():
+            assert 0 <= idx < nlines
+
+    def test_doublet_targets_in_doublet_idx(self, emfit):
+        """Known doublet targets appear in doublet_idx."""
+        known_targets = {'mgii_2796', 'oii_3726', 'sii_6731'}
+        target_indices = {emfit.line_map[n] for n in known_targets}
+        assert target_indices.issubset(set(emfit.doublet_idx.tolist()))
+
+    def test_isBroad_isNarrow_mutually_exclusive(self, emfit):
+        """isBroad and isNarrow are mutually exclusive (broad Balmer lines belong to neither)."""
+        assert not np.any(emfit.isBroad & emfit.isNarrow)
+
+    def test_param_types_cover_all_three(self, emfit):
+        from fastspecfit.emlines import ParamType
+        types = set(int(t) for t in emfit.param_table['type'])
+        for pt in ParamType:
+            assert int(pt) in types
+
+    def test_param_table_has_modelname(self, emfit):
+        assert 'modelname' in emfit.param_table.colnames
+
+    def test_stronglines_flag_reduces_table(self, emfit):
+        """stronglines=True produces a smaller line table."""
+        emfit_strong = _make_emfit(stronglines=True)
+        assert len(emfit_strong.line_table) < len(emfit.line_table)
+
+
+# ── compute_inrange_lines ─────────────────────────────────────────────────────
+
+class TestComputeInrangeLines:
+
+    def test_result_shape(self):
+        emfit = _make_emfit()
+        emfit.compute_inrange_lines(0.)
+        assert emfit.line_in_range.shape == (len(emfit.line_table),)
+
+    def test_z0_common_optical_lines_in_range(self):
+        """At z=0 the key optical lines are within the default 3600-9900 Å window."""
+        emfit = _make_emfit()
+        emfit.compute_inrange_lines(0.)
+        for linename in ('halpha', 'hbeta', 'oiii_5007', 'oii_3729'):
+            idx = emfit.line_map[linename]
+            assert emfit.line_in_range[idx], f'{linename} expected in range at z=0'
+
+    def test_z5_far_fewer_lines_than_z0(self):
+        """At z=5 far fewer lines are in range than at z=0 (most optical lines are shifted out)."""
+        emfit_z0 = _make_emfit()
+        emfit_z5 = _make_emfit()
+        emfit_z0.compute_inrange_lines(0.)
+        emfit_z5.compute_inrange_lines(5.)
+        assert np.sum(emfit_z5.line_in_range) < np.sum(emfit_z0.line_in_range) // 4
+
+    def test_narrow_wavelims_reduce_in_range_count(self):
+        emfit_wide   = _make_emfit()
+        emfit_narrow = _make_emfit()
+        emfit_wide.compute_inrange_lines(0., wavelims=(3600., 9900.))
+        emfit_narrow.compute_inrange_lines(0., wavelims=(5000., 7000.))
+        assert np.sum(emfit_narrow.line_in_range) < np.sum(emfit_wide.line_in_range)
+
+    def test_no_lines_outside_wavelims(self):
+        """No in-range line falls outside the specified wavelength limits."""
+        emfit = _make_emfit()
+        wlo, whi = 5000., 7000.
+        emfit.compute_inrange_lines(0., wavelims=(wlo, whi))
+        in_range_waves = emfit.line_table['restwave'][emfit.line_in_range]
+        assert np.all(in_range_waves > wlo)
+        assert np.all(in_range_waves < whi)
+
+
+# ── build_linemodels ──────────────────────────────────────────────────────────
+
+class TestBuildLinemodels:
+
+    @pytest.fixture(scope='class')
+    def linemodels(self):
+        emfit = _make_emfit()
+        emfit.compute_inrange_lines(0.1)
+        broad, nobroad = emfit.build_linemodels()
+        return emfit, broad, nobroad
+
+    def test_columns_present(self, linemodels):
+        _, broad, nobroad = linemodels
+        for col in ('free', 'fixed', 'tiedtoparam', 'tiedfactor'):
+            assert col in broad.colnames
+            assert col in nobroad.colnames
+
+    def test_row_count_equals_param_table(self, linemodels):
+        emfit, broad, nobroad = linemodels
+        expected = len(emfit.param_table)
+        assert len(broad) == expected
+        assert len(nobroad) == expected
+
+    def test_free_fixed_mutually_exclusive(self, linemodels):
+        _, broad, nobroad = linemodels
+        for lm in (broad, nobroad):
+            assert not np.any(lm['free'] & lm['fixed'])
+
+    def test_broad_has_at_least_as_many_free_params(self, linemodels):
+        """Broad model must free at least as many parameters as narrow-only model."""
+        _, broad, nobroad = linemodels
+        assert np.sum(broad['free']) >= np.sum(nobroad['free'])
+
+    def test_out_of_range_params_fixed_or_tied(self, linemodels):
+        """Every parameter of an out-of-range line is either fixed or tied."""
+        emfit, broad, _ = linemodels
+        out_of_range = ~emfit.line_in_range
+        for line_idx in np.where(out_of_range)[0]:
+            for param_idx in emfit.line_table['params'][line_idx]:
+                row = broad[param_idx]
+                assert row['fixed'] or (row['tiedtoparam'] != -1), \
+                    f"Out-of-range param {param_idx} is neither fixed nor tied"
+
+    def test_tiedfactor_zero_for_untied(self, linemodels):
+        """tiedfactor must be 0 for parameters that are not tied."""
+        _, broad, nobroad = linemodels
+        for lm in (broad, nobroad):
+            untied = lm['tiedtoparam'] == -1
+            assert np.all(lm['tiedfactor'][untied] == 0.)
+
+
+# ── chi2 (static method) ──────────────────────────────────────────────────────
+
+class TestChi2:
+
+    def _lm(self, n_free):
+        """Minimal linemodel Table with n_free free parameters."""
+        n = n_free + 2
+        free = np.zeros(n, dtype=bool)
+        free[:n_free] = True
+        return Table({'free': free})
+
+    def _call(self, lm, flux, ivar, model, **kwargs):
+        from fastspecfit.emlines import EMFitTools
+        wave = np.arange(len(flux), dtype=float)
+        return EMFitTools.chi2(lm, wave, flux, ivar, model, **kwargs)
+
+    def test_perfect_fit_zero_chi2(self):
+        flux = np.ones(20)
+        chi2 = self._call(self._lm(3), flux, np.ones(20), flux)
+        assert chi2 == 0.
+
+    def test_nonzero_residuals_positive_chi2(self):
+        flux  = np.ones(20)
+        model = np.zeros(20)
+        chi2 = self._call(self._lm(2), flux, np.ones(20), model)
+        assert chi2 > 0.
+
+    def test_dof_zero_returns_zero(self):
+        """When free params exceed good pixels, dof <= 0 and chi2 is returned as 0."""
+        flux = np.ones(10)
+        chi2 = self._call(self._lm(15), flux, np.ones(10), np.zeros(10))
+        assert chi2 == 0.
+
+    def test_return_dof_tuple(self):
+        flux = np.ones(20)
+        ivar = np.ones(20)
+        result = self._call(self._lm(3), flux, ivar, flux, return_dof=True)
+        assert len(result) == 3
+        chi2, dof, nfree = result
+        assert nfree == 3
+        assert dof == 17
+        assert chi2 == 0.
+
+    def test_nfree_patches_reduces_dof(self):
+        """Adding nfree_patches decreases dof, increasing chi2 for the same residuals."""
+        lm    = self._lm(2)
+        flux  = np.ones(20)
+        ivar  = np.ones(20)
+        model = np.zeros(20)
+        chi2_no  = self._call(lm, flux, ivar, model)
+        chi2_yes = self._call(lm, flux, ivar, model, nfree_patches=3)
+        assert chi2_yes > chi2_no
+
+    def test_continuum_model_applied(self):
+        """continuum_model is added to emlineflux_model before computing chi2."""
+        lm   = self._lm(2)
+        flux = np.ones(20)
+        ivar = np.ones(20)
+        chi2 = self._call(lm, flux, ivar, np.zeros(20),
+                          continuum_model=np.ones(20))
+        assert chi2 == 0.
+
+    def test_zero_ivar_pixels_excluded(self):
+        """Pixels with ivar=0 do not count toward dof or chi2."""
+        lm   = self._lm(2)
+        n    = 20
+        flux = np.ones(n)
+        # Half the pixels masked; same residuals → fewer good pixels
+        ivar_full = np.ones(n)
+        ivar_half = np.zeros(n)
+        ivar_half[:n//2] = 1.
+        model = np.zeros(n)
+        _, dof_full, _ = self._call(lm, flux, ivar_full, model, return_dof=True)
+        _, dof_half, _ = self._call(lm, flux, ivar_half, model, return_dof=True)
+        assert dof_half < dof_full
+
+
+# ── build_coadded_models ──────────────────────────────────────────────────────
+
+class TestBuildCoaddedModels:
+
+    @pytest.fixture
+    def inputs(self):
+        dwave = 0.8
+        n = 200
+        wave = 3600. + dwave * np.arange(n)
+        data = {'coadd_wave': wave}
+        emlinewave        = wave.copy()
+        emlineflux_model  = np.ones(n)
+        continuum_flux    = np.full(n, 2.)
+        smooth_continuum  = np.full(n, 0.5)
+        return data, emlinewave, emlineflux_model, continuum_flux, smooth_continuum
+
+    def test_returns_four_values(self, inputs):
+        from fastspecfit.emlines import build_coadded_models
+        assert len(build_coadded_models(*inputs)) == 4
+
+    def test_output_arrays_same_length(self, inputs):
+        from fastspecfit.emlines import build_coadded_models
+        wave_out, cont_out, emline_out, _ = build_coadded_models(*inputs)
+        assert len(wave_out) == len(cont_out) == len(emline_out)
+
+    def test_wave_spacing_preserved(self, inputs):
+        from fastspecfit.emlines import build_coadded_models
+        dwave_in = inputs[0]['coadd_wave'][1] - inputs[0]['coadd_wave'][0]
+        wave_out, *_ = build_coadded_models(*inputs)
+        assert np.allclose(np.diff(wave_out), dwave_in, rtol=1e-3)
+
+    def test_spectra_table_columns(self, inputs):
+        from fastspecfit.emlines import build_coadded_models
+        _, _, _, spectra = build_coadded_models(*inputs)
+        for col in ('CONTINUUM', 'SMOOTHCONTINUUM', 'EMLINEMODEL'):
+            assert col in spectra.colnames
+
+    def test_spectra_table_has_wcs_meta(self, inputs):
+        from fastspecfit.emlines import build_coadded_models
+        _, _, _, spectra = build_coadded_models(*inputs)
+        for key in ('CRVAL1', 'CDELT1', 'NAXIS1'):
+            assert key in spectra.meta
+
+    def test_flat_continuum_interpolated_correctly(self, inputs):
+        """Flat continuum_flux=2 should interpolate to ~2 on the output grid."""
+        from fastspecfit.emlines import build_coadded_models
+        _, cont_out, _, _ = build_coadded_models(*inputs)
+        assert np.allclose(cont_out, 2., atol=1e-4)

--- a/py/fastspecfit/test/test_io.py
+++ b/py/fastspecfit/test/test_io.py
@@ -1,0 +1,234 @@
+"""
+fastspecfit.test.test_io
+========================
+Unit tests for pure, file-I/O-free functions in io.py:
+  - select()         — filter metadata/specphot tables by healpix / tile / night
+  - get_qa_filename() — build QA PNG filenames from metadata
+
+The heavy I/O methods (DESISpectra.read, write_fastspecfit, etc.) are
+covered by the integration tests in test_fastspecfit.py.
+"""
+import numpy as np
+import pytest
+from astropy.table import Table
+
+
+# ── shared fixtures ───────────────────────────────────────────────────────────
+
+@pytest.fixture(scope='module')
+def healpix_tables():
+    """Small metadata + specphot Tables with healpix-coadd columns."""
+    meta = Table({
+        'TARGETID': np.array([1, 2, 3, 4, 5]),
+        'HEALPIX':  np.array([100, 200, 100, 300, 200]),
+        'SURVEY':   ['main', 'main', 'sv3', 'main', 'sv3'],
+        'PROGRAM':  ['bright', 'dark', 'bright', 'dark', 'bright'],
+    })
+    specphot = Table({'FLUX': np.ones(5)})
+    return meta, specphot
+
+
+@pytest.fixture(scope='module')
+def tile_tables():
+    """Small metadata + specphot Tables with tile-coadd columns."""
+    meta = Table({
+        'TARGETID': np.array([10, 20, 30, 40]),
+        'TILEID':   np.array([1000, 1000, 2000, 2000]),
+        'NIGHT':    np.array([20230101, 20230101, 20230202, 20230303]),
+    })
+    specphot = Table({'FLUX': np.ones(4)})
+    return meta, specphot
+
+
+@pytest.fixture(scope='module')
+def healpix_row():
+    """Single astropy Row with healpix columns for get_qa_filename tests."""
+    t = Table({
+        'SURVEY':   ['main'],
+        'PROGRAM':  ['bright'],
+        'HEALPIX':  [42],
+        'TARGETID': [999],
+    })
+    return t[0]
+
+
+@pytest.fixture(scope='module')
+def tile_row():
+    """Single astropy Row with tile/night columns."""
+    t = Table({
+        'TILEID':   [1234],
+        'NIGHT':    [20230101],
+        'EXPID':    [56789],
+        'TARGETID': [888],
+    })
+    return t[0]
+
+
+@pytest.fixture(scope='module')
+def stacked_row():
+    """Single astropy Row with STACKID column."""
+    t = Table({'STACKID': [7]})
+    return t[0]
+
+
+# ── select: healpix mode ──────────────────────────────────────────────────────
+
+class TestSelectHealpix:
+
+    def _call(self, meta, specphot, **kwargs):
+        from fastspecfit.io import select
+        return select(meta, specphot, coadd_type='healpix', **kwargs)
+
+    def test_no_filter_keeps_all(self, healpix_tables):
+        meta, sp = healpix_tables
+        out_meta, out_sp, out_ff = self._call(meta, sp)
+        assert len(out_meta) == len(meta)
+
+    def test_single_healpixel_filter(self, healpix_tables):
+        meta, sp = healpix_tables
+        out_meta, out_sp, _ = self._call(meta, sp, healpixels=['100'])
+        assert len(out_meta) == 2
+        assert np.all(out_meta['HEALPIX'] == 100)
+
+    def test_multiple_healpixels(self, healpix_tables):
+        meta, sp = healpix_tables
+        out_meta, out_sp, _ = self._call(meta, sp, healpixels=['100', '300'])
+        assert len(out_meta) == 3
+        assert set(out_meta['HEALPIX'].tolist()) == {100, 300}
+
+    def test_nonexistent_healpixel_returns_empty(self, healpix_tables):
+        meta, sp = healpix_tables
+        out_meta, out_sp, _ = self._call(meta, sp, healpixels=['9999'])
+        assert len(out_meta) == 0
+
+    def test_return_index_gives_array(self, healpix_tables):
+        meta, sp = healpix_tables
+        idx = self._call(meta, sp, healpixels=['200'], return_index=True)
+        assert isinstance(idx, np.ndarray)
+        assert np.all(meta['HEALPIX'][idx] == 200)
+
+    def test_fastfit_filtered_in_sync(self, healpix_tables):
+        meta, sp = healpix_tables
+        fastfit = Table({'VAL': np.arange(len(meta))})
+        out_meta, out_sp, out_ff = self._call(meta, sp, fastfit=fastfit,
+                                              healpixels=['100'])
+        assert len(out_ff) == len(out_meta)
+
+    def test_specphot_filtered_in_sync(self, healpix_tables):
+        meta, sp = healpix_tables
+        out_meta, out_sp, _ = self._call(meta, sp, healpixels=['300'])
+        assert len(out_sp) == len(out_meta)
+
+
+# ── select: tile mode ─────────────────────────────────────────────────────────
+
+class TestSelectTile:
+
+    def _call(self, meta, specphot, **kwargs):
+        from fastspecfit.io import select
+        return select(meta, specphot, coadd_type='cumulative', **kwargs)
+
+    def test_no_filter_keeps_all(self, tile_tables):
+        meta, sp = tile_tables
+        out_meta, out_sp, _ = self._call(meta, sp)
+        assert len(out_meta) == len(meta)
+
+    def test_tile_filter_only(self, tile_tables):
+        meta, sp = tile_tables
+        out_meta, _, _ = self._call(meta, sp, tiles=['1000'])
+        assert len(out_meta) == 2
+        assert np.all(out_meta['TILEID'] == 1000)
+
+    def test_night_filter_only(self, tile_tables):
+        meta, sp = tile_tables
+        out_meta, _, _ = self._call(meta, sp, nights=['20230101'])
+        assert len(out_meta) == 2
+        assert np.all(out_meta['NIGHT'] == 20230101)
+
+    def test_tile_and_night_filter(self, tile_tables):
+        meta, sp = tile_tables
+        out_meta, _, _ = self._call(meta, sp, tiles=['1000'], nights=['20230101'])
+        assert len(out_meta) == 2
+
+    def test_tile_and_night_no_intersection(self, tile_tables):
+        """Tile 2000 + night 20230101 don't overlap → empty result."""
+        meta, sp = tile_tables
+        out_meta, _, _ = self._call(meta, sp, tiles=['2000'], nights=['20230101'])
+        assert len(out_meta) == 0
+
+    def test_return_index_tile_filter(self, tile_tables):
+        meta, sp = tile_tables
+        idx = self._call(meta, sp, tiles=['2000'], return_index=True)
+        assert np.all(meta['TILEID'][idx] == 2000)
+
+
+# ── get_qa_filename ───────────────────────────────────────────────────────────
+
+class TestGetQaFilename:
+
+    def _call(self, metadata, coadd_type, **kwargs):
+        from fastspecfit.io import get_qa_filename
+        return get_qa_filename(metadata, coadd_type, **kwargs)
+
+    def test_healpix_default_prefix(self, healpix_row):
+        fn = self._call(healpix_row, 'healpix')
+        assert fn.endswith('.png')
+        assert 'fastspec' in fn
+        assert 'main' in fn
+        assert 'bright' in fn
+        assert '42' in fn
+        assert '999' in fn
+
+    def test_custom_coadd_type_same_as_healpix(self, healpix_row):
+        fn_hp  = self._call(healpix_row, 'healpix')
+        fn_cus = self._call(healpix_row, 'custom')
+        assert fn_hp == fn_cus
+
+    def test_fastphot_prefix(self, healpix_row):
+        fn = self._call(healpix_row, 'healpix', fastphot=True)
+        assert fn.startswith('./fastphot')
+
+    def test_custom_outprefix(self, healpix_row):
+        fn = self._call(healpix_row, 'healpix', outprefix='myprefix')
+        assert 'myprefix' in fn
+
+    def test_custom_outdir(self, healpix_row, tmp_path):
+        fn = self._call(healpix_row, 'healpix', outdir=str(tmp_path))
+        assert fn.startswith(str(tmp_path))
+
+    def test_cumulative(self, tile_row):
+        fn = self._call(tile_row, 'cumulative')
+        assert 'cumulative' in fn
+        assert '1234' in fn
+        assert '888' in fn
+
+    def test_pernight(self, tile_row):
+        fn = self._call(tile_row, 'pernight')
+        assert '20230101' in fn
+        assert '888' in fn
+
+    def test_perexp(self, tile_row):
+        fn = self._call(tile_row, 'perexp')
+        assert '56789' in fn
+        assert '888' in fn
+
+    def test_stacked(self, stacked_row):
+        fn = self._call(stacked_row, 'stacked')
+        assert 'stacked' in fn
+        assert '7' in fn
+
+    def test_unknown_coadd_type_raises(self, healpix_row):
+        with pytest.raises(ValueError):
+            self._call(healpix_row, 'bogus_type')
+
+    def test_table_input_returns_list(self, healpix_row):
+        """Passing a multi-row Table returns a list of filenames."""
+        t = Table({
+            'SURVEY':   ['main', 'sv3'],
+            'PROGRAM':  ['dark', 'bright'],
+            'HEALPIX':  [10, 20],
+            'TARGETID': [1, 2],
+        })
+        result = self._call(t, 'healpix')
+        assert isinstance(result, list)
+        assert len(result) == 2

--- a/py/fastspecfit/test/test_linemasker.py
+++ b/py/fastspecfit/test/test_linemasker.py
@@ -1,0 +1,143 @@
+"""
+fastspecfit.test.test_linemasker
+=================================
+Unit tests for LineMasker.linepix_and_contpix in linemasker.py.
+
+build_linemask is not tested here: it requires a fully initialized
+EMFitTools instance and resolution matrices, and is covered indirectly
+by the integration tests in test_fastspecfit.py.
+"""
+import numpy as np
+import pytest
+from astropy.table import Table
+
+from fastspecfit.util import C_LIGHT
+
+
+# ── shared fixtures ───────────────────────────────────────────────────────────
+
+@pytest.fixture(scope='module')
+def wave():
+    """Observed-frame wavelength grid from 4000 to 8000 Å (3000 pixels)."""
+    return np.linspace(4000., 8000., 3000)
+
+
+@pytest.fixture(scope='module')
+def ivar(wave):
+    return np.ones_like(wave)
+
+
+@pytest.fixture(scope='module')
+def linetable():
+    """Minimal emission-line table with a single OIII 5007 line."""
+    return Table({'name': ['oiii_5007'], 'restwave': [5007.0]})
+
+
+@pytest.fixture(scope='module')
+def linesigmas():
+    return np.array([150.])  # km/s
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _call(wave, ivar, linetable, linesigmas, **kwargs):
+    """Thin wrapper so each test passes a fresh copy of linesigmas."""
+    from fastspecfit.linemasker import LineMasker
+    return LineMasker.linepix_and_contpix(
+        wave, ivar, linetable, linesigmas.copy(), **kwargs)
+
+
+# ── linepix_and_contpix tests ─────────────────────────────────────────────────
+
+class TestLinepixAndContpix:
+
+    def test_linepix_contains_line_center(self, wave, ivar, linetable, linesigmas):
+        """Pixels bracketing the line rest wavelength should be in linepix."""
+        pix = _call(wave, ivar, linetable, linesigmas, redshift=0.)
+        assert 'oiii_5007' in pix['linepix']
+        lpix = pix['linepix']['oiii_5007']
+        assert len(lpix) > 0
+        # The observed wavelength of the line center should be bracketed.
+        line_wave = 5007.
+        assert wave[lpix[0]] <= line_wave <= wave[lpix[-1]]
+
+    def test_contpix_does_not_overlap_linepix(self, wave, ivar, linetable, linesigmas):
+        pix = _call(wave, ivar, linetable, linesigmas, redshift=0.)
+        lpix = set(pix['linepix']['oiii_5007'].tolist())
+        cpix = set(pix['contpix']['oiii_5007'].tolist())
+        assert lpix.isdisjoint(cpix)
+
+    def test_keys_match(self, wave, ivar, linetable, linesigmas):
+        """linepix and contpix must have the same set of line names."""
+        pix = _call(wave, ivar, linetable, linesigmas, redshift=0.)
+        assert pix['linepix'].keys() == pix['contpix'].keys()
+
+    def test_linepix_absent_for_out_of_range_line(self, ivar, linesigmas):
+        """A line outside the wavelength range should not appear in linepix."""
+        wave_short = np.linspace(4000., 6000., 1000)
+        ivar_short = np.ones_like(wave_short)
+        far_table  = Table({'name': ['oiii_5007'], 'restwave': [9000.]})
+        pix = _call(wave_short, ivar_short, far_table, linesigmas, redshift=0.,
+                    get_contpix=False)
+        assert 'oiii_5007' not in pix['linepix']
+
+    def test_zero_ivar_excluded_from_linepix(self, wave, linetable, linesigmas):
+        """Pixels with ivar == 0 must not appear in linepix."""
+        ivar_masked = np.ones_like(wave)
+        # Mask pixels right at the line center.
+        center_idx = np.argmin(np.abs(wave - 5007.))
+        ivar_masked[center_idx - 2 : center_idx + 3] = 0.
+        pix = _call(wave, ivar_masked, linetable, linesigmas, redshift=0.,
+                    get_contpix=False)
+        if 'oiii_5007' in pix['linepix']:
+            masked_indices = np.where(ivar_masked == 0.)[0]
+            assert len(np.intersect1d(pix['linepix']['oiii_5007'],
+                                      masked_indices)) == 0
+
+    def test_get_contpix_false_returns_empty_contpix(self, wave, ivar,
+                                                      linetable, linesigmas):
+        pix = _call(wave, ivar, linetable, linesigmas, redshift=0.,
+                    get_contpix=False)
+        assert len(pix['contpix']) == 0
+
+    def test_positive_vshift_moves_linepix_redward(self, wave, ivar,
+                                                    linetable, linesigmas):
+        """A positive velocity shift should move the line mask to higher wavelength."""
+        pix0 = _call(wave, ivar, linetable, linesigmas, redshift=0.,
+                     linevshifts=np.array([0.]), get_contpix=False)
+        pix1 = _call(wave, ivar, linetable, linesigmas, redshift=0.,
+                     linevshifts=np.array([2000.]), get_contpix=False)
+        center0 = np.mean(wave[pix0['linepix']['oiii_5007']])
+        center1 = np.mean(wave[pix1['linepix']['oiii_5007']])
+        assert center1 > center0
+
+    def test_linevshifts_length_mismatch_raises(self, wave, ivar,
+                                                 linetable, linesigmas):
+        """linevshifts with a different length than linesigmas should raise ValueError."""
+        from fastspecfit.linemasker import LineMasker
+        with pytest.raises(ValueError, match='Mismatch'):
+            LineMasker.linepix_and_contpix(
+                wave, ivar, linetable, linesigmas.copy(),
+                linevshifts=np.array([0., 0.]),  # wrong length
+                get_contpix=False)
+
+    def test_get_snr_adds_keys(self, wave, ivar, linetable, linesigmas):
+        """get_snr=True should add snr, amp, clocal, cnoise to the result."""
+        rng = np.random.default_rng(7)
+        flux      = np.ones_like(wave) + 0.1 * rng.standard_normal(len(wave))
+        residuals = 0.1 * rng.standard_normal(len(wave))
+        pix = _call(wave, ivar, linetable, linesigmas, redshift=0.,
+                    flux=flux, residuals=residuals, get_snr=True)
+        assert 'oiii_5007' in pix['linepix']
+        for key in ('snr', 'amp', 'clocal', 'cnoise'):
+            assert 'oiii_5007' in pix[key]
+
+    def test_redshift_moves_linepix(self, wave, ivar, linetable, linesigmas):
+        """Nonzero redshift should shift linepix to longer wavelengths."""
+        pix0 = _call(wave, ivar, linetable, linesigmas, redshift=0.,
+                     get_contpix=False)
+        pix1 = _call(wave, ivar, linetable, linesigmas, redshift=0.1,
+                     get_contpix=False)
+        center0 = np.mean(wave[pix0['linepix']['oiii_5007']])
+        center1 = np.mean(wave[pix1['linepix']['oiii_5007']])
+        assert center1 > center0

--- a/py/fastspecfit/test/test_resolution.py
+++ b/py/fastspecfit/test/test_resolution.py
@@ -1,0 +1,136 @@
+"""
+fastspecfit.test.test_resolution
+=================================
+Unit tests for the DESI resolution matrix handling in resolution.py.
+"""
+import numpy as np
+import pytest
+
+
+# ── shared fixtures ───────────────────────────────────────────────────────────
+
+@pytest.fixture(scope='module')
+def diag_matrix():
+    """Synthetic normalized Gaussian band matrix in DESI diagonal-storage format."""
+    ndiag, npix = 11, 100
+    w2 = ndiag // 2
+    D = np.zeros((ndiag, npix))
+    for i in range(ndiag):
+        k = w2 - i
+        D[i, :] = np.exp(-0.5 * k**2 / 2.0**2)
+    D /= D.sum(axis=0, keepdims=True)
+    return D
+
+
+@pytest.fixture(scope='module')
+def res(diag_matrix):
+    from fastspecfit.resolution import Resolution
+    return Resolution(diag_matrix)
+
+
+# ── _mat_torows / _mat_tocolumns ──────────────────────────────────────────────
+
+class TestDiagConversions:
+
+    def test_torows_shape_preserved(self, diag_matrix):
+        from fastspecfit.resolution import _mat_torows
+        result = _mat_torows(diag_matrix)
+        assert result.shape == diag_matrix.shape
+
+    def test_tocolumns_shape_preserved(self, diag_matrix):
+        from fastspecfit.resolution import _mat_tocolumns
+        result = _mat_tocolumns(diag_matrix)
+        assert result.shape == diag_matrix.shape
+
+    def test_torows_involution(self, diag_matrix):
+        """_mat_torows applied twice is the identity (it is its own inverse)."""
+        from fastspecfit.resolution import _mat_torows
+        assert np.allclose(_mat_torows(_mat_torows(diag_matrix)), diag_matrix)
+
+    def test_torows_preserves_center_diagonal(self, diag_matrix):
+        from fastspecfit.resolution import _mat_torows
+        w2 = diag_matrix.shape[0] // 2
+        result = _mat_torows(diag_matrix)
+        assert np.allclose(result[w2, :], diag_matrix[w2, :])
+
+    def test_tocolumns_preserves_center_diagonal(self, diag_matrix):
+        from fastspecfit.resolution import _mat_tocolumns
+        w2 = diag_matrix.shape[0] // 2
+        result = _mat_tocolumns(diag_matrix)
+        assert np.allclose(result[w2, :], diag_matrix[w2, :])
+
+
+# ── deconvolve_resolution_matrix ──────────────────────────────────────────────
+
+class TestDeconvolve:
+
+    def test_output_shape(self, diag_matrix):
+        from fastspecfit.resolution import deconvolve_resolution_matrix
+        W = deconvolve_resolution_matrix(diag_matrix)
+        assert W.shape == diag_matrix.shape
+
+    def test_nonstandard_width_uses_fallback(self):
+        """Width != 11 triggers the non-cached solve path."""
+        from fastspecfit.resolution import deconvolve_resolution_matrix
+        ndiag, npix = 7, 80
+        w2 = ndiag // 2
+        D = np.zeros((ndiag, npix))
+        for i in range(ndiag):
+            k = w2 - i
+            D[i, :] = np.exp(-0.5 * k**2 / 2.0**2)
+        D /= D.sum(axis=0, keepdims=True)
+        W = deconvolve_resolution_matrix(D)
+        assert W.shape == (ndiag, npix)
+
+
+# ── Resolution class ──────────────────────────────────────────────────────────
+
+class TestResolution:
+
+    def test_shape(self, diag_matrix, res):
+        npix = diag_matrix.shape[1]
+        assert res.shape == (npix, npix)
+
+    def test_ndiag(self, diag_matrix, res):
+        assert res.ndiag == diag_matrix.shape[0]
+
+    def test_dot_output_shape(self, res):
+        npix = res.shape[0]
+        v = np.ones(npix)
+        assert res.dot(v).shape == (npix,)
+
+    def test_dot_out_parameter(self, res):
+        npix = res.shape[0]
+        v   = np.ones(npix)
+        out = np.empty(npix)
+        result = res.dot(v, out=out)
+        assert result is out
+        assert np.allclose(result, res.dot(v))
+
+    def test_dot_linearity(self, res):
+        """dot(a * v) == a * dot(v)."""
+        rng  = np.random.default_rng(42)
+        v    = rng.standard_normal(res.shape[0])
+        a    = 3.7
+        assert np.allclose(res.dot(a * v), a * res.dot(v))
+
+    def test_dot_additivity(self, res):
+        """dot(v1 + v2) == dot(v1) + dot(v2)."""
+        rng = np.random.default_rng(0)
+        v1  = rng.standard_normal(res.shape[0])
+        v2  = rng.standard_normal(res.shape[0])
+        assert np.allclose(res.dot(v1 + v2), res.dot(v1) + res.dot(v2))
+
+    def test_dot_zero_vector(self, res):
+        v = np.zeros(res.shape[0])
+        assert np.all(res.dot(v) == 0.)
+
+    def test_rowdata_shape(self, res):
+        rows = res.rowdata()
+        assert rows.shape == (res.shape[0], res.ndiag)
+
+    def test_rowdata_cached(self, res):
+        """rowdata() returns the same object on repeated calls."""
+        r1 = res.rowdata()
+        r2 = res.rowdata()
+        assert r1 is r2

--- a/py/fastspecfit/test/test_templates.py
+++ b/py/fastspecfit/test/test_templates.py
@@ -8,9 +8,9 @@ import os
 
 # See conftest.py for fixtures used by multiple unit tests.
 
-def test_templates_nofilename(outdir, template_version, templates):
+def test_templates_nofilename(templatedir, template_version, templates):
     from fastspecfit.templates import Templates
-    os.environ['FTEMPLATES_DIR'] = str(outdir)
+    os.environ['FTEMPLATES_DIR'] = str(templatedir.parent)
     temp = Templates()
     assert(os.path.isfile(temp.file))
 


### PR DESCRIPTION
## Summary

- Caches the ~100 MB template download in CI using `actions/cache@v4` (keyed on template version + OS), cutting repeated download time on subsequent pushes
- Adds `FTEMPLATES_CACHE_DIR` support in `conftest.py` so the cached path is used when set
- Adds unit test files for five previously untested modules:
  - `test_emline_fit.py` — `norm_cdf/pdf`, `max_buffer_width`, `emline_model`, `ParamsMapping`, `emline_model_jacobian` (numerical + analytical)
  - `test_resolution.py` — diagonal storage conversions, `deconvolve_resolution_matrix`, `Resolution` dot/rowdata
  - `test_linemasker.py` — `LineMasker.linepix_and_contpix` across all keyword paths
  - `test_continuum.py` — `can_compute_vdisp`, `_younger_than_universe`, `attenuate`, `attenuate_nodust`, `stellar_continuum_chi2`, `smooth_continuum`
  - `test_emlines.py` — `ParamType`, `EMFitTools` init/`compute_inrange_lines`/`build_linemodels`, `chi2`, `build_coadded_models`
  - `test_io.py` — `select()` (healpix and tile modes) and `get_qa_filename()` (all six `coadd_type` variants)
- Streamlines the CI matrix: `tests` job now covers 3.10, 3.12, 3.14 (drops redundant 3.11/3.13, adds 3.14, switches to `fail-fast: false`); `coverage` job reduced to a single Python version (3.12)

## Test plan

- [ ] CI passes on all three Python versions (3.10, 3.12, 3.14)
- [ ] Template cache is populated on first run and reused on subsequent pushes
- [ ] Coverage job reports to Coveralls on 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)