### PR TITLE
Bug fixes: IGM integer input (#230) and FIBERFLUX extinction correction (#237)

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,10 @@ Change Log
 3.3.0 (not released yet)
 ------------------------
 
+* Fix ``Inoue14.full_IGM`` returning all-ones when ``lobs`` is an integer
+  array; fix MW extinction correction not applied to ``FIBERFLUX`` and
+  ``FIBERTOTFLUX`` in the output metadata table; fix ``FIBERTOTFLUX`` writeback
+  in ``fastspec_one`` using wrong data source [`PR #249`_].
 * Overhaul documentation: replace ``sphinx-toolbox`` with ``sphinx-design``;
   remove stale ``Sphinx<8.2`` pin; expand API docs to include
   ``fastspecfit.emline_fit`` subpackage; rewrite ``install.rst`` with
@@ -25,6 +29,7 @@ Change Log
 * Deconvolve the resolution matrix before fitting, as recommended
   by S. Koposov and update config files [`PR #244`_].
 
+.. _`PR #249`: https://github.com/desihub/fastspecfit/pull/249
 .. _`PR #248`: https://github.com/desihub/fastspecfit/pull/248
 .. _`PR #247`: https://github.com/desihub/fastspecfit/pull/247
 .. _`PR #246`: https://github.com/desihub/fastspecfit/pull/246

--- a/doc/fastphot.rst
+++ b/doc/fastphot.rst
@@ -304,14 +304,14 @@ ABSMAG00_SYNTH_IVAR_TWOMASS_J      float32                      1 / mag2 Inverse
              LOGLNU_1500_IVAR      float32           1e+56 Hz2 s2 / erg2 Inverse variance in LOGLNU_1500.
                   LOGLNU_2800      float32            1e-28 erg / (Hz s) Monochromatic luminosity at 2800 A in the rest-frame.
              LOGLNU_2800_IVAR      float32           1e+56 Hz2 s2 / erg2 Inverse variance in LOGLNU_2800.
-                    LOGL_1450      float32                    1e-10 Lsun Integrated luminosity at 1450 A in the rest-frame.
-               LOGL_1450_IVAR      float32                 1e+20 / Lsun2 Inverse variance in LOGL_1450.
-                    LOGL_1700      float32                    1e-10 Lsun Integrated luminosity at 1700 A in the rest-frame.
-               LOGL_1700_IVAR      float32                 1e+20 / Lsun2 Inverse variance in LOGL_1700.
-                    LOGL_3000      float32                    1e-10 Lsun Integrated luminosity at 3000 A in the rest-frame.
-               LOGL_3000_IVAR      float32                 1e+20 / Lsun2 Inverse variance in LOGL_3000.
-                    LOGL_5100      float32                    1e-10 Lsun Integrated luminosity at 5100 A in the rest-frame.
-               LOGL_5100_IVAR      float32                 1e+20 / Lsun2 Inverse variance in LOGL_5100.
+                    LOGL_1450      float32                     1e10 Lsun Integrated luminosity at 1450 A in the rest-frame.
+               LOGL_1450_IVAR      float32                 1e-20 / Lsun2 Inverse variance in LOGL_1450.
+                    LOGL_1700      float32                     1e10 Lsun Integrated luminosity at 1700 A in the rest-frame.
+               LOGL_1700_IVAR      float32                 1e-20 / Lsun2 Inverse variance in LOGL_1700.
+                    LOGL_3000      float32                     1e10 Lsun Integrated luminosity at 3000 A in the rest-frame.
+               LOGL_3000_IVAR      float32                 1e-20 / Lsun2 Inverse variance in LOGL_3000.
+                    LOGL_5100      float32                     1e10 Lsun Integrated luminosity at 5100 A in the rest-frame.
+               LOGL_5100_IVAR      float32                 1e-20 / Lsun2 Inverse variance in LOGL_5100.
                FLYA_1215_CONT      float32  1e-17 erg / (Angstrom cm2 s) Continuum flux at 1215.67 A in the rest-frame.
           FLYA_1215_CONT_IVAR      float32 1e+34 cm4 Angstrom2 s2 / erg2 Inverse variance in FLYA_1215_CONT.
                FOII_3727_CONT      float32  1e-17 erg / (Angstrom cm2 s) Continuum flux at 3728.483 A in the rest-frame.

--- a/doc/fastspec.rst
+++ b/doc/fastspec.rst
@@ -311,14 +311,14 @@ ABSMAG00_SYNTH_IVAR_TWOMASS_J      float32                      1 / mag2 Inverse
              LOGLNU_1500_IVAR      float32           1e+56 Hz2 s2 / erg2 Inverse variance in LOGLNU_1500.
                   LOGLNU_2800      float32            1e-28 erg / (Hz s) Monochromatic luminosity at 2800 A in the rest-frame.
              LOGLNU_2800_IVAR      float32           1e+56 Hz2 s2 / erg2 Inverse variance in LOGLNU_2800.
-                    LOGL_1450      float32                    1e-10 Lsun Integrated luminosity at 1450 A in the rest-frame.
-               LOGL_1450_IVAR      float32                 1e+20 / Lsun2 Inverse variance in LOGL_1450.
-                    LOGL_1700      float32                    1e-10 Lsun Integrated luminosity at 1700 A in the rest-frame.
-               LOGL_1700_IVAR      float32                 1e+20 / Lsun2 Inverse variance in LOGL_1700.
-                    LOGL_3000      float32                    1e-10 Lsun Integrated luminosity at 3000 A in the rest-frame.
-               LOGL_3000_IVAR      float32                 1e+20 / Lsun2 Inverse variance in LOGL_3000.
-                    LOGL_5100      float32                    1e-10 Lsun Integrated luminosity at 5100 A in the rest-frame.
-               LOGL_5100_IVAR      float32                 1e+20 / Lsun2 Inverse variance in LOGL_5100.
+                    LOGL_1450      float32                     1e10 Lsun Integrated luminosity at 1450 A in the rest-frame.
+               LOGL_1450_IVAR      float32                 1e-20 / Lsun2 Inverse variance in LOGL_1450.
+                    LOGL_1700      float32                     1e10 Lsun Integrated luminosity at 1700 A in the rest-frame.
+               LOGL_1700_IVAR      float32                 1e-20 / Lsun2 Inverse variance in LOGL_1700.
+                    LOGL_3000      float32                     1e10 Lsun Integrated luminosity at 3000 A in the rest-frame.
+               LOGL_3000_IVAR      float32                 1e-20 / Lsun2 Inverse variance in LOGL_3000.
+                    LOGL_5100      float32                     1e10 Lsun Integrated luminosity at 5100 A in the rest-frame.
+               LOGL_5100_IVAR      float32                 1e-20 / Lsun2 Inverse variance in LOGL_5100.
                FLYA_1215_CONT      float32  1e-17 erg / (Angstrom cm2 s) Continuum flux at 1215.67 A in the rest-frame.
           FLYA_1215_CONT_IVAR      float32 1e+34 cm4 Angstrom2 s2 / erg2 Inverse variance in FLYA_1215_CONT.
                FOII_3727_CONT      float32  1e-17 erg / (Angstrom cm2 s) Continuum flux at 3728.483 A in the rest-frame.

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -169,8 +169,10 @@ def fastspec_one(iobj, data, meta, fastfit_dtype, specphot_dtype, broadlinefit=T
             meta[f'FLUX_IVAR_{band.upper()}'] = fluxivar[iband]
 
         if hasattr(phot, 'fiber_bands'):
-            fibertotflux = data['fiberphot']['nanomaggies']
+            fiberflux = data['fiberphot']['nanomaggies']
+            fibertotflux = data['fibertotphot']['nanomaggies']
             for iband, band in enumerate(phot.fiber_bands):
+                meta[f'FIBERFLUX_{band.upper()}'] = fiberflux[iband]
                 meta[f'FIBERTOTFLUX_{band.upper()}'] = fibertotflux[iband]
 
     # output structures

--- a/py/fastspecfit/igm.py
+++ b/py/fastspecfit/igm.py
@@ -82,6 +82,8 @@ class Inoue14(object):
             IGM transmission :math:`e^{-\tau}` at each wavelength.
 
         """
+        if np.issubdtype(np.asarray(lobs).dtype, np.integer):
+            lobs = np.asarray(lobs, dtype=np.float64)
         return self._full_IGM(z, lobs,
                               self.scale_tau,
                               self.igm_params)

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -126,12 +126,10 @@ def one_spectrum(specdata, meta, uncertainty_floor=0.01, RV=3.1,
         nanomaggies=True, lambda_eff=filters.effective_wavelengths.value,
         min_uncertainty=phot.min_uncertainty)
 
-    # Optionally add the fiber photometry; note that the transmission
-    # factors were computed in DESISpectra.read.
+    # Optionally add the fiber photometry; MW extinction correction already
+    # applied in-place to meta by DESISpectra.read.
     if hasattr(phot, 'fiber_filters'):
         fiber_filters = phot.fiber_filters[specdata['photsys']]
-
-        mw_transmission_fiberflux = specdata['mw_transmission_fiberflux']
 
         fibermaggies = np.zeros(len(phot.fiber_bands))
         fibertotmaggies = np.zeros(len(phot.fiber_bands))
@@ -139,8 +137,8 @@ def one_spectrum(specdata, meta, uncertainty_floor=0.01, RV=3.1,
 
         for iband, band in enumerate(phot.fiber_bands):
             band = band.upper()
-            fibermaggies[iband] = meta[f'FIBERFLUX_{band}'] / mw_transmission_fiberflux[iband]
-            fibertotmaggies[iband] = meta[f'FIBERTOTFLUX_{band}'] / mw_transmission_fiberflux[iband]
+            fibermaggies[iband] = meta[f'FIBERFLUX_{band}']
+            fibertotmaggies[iband] = meta[f'FIBERTOTFLUX_{band}']
 
         lambda_eff=fiber_filters.effective_wavelengths.value
         specdata['fiberphot'] = Photometry.parse_photometry(phot.fiber_bands,
@@ -1105,6 +1103,11 @@ class DESISpectra(object):
                 else:
                     mw_transmission_fiberflux = None
 
+            if mw_transmission_fiberflux is not None:
+                for iband, band in enumerate(photometry.fiber_bands):
+                    meta[f'FIBERFLUX_{band.upper()}'] /= mw_transmission_fiberflux[:, iband]
+                    meta[f'FIBERTOTFLUX_{band.upper()}'] /= mw_transmission_fiberflux[:, iband]
+
             if fastphot:
                 for iobj in range(nobj):
                     specdata = {
@@ -1115,8 +1118,6 @@ class DESISpectra(object):
                         'dmodulus': dmod[iobj],
                         'tuniv': tuniv[iobj],
                         }
-                    if mw_transmission_fiberflux is not None:
-                        specdata.update({'mw_transmission_fiberflux': mw_transmission_fiberflux[iobj, :]})
                     alldata.append(specdata)
             else:
                 # Don't use .select since meta and spec can be sorted
@@ -1159,9 +1160,6 @@ class DESISpectra(object):
                         'coadd_ivar': coadd_spec.ivar[coadd_cams][iobj, :],
                         'coadd_res': [Resolution(coadd_spec.resolution_data[coadd_cams][iobj, :])],
                     }
-                    if mw_transmission_fiberflux is not None:
-                        specdata.update({'mw_transmission_fiberflux': mw_transmission_fiberflux[iobj, :]})
-
                     alldata.append(specdata)
 
             allmeta.append(meta)


### PR DESCRIPTION
## Summary

- Fix `Inoue14.full_IGM` returning all-ones when `lobs` is an integer array (closes #230)
- Apply MW extinction correction to `FIBERFLUX`/`FIBERTOTFLUX` in the output metadata table (closes #237)
- Fix `FIBERTOTFLUX` writeback in `fastspec_one` using wrong data source (`fiberphot` instead of `fibertotphot`); add missing `FIBERFLUX` writeback (refs #237)
- Fix documentation bug (refs #234)

## Test plan

- [ ] Verify `Inoue14.full_IGM` gives identical results for integer and float wavelength arrays
- [ ] Verify output metadata `FIBERFLUX_*` and `FIBERTOTFLUX_*` match raw imaging values divided by MW transmission factor
- [ ] Run existing test suite: `pytest py/fastspecfit/test/test_fastspecfit.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)