### PR TITLE
Fix position-dependent flux bias in emission-line fitting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Note: The main integration tests (`test_fastphot`, `test_fastspec`) download tem
 sphinx-build -W --keep-going -b html doc doc/_build/html
 ```
 
+Technical notes (LaTeX) are in `doc/technote/`. Build with `make` in that directory.
+
 ### Style check
 CI runs `flake8` with custom ignores defined in `pyproject.toml` under `[tool.flake8]`.
 
@@ -53,6 +55,7 @@ Defined in `pyproject.toml` and implemented in `py/fastspecfit/fastspecfit.py`:
 - `stackfit` — fit stacked/coadded spectra
 - `fastqa` — generate QA figures from output catalogs
 - `mpi-fastspecfit` (bin script) — MPI parallel execution across many files
+- `profile-fastspec` (bin script) — profiling tool for fastspec performance
 
 ## Architecture
 
@@ -82,11 +85,11 @@ This pattern avoids re-reading large files in multiprocessing workers.
 | `fastspecfit.py` | CLI parsing, top-level `fastspec`/`fastphot` drivers, per-object dispatch |
 | `continuum.py` | `ContinuumTools` class — stellar SED fitting against SPS templates with dust attenuation and velocity dispersion |
 | `emlines.py` | `EMFitTools` class — emission-line fitting orchestration |
-| `emline_fit/` | Numba-accelerated emission-line model, Jacobian, sparse representation, and parameter mapping |
+| `emline_fit/` | Numba-accelerated emission-line model (Gaussian point evaluation at pixel centers), Jacobian, sparse representation, and parameter mapping |
 | `io.py` | `DESISpectra` class for reading DESI spectra; output FITS writing |
 | `photometry.py` | `Photometry` class — filter curves (via speclite), photometric bands, dust reddening |
 | `templates.py` | `Templates` class — reads SPS template FITS files, manages FFT convolution caching for velocity dispersion broadening |
-| `resolution.py` | DESI resolution matrix handling; deconvolution using Koposov/rvspecfit approach |
+| `resolution.py` | DESI resolution matrix handling; deconvolution using Koposov/rvspecfit approach; defines `SIGMA0_ANGSTROM` pre-convolution Gaussian sigma |
 | `linetable.py` | Reads `data/emlines.ecsv` emission-line parameter table |
 | `igm.py` | `Inoue14` IGM attenuation (Ly-α forest) |
 | `cosmo.py` | Tabulated DESI fiducial cosmology interpolation |

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,13 @@ Change Log
 3.3.1 (not released yet)
 ------------------------
 
+* Fix position-dependent flux bias in emission-line fitting: replace the
+  Buhler per-bin CDF integration forward model with Gaussian point evaluation
+  matched to the Gaussian pre-convolution expected by the deconvolved resolution
+  matrix; switch reported line flux to the analytic formula
+  ``sqrt(2π)·A·λ*·σ/c``; update the Jacobian accordingly; remove dead
+  ``norm_cdf``/``norm_pdf`` code; extend unit tests with flux-recovery and
+  sub-pixel position-independence checks on a linear-lambda grid [`PR #252`_].
 * Performance optimizations: replace TRF continuum optimizer with Variable
   Projection (VARPRO) for all ``fit_vdisp=False`` cases; vectorize the VARPRO
   inner loop (batched phi construction, spectroscopy, and photometry); use loose
@@ -12,6 +19,7 @@ Change Log
   Carlo emission-line refits from the nominal best-fit values; add
   ``bin/profile-fastspec`` profiling harness [`PR #251`_].
 
+.. _`PR #252`: https://github.com/desihub/fastspecfit/pull/252
 .. _`PR #251`: https://github.com/desihub/fastspecfit/pull/251
 
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,7 +2,7 @@
 Change Log
 ==========
 
-3.3.1 (not released yet)
+3.4.0 (not released yet)
 ------------------------
 
 * Fix position-dependent flux bias in emission-line fitting: replace the

--- a/doc/technote/Makefile
+++ b/doc/technote/Makefile
@@ -1,0 +1,16 @@
+TEX = emline-model
+PDFS = $(TEX:%=%.pdf)
+
+LATEXMK = latexmk
+
+all: $(PDFS)
+
+%.pdf: %.tex
+	$(LATEXMK) -pdf -quiet $<
+	$(LATEXMK) -c $*
+
+clean:
+	$(LATEXMK) -C
+	rm -f $(PDFS)
+
+.PHONY: all clean

--- a/doc/technote/emline-model.tex
+++ b/doc/technote/emline-model.tex
@@ -1,0 +1,417 @@
+\documentclass[12pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage[margin=1in]{geometry}
+\usepackage{hyperref}
+\usepackage{booktabs}
+\usepackage{microtype}
+
+% ── notation shortcuts ─────────────────────────────────────────────────────────
+\newcommand{\lstar}{\lambda^{*}}
+\newcommand{\sG}{\sigma_{\mathrm{G}}}
+\newcommand{\sGl}{\sigma_{\mathrm{G},\ell}}   % sigma_G in log-lambda
+\newcommand{\seff}{\sigma_{\mathrm{eff}}}
+\newcommand{\C}{c}                             % speed of light
+\newcommand{\R}{\mathbf{R}}
+\newcommand{\W}{\mathbf{W}}
+\newcommand{\M}{\mathbf{M}}
+\newcommand{\inv}[1]{#1^{-1}}
+
+\title{FastSpecFit Emission-Line Model}
+\author{John Moustakas%
+  \thanks{Emission-line model derivations and implementation assisted by
+    Claude Code (Claude Sonnet 4.6, Anthropic).}}
+\date{\today}
+
+
+\begin{document}
+\maketitle
+%\tableofcontents
+%\bigskip
+
+\section{Introduction}
+
+This note documents the forward model used by \textsc{FastSpecFit} to
+fit emission lines in DESI galaxy spectra. The new model supersedes
+the earlier bin-integration approach developed by Jeremy Buhler
+(@jbuhler) in 2024 and used in FastSpecFit versions 3.0.0 through
+3.3.0, and reconciles it with the resolution-matrix deconvolution
+framework recommended by Sergey Koposov (@segasai).
+
+%The three topics covered are: (i)~the analytic pre-convolved Gaussian
+%profile that serves as the forward model, (ii)~how that profile is
+%coupled to the deconvolved DESI resolution matrix, and (iii)~the
+%closed-form Jacobian used by the nonlinear least-squares optimizer.
+
+
+\section{Intrinsic Emission-Line Profile}
+\label{sec:intrinsic}
+
+The intrinsic spectral profile of a single emission line is modeled as a
+log-Gaussian in observed wavelength,
+\begin{equation}
+  f(\lambda;\, A,\lstar,\sigma)
+  \;=\;
+  A \exp\!\left(-\frac{(\ln\lambda - \ln\lstar)^{2}}{2\sigma^{2}}\right),
+  \label{eq:intrinsic}
+\end{equation}
+where $A$ is the peak amplitude (in flux-density units, e.g.\
+$10^{-17}$\,erg\,s$^{-1}$\,cm$^{-2}$\,\AA$^{-1}$), $\lstar$ is the
+observed line center, and $\sigma$ is the intrinsic line width in
+log-$\lambda$ units (dimensionless).
+
+\paragraph{Line center.}
+The observed center is determined by the rest-frame wavelength
+$\lambda_{\mathrm{rest}}$, the spectroscopic redshift $z$ (fixed from
+Redrock), and a residual velocity shift $\Delta v$ (km\,s$^{-1}$):
+\begin{equation}
+  \lstar \;=\; \lambda_{\mathrm{rest}}\,\bigl(1 + z + \Delta v/\C\bigr)
+  \;\equiv\; \lambda_{\mathrm{rest}} \cdot \text{line\_shift}.
+  \label{eq:lstar}
+\end{equation}
+
+\paragraph{Line width.}
+The width $\sigma$ is related to the physical velocity dispersion
+$s$\,(km\,s$^{-1}$) by $\sigma = s/\C$.  For astrophysical lines
+$\sigma \lesssim 10^{-3}$, so the log-Gaussian is an excellent
+approximation to a Gaussian in linear wavelength.
+
+\paragraph{Integrated flux.}
+The total flux of the intrinsic profile is
+\begin{equation}
+  \Phi
+  \;=\; \int_0^{\infty} f(\lambda)\,d\lambda
+  \;=\; \sqrt{2\pi}\,A\,\lstar\,\sigma\,e^{\sigma^2/2}
+  \;\approx\; \sqrt{2\pi}\,A\,\lstar\,\sigma,
+  \label{eq:flux}
+\end{equation}
+where the correction factor $e^{\sigma^2/2} \approx 1 + \mathcal{O}(\sigma^2)$
+is negligible for any astrophysical line width.  In terms of the fitted
+parameters,
+\begin{equation}
+  \boxed{\Phi \;=\; \sqrt{2\pi}\,A\,\lstar\,s/\C.}
+  \label{eq:flux_phys}
+\end{equation}
+This result is independent of the pixel grid and of the instrumental
+resolution matrix; \textsc{FastSpecFit} reports $\Phi$ as the measured line
+flux.
+
+
+\section{The DESI Resolution Matrix}
+\label{sec:resolution}
+
+\paragraph{Extraction model.}
+DESI spectra are produced by an optimal extraction that encodes the
+wavelength-dependent instrumental line-spread function (LSF) in a sparse
+resolution matrix $\R$.  For an ideal (noiseless) spectrum, the extracted
+flux vector $\mathbf{d}$ and the true spectral flux vector $\mathbf{f}$
+(sampled at pixel centers) are related by
+\begin{equation}
+  \mathbf{d} \;=\; \R\,\mathbf{f}.
+\end{equation}
+$\R$ is stored in DESI FITS files in band (diagonal) format with
+$\sim$11 diagonals and is normalized so that each row sums to unity,
+preserving integrated flux.
+
+\paragraph{Deconvolved representation.}
+Rather than inverting $\R$ directly (which amplifies noise), the
+approach of Koposov pre-convolves the model with a reference Gaussian
+of width $\sG$ (the \emph{pre-convolution kernel}) and constructs a
+deconvolved resolution matrix $\W$ such that
+\begin{equation}
+  \mathbf{d} \;\approx\; \W\,\mathbf{h},
+  \label{eq:deconv}
+\end{equation}
+where $\mathbf{h}_j = (G_{\sG} * f)(\lambda_j)$ is the true spectrum
+pre-convolved with the reference Gaussian, evaluated at pixel center
+$\lambda_j$.  Concretely, let $\M$ be the design matrix of the reference
+Gaussian,
+\begin{equation}
+  M_{ij} \;=\; G\!\left(\lambda_i - \lambda_j;\, 0,\, \sG\right),
+\end{equation}
+which maps $\mathbf{f} \mapsto \mathbf{h} = \M\,\mathbf{f}$ approximately.
+Then $\mathbf{f} \approx \inv{\M}\,\mathbf{h}$ and
+\begin{equation}
+  \W \;=\; \R\,\inv{\M}.
+  \label{eq:W}
+\end{equation}
+\textsc{FastSpecFit} uses $\sG = \sigma_0 = 0.5$\,\AA\ (the constant
+\texttt{SIGMA0\_ANGSTROM} in \texttt{resolution.py}), which is chosen to be
+broad enough to regularize the inversion of $\M$ while remaining small
+compared to the DESI LSF.
+
+\paragraph{Forward-model strategy.}
+Given an analytic expression for $\mathbf{h}$, equation~\eqref{eq:deconv}
+provides the predicted extracted spectrum directly.  The problem reduces to
+computing the pre-convolved model
+$h_j = (G_{\sG} * f)(\lambda_j)$ analytically.
+
+
+\section{Pre-Convolved Forward Model}
+\label{sec:model}
+
+\subsection{Key approximation}
+\label{ssec:approx}
+
+In log-$\lambda$ coordinates $u = \ln\lambda$, the intrinsic profile
+\eqref{eq:intrinsic} is an exact Gaussian:
+\begin{equation}
+  f(u) \;=\; A\exp\!\left(-\frac{(u - u^*)^2}{2\sigma^2}\right),
+  \qquad u^* = \ln\lstar.
+\end{equation}
+The linear-space Gaussian kernel $G_{\sG}(\lambda)$ maps to log-$\lambda$
+space as
+\begin{equation}
+  G_{\sG}(\lambda) \;\longrightarrow\;
+  G\!\left(u - u^*;\, 0,\, \sGl\right)
+  \;+\; \mathcal{O}\!\left(\sGl^2\right),
+  \qquad
+  \sGl \;\equiv\; \sG/\lstar,
+  \label{eq:kernel_approx}
+\end{equation}
+where the approximation replaces the linear-space Gaussian with a
+log-space Gaussian of width $\sGl = \sG/\lstar$.  The relative error is
+$\mathcal{O}(\sGl) = \mathcal{O}(\sG/\lstar) \approx 7\times10^{-5}$ for
+DESI, and is negligible.
+
+\subsection{Convolved profile}
+\label{ssec:convolved}
+
+Using the approximation \eqref{eq:kernel_approx}, the convolution of two
+log-space Gaussians with widths $\sigma$ and $\sGl$ is itself a Gaussian
+with quadrature-summed width.  Defining the \emph{effective width}
+\begin{equation}
+  \seff \;=\; \sqrt{\sigma^2 + \sGl^2},
+  \label{eq:seff}
+\end{equation}
+the pre-convolved profile evaluates at pixel center $\lambda_j$ as
+\begin{equation}
+  \boxed{
+  F_j \;=\; A\,\frac{\sigma}{\seff}
+  \exp\!\left(-\frac{x_j^2}{2\seff^2}\right),
+  }
+  \label{eq:model}
+\end{equation}
+where $x_j = \ln\lambda_j - \ln\lstar$ is the log-$\lambda$ offset from
+the line center.  The amplitude factor $\sigma/\seff \leq 1$ accounts for
+the broadening: a narrower intrinsic line ($\sigma \ll \sGl$) is dominated
+by the pre-convolution and its peak is suppressed relative to a broad line.
+
+Equation~\eqref{eq:model} is evaluated only over pixels within
+$\pm N_\sigma\,\seff$ of the line center (with $N_\sigma = 5$ in
+\textsc{FastSpecFit}); pixels outside this range are set to zero.  The
+complete spectrum model is the sum of all line profiles plus the per-patch
+affine continuum pedestal.
+
+\subsection{Comparison to the earlier bin-integration approach}
+\label{ssec:comparison}
+
+The earlier formulation (Buhler 2024) computed a \emph{bin-integrated} flux
+\begin{equation}
+  F_j^{(\mathrm{old})}
+  \;=\; A\bigl[\Phi_\sigma(b_{j+1}) - \Phi_\sigma(b_j)\bigr],
+\end{equation}
+where $\Phi_\sigma$ is the CDF of the log-Gaussian and $b_j$,
+$b_{j+1}$ are the bin edges.  These values are exact per-bin averages
+of the intrinsic profile~\eqref{eq:intrinsic}.  However, $\W$ was
+constructed to accept the Gaussian-\emph{convolved} point values $F_j$
+(equation~\ref{eq:model}), not bin integrals.  Feeding
+$F_j^{(\mathrm{old})}$ into $\W$ therefore produces a systematic model
+error: for lines narrower than approximately one DESI pixel
+(${\sim}0.8$\,\AA), the mismatch between a bin integral and a
+convolved point value is position-dependent, causing flux biases of
+5\%--30\% depending on where the line center falls within the pixel.
+The Gaussian-point-evaluation model~\eqref{eq:model} removes this
+bias.
+
+
+\section{Analytic Jacobian}
+\label{sec:jacobian}
+
+The emission-line optimizer (\texttt{scipy.optimize.least\_squares}) requires
+the Jacobian of the \emph{pre-convolved} model $F_j$ with respect to the
+three per-line parameters $(A,\, \Delta v,\, s)$.  We define the shorthand
+\begin{align}
+  g_j &\;\equiv\; A\,\frac{\sigma}{\seff}\,
+       \exp\!\left(-\frac{x_j^2}{2\seff^2}\right)
+       \;=\; \text{amp\_eff}\times\text{gauss}, \\[4pt]
+  \iota &\;\equiv\; \seff^{-2}, \\[4pt]
+  \text{line\_shift} &\;\equiv\; 1 + z + \Delta v/\C.
+\end{align}
+The Jacobian rows for pixel $j$ are derived below; they are nonzero only
+within the support region $|x_j| < N_\sigma\,\seff$.
+
+\subsection{Amplitude: \texorpdfstring{$\partial F_j/\partial A$}{dF/dA}}
+
+The model is linear in $A$, and $\sigma$, $\seff$, $x_j$ are all independent
+of $A$:
+\begin{equation}
+  \frac{\partial F_j}{\partial A}
+  \;=\; \frac{\sigma}{\seff}
+        \exp\!\left(-\frac{x_j^2}{2\seff^2}\right)
+  \;=\; \frac{g_j}{A}.
+  \label{eq:dF_dA}
+\end{equation}
+
+\subsection{Velocity shift: \texorpdfstring{$\partial F_j/\partial \Delta v$}{dF/dv}}
+\label{ssec:dFdv}
+
+The dependence on $\Delta v$ enters through $\ln\lstar =
+\ln(\lambda_{\rm rest} \cdot \text{line\_shift})$, so
+\begin{equation}
+  \frac{\partial \ln\lstar}{\partial \Delta v}
+  \;=\; \frac{1}{\C\cdot\text{line\_shift}},
+  \qquad
+  \frac{\partial x_j}{\partial \Delta v}
+  \;=\; -\frac{1}{\C\cdot\text{line\_shift}}.
+  \label{eq:dlnl_dv}
+\end{equation}
+There is a secondary dependence through $\sGl = \sG/\lstar$, but its
+contribution to $\partial F_j/\partial \Delta v$ is of order
+$\sGl^2\,(1-x_j^2/\seff^2)/x_j \sim 10^{-5}$ relative to the primary term
+and is neglected.  The primary result is
+\begin{equation}
+  \frac{\partial F_j}{\partial \Delta v}
+  \;=\; \frac{\partial F_j}{\partial x_j}\cdot
+        \frac{\partial x_j}{\partial \Delta v}
+  \;=\; \frac{g_j\,x_j\,\iota}{\C\cdot\text{line\_shift}}.
+  \label{eq:dF_dv}
+\end{equation}
+
+%\noindent\textit{Note:} using $1/\C$ in place of
+%$1/(\C\cdot\text{line\_shift})$ introduces a systematic error of order $z$
+%at all redshifts (e.g.\ 10\% at $z=0.1$) and must be avoided.
+
+\subsection{Line width: \texorpdfstring{$\partial F_j/\partial s$}{dF/ds}}
+\label{ssec:dFds}
+
+With $\sigma = s/\C$, we need $\partial F_j/\partial s =
+(\partial F_j/\partial \sigma)/\C$.  Both the amplitude factor
+$\text{amp\_eff} = A\sigma/\seff$ and the exponent depend on $\sigma$.
+Using $\partial\seff/\partial\sigma = \sigma/\seff$:
+\begin{align}
+  \frac{\partial}{\partial\sigma}\!\left(\frac{A\sigma}{\seff}\right)
+  &\;=\;
+  \frac{A(\seff^2 - \sigma^2)}{\seff^3}
+  \;=\;
+  \frac{A\,\sGl^2}{\seff^3},
+  \\[6pt]
+  \frac{\partial}{\partial\sigma}\!
+  \left[\exp\!\left(-\frac{x_j^2}{2\seff^2}\right)\right]
+  &\;=\;
+  \exp\!\left(-\frac{x_j^2}{2\seff^2}\right)
+  \cdot\frac{x_j^2\,\sigma}{\seff^4}.
+\end{align}
+Combining and using $\sGl^2 = \seff^2 - \sigma^2$:
+\begin{align}
+  \frac{\partial F_j}{\partial\sigma}
+  &\;=\;
+  \frac{A}{\seff}\cdot\text{gauss}\cdot
+  \left(\frac{\sGl^2}{\seff^2} + \frac{\sigma^2 x_j^2}{\seff^4}\right)
+  \nonumber\\
+  &\;=\;
+  \frac{A}{\seff}\cdot\text{gauss}\cdot
+  \left[1 - \frac{\sigma^2}{\seff^2} + \frac{\sigma^2 x_j^2}{\seff^4}\right]
+  \nonumber\\
+  &\;=\;
+  \frac{A}{\seff}\cdot\text{gauss}\cdot
+  \Bigl[1 - \sigma^2\bigl(1 - x_j^2\iota\bigr)\iota\Bigr].
+\end{align}
+Dividing by $\C$:
+\begin{equation}
+  \boxed{
+  \frac{\partial F_j}{\partial s}
+  \;=\;
+  \frac{A}{\seff\,\C}\cdot\text{gauss}\cdot
+  \Bigl[1 - \sigma^2\bigl(1 - x_j^2\iota\bigr)\iota\Bigr].
+  }
+  \label{eq:dF_ds}
+\end{equation}
+
+\paragraph{Numerical stability at $\sigma\to 0$.}
+When $\sigma = 0$ (a line width fixed to zero), $\seff = \sGl \neq 0$ and
+equation~\eqref{eq:dF_ds} evaluates to
+\begin{equation}
+  \left.\frac{\partial F_j}{\partial s}\right|_{\sigma=0}
+  \;=\;
+  \frac{A}{\sGl\,\C}
+  \exp\!\left(-\frac{x_j^2}{2\sGl^2}\right),
+\end{equation}
+which is finite.
+
+%An earlier equivalent form of \eqref{eq:dF_ds}, $g_j(1/\sigma -
+%\sigma\cdots)/\C$, has an explicit $1/\sigma$ that diverges at
+%$\sigma=0$ and must \emph{not} be used.
+
+\subsection{Summary}
+
+Table~\ref{tab:jacobian} collects the three Jacobian entries.
+
+\begin{table}[h]
+\centering
+\renewcommand{\arraystretch}{1.6}
+\begin{tabular}{@{}lll@{}}
+\toprule
+Parameter & Symbol & $\partial F_j/\partial\,\text{param}$ \\
+\midrule
+Amplitude    & $A$   &
+  $g_j / A$
+  \\
+Velocity shift & $\Delta v$ (km\,s$^{-1}$) &
+  $g_j\,x_j\,\iota\;/\;(\C\cdot\text{line\_shift})$
+  \\
+Line width   & $s$ (km\,s$^{-1}$) &
+  $(A/\seff\C)\cdot\text{gauss}\cdot
+   [1 - \sigma^2(1-x_j^2\iota)\iota]$
+  \\
+\bottomrule
+\end{tabular}
+\caption{Jacobian of the pre-convolved model $F_j$ with respect to the
+  three per-line parameters. Here $\iota\equiv\seff^{-2}$,
+  $g_j = (A\sigma/\seff)\,e^{-x_j^2/(2\seff^2)}$, and
+  $\text{line\_shift}=1+z+v/\C$.}
+\label{tab:jacobian}
+\end{table}
+
+
+\section{Implementation Notes}
+\label{sec:impl}
+
+\paragraph{Effective width and pixel support.}
+The pre-convolution sets a floor on the effective line width:
+$\seff \geq \sGl = \sG/\lstar$, so even an unresolved line
+($\sigma\to 0$) occupies approximately $2N_\sigma\sGl/\Delta\!\ln\lambda$
+pixels, where $\Delta\!\ln\lambda \approx \Delta\lambda/\lambda$ is the
+pixel scale in log-$\lambda$.  For DESI ($\sG=0.5$\,\AA,
+$\Delta\lambda=0.8$\,\AA\ at $\lambda\sim6000$\,\AA), this floor is
+$\sGl/(\Delta\ln\lambda) \approx 0.5/0.8 \approx 0.6$\,pixel, so the
+pre-convolved profile always spans $\gtrsim 6$ pixels at $5\sigma$ truncation.
+This ensures the Riemann sum $\sum_j F_j\,\Delta\lambda_j$ recovers the
+analytic flux \eqref{eq:flux} to better than 2\%, independent of the
+sub-pixel position of the line center.
+
+\paragraph{Flux independence of resolution matrix.}
+The reported line flux $\Phi = \sqrt{2\pi}\,A\,\lstar\,s/\C$
+(equation~\ref{eq:flux_phys}) is the integral of the \emph{intrinsic}
+profile~\eqref{eq:intrinsic} before any convolution.  It is therefore
+independent of $\sG$, the pixel grid, and $\W$.  This is preferable to
+summing the model pixels $\sum_j (\W\mathbf{F})_j\,\Delta\lambda_j$, which
+depends on all of these quantities.
+
+\paragraph{Shared parameter constraints.}
+In \textsc{FastSpecFit}, lines within a kinematic group share a common $\Delta v$
+and $s$.  The Jacobian rows for those lines are assembled by the sparse
+\texttt{ParamsMapping} layer, which maps the physically constrained parameter
+vector to and from the per-line parameter array before calling
+the functions described here.
+
+
+\section*{Acknowledgments}
+
+The deconvolved-resolution-matrix framework follows the implementation
+by Sergey Koposov (rvspecfit) and the original bin-integration model
+is due to Buhler (2024). The reconciliation presented here, and the
+corrected Jacobian, were developed during \textsc{FastSpecFit}
+PR\,\#252.
+
+\end{document}

--- a/doc/technote/emline-model.tex
+++ b/doc/technote/emline-model.tex
@@ -103,48 +103,46 @@ flux.
 \paragraph{Extraction model.}
 DESI spectra are produced by an optimal extraction that encodes the
 wavelength-dependent instrumental line-spread function (LSF) in a sparse
-resolution matrix $\R$.  For an ideal (noiseless) spectrum, the extracted
-flux vector $\mathbf{d}$ and the true spectral flux vector $\mathbf{f}$
-(sampled at pixel centers) are related by
+resolution matrix $\R$, stored in band (diagonal) format with ${\sim}11$
+diagonals and row-normalized to preserve integrated flux.  For an ideal
+continuous spectrum $f(\lambda)$, the extracted flux at pixel $i$ is the
+integral
 \begin{equation}
-  \mathbf{d} \;=\; \R\,\mathbf{f}.
+  d_i \;=\; \int_0^\infty K(\lambda_i,\lambda)\,f(\lambda)\,d\lambda,
+  \label{eq:continuous}
 \end{equation}
-$\R$ is stored in DESI FITS files in band (diagonal) format with
-$\sim$11 diagonals and is normalized so that each row sums to unity,
-preserving integrated flux.
+where $K(\lambda_i,\lambda)$ is the effective extraction kernel encoded by
+$\R$.  The familiar discrete relation $\mathbf{d} \approx \R\,\mathbf{f}$
+(with $\mathbf{f}$ evaluated at pixel centers) approximates $f$ as constant
+within each pixel; it is accurate for broad, slowly varying features but
+fails for unresolved emission lines.
 
-\paragraph{Deconvolved representation.}
-Rather than inverting $\R$ directly (which amplifies noise), the
-approach of Koposov pre-convolves the model with a reference Gaussian
-of width $\sG$ (the \emph{pre-convolution kernel}) and constructs a
-deconvolved resolution matrix $\W$ such that
+\paragraph{Pre-convolved representation.}
+A more accurate discretization rewrites \eqref{eq:continuous} in terms of
+the $\sG$-pre-convolved spectrum evaluated at pixel centers,
+$h_j = (G_{\sG}*f)(\lambda_j)$.  Defining the Gaussian design matrix
+$M_{ij} = G(\lambda_i - \lambda_j;\,0,\,\sG)$, so that
+$\mathbf{h} \approx \M\,\mathbf{f}$ and $\mathbf{f} \approx \inv{\M}\,\mathbf{h}$,
+gives
 \begin{equation}
   \mathbf{d} \;\approx\; \W\,\mathbf{h},
+  \qquad
+  \W \;=\; \R\,\inv{\M}.
   \label{eq:deconv}
 \end{equation}
-where $\mathbf{h}_j = (G_{\sG} * f)(\lambda_j)$ is the true spectrum
-pre-convolved with the reference Gaussian, evaluated at pixel center
-$\lambda_j$.  Concretely, let $\M$ be the design matrix of the reference
-Gaussian,
-\begin{equation}
-  M_{ij} \;=\; G\!\left(\lambda_i - \lambda_j;\, 0,\, \sG\right),
-\end{equation}
-which maps $\mathbf{f} \mapsto \mathbf{h} = \M\,\mathbf{f}$ approximately.
-Then $\mathbf{f} \approx \inv{\M}\,\mathbf{h}$ and
-\begin{equation}
-  \W \;=\; \R\,\inv{\M}.
-  \label{eq:W}
-\end{equation}
-\textsc{FastSpecFit} uses $\sG = \sigma_0 = 0.5$\,\AA\ (the constant
-\texttt{SIGMA0\_ANGSTROM} in \texttt{resolution.py}), which is chosen to be
-broad enough to regularize the inversion of $\M$ while remaining small
-compared to the DESI LSF.
+Because $h_j = \int G(\lambda_j - \lambda;\,0,\,\sG)\,f(\lambda)\,d\lambda$
+is a weighted integral of $f$ rather than a point evaluation, it more
+faithfully represents the continuous spectrum even for features as narrow as
+one pixel.  \textsc{FastSpecFit} uses $\sG = \sigma_0 = 0.5$\,\AA\ (the
+constant \texttt{SIGMA0\_ANGSTROM} in \texttt{resolution.py}), much smaller
+than the DESI LSF FWHM (${\sim}2$\,\AA), so that $h_j \approx f_j$ for
+broad features while providing an accurate discretization for narrow ones.
 
 \paragraph{Forward-model strategy.}
-Given an analytic expression for $\mathbf{h}$, equation~\eqref{eq:deconv}
-provides the predicted extracted spectrum directly.  The problem reduces to
-computing the pre-convolved model
-$h_j = (G_{\sG} * f)(\lambda_j)$ analytically.
+Given an analytic expression for $h_j = (G_{\sG}*f)(\lambda_j)$,
+equation~\eqref{eq:deconv} provides the predicted extracted spectrum
+directly, without numerical integration.  The problem reduces to evaluating
+the pre-convolved profile $\mathbf{h}$ analytically.
 
 
 \section{Pre-Convolved Forward Model}

--- a/py/fastspecfit/emline_fit/interface.py
+++ b/py/fastspecfit/emline_fit/interface.py
@@ -1,17 +1,11 @@
 import numpy as np
-from math import erf, erfc
 
 from numba import jit
 
+from fastspecfit.resolution import SIGMA0_ANGSTROM
+
 from .params_mapping import ParamsMapping
 from .sparse_rep import EMLineJacobian
-
-from .utils import (
-    MAX_SDEV,
-    norm_pdf,
-    norm_cdf,
-    max_buffer_width,
-)
 
 from .model import (
     emline_model,
@@ -86,8 +80,8 @@ class EMLine_Objective(object):
             self.nPatches = 0
             self.J_P = None
 
-        self.log_obs_bin_edges, self.ibin_widths = \
-            _prepare_bins(obs_bin_centers, camerapix)
+        self.log_obs_bin_centers = np.log(obs_bin_centers)
+        self.sigma_G = SIGMA0_ANGSTROM
 
         # temporary storage to prevent allocation in params_mapping
         # on every call to objective/jacobian
@@ -126,8 +120,8 @@ class EMLine_Objective(object):
         _build_model_core(line_parameters,
                           self.line_wavelengths,
                           self.redshift,
-                          self.log_obs_bin_edges,
-                          self.ibin_widths,
+                          self.log_obs_bin_centers,
+                          self.sigma_G,
                           self.resolution_matrices,
                           self.camerapix,
                           model_fluxes)
@@ -185,18 +179,12 @@ class EMLine_Objective(object):
         for icam, campix in enumerate(self.camerapix):
             s, e = campix
 
-            # Actual inverse bin widths are in ibin_widths[s+1:e+2].
-            # Setup guarantees that at least one more array entry
-            # exists to either side of this range, so we can pass
-            # those in as dummies.
-            ibw = self.ibin_widths[s:e+3]
-
             idealJac = \
                 emline_model_jacobian(line_parameters,
-                                      self.log_obs_bin_edges[s+icam:e+icam+1],
-                                      ibw,
+                                      self.log_obs_bin_centers[s:e],
                                       self.redshift,
                                       self.line_wavelengths,
+                                      self.sigma_G,
                                       self.resolution_matrices[icam].ndiag)
 
             # ignore any columns corresponding to fixed parameters
@@ -250,15 +238,15 @@ def build_model(redshift,
 
     """
 
-    log_obs_bin_edges, ibin_widths = _prepare_bins(obs_bin_centers, camerapix)
+    log_obs_bin_centers = np.log(obs_bin_centers)
 
     model_fluxes = np.empty_like(obs_bin_centers, dtype=obs_bin_centers.dtype)
 
     _build_model_core(line_parameters,
                       line_wavelengths,
                       redshift,
-                      log_obs_bin_edges,
-                      ibin_widths,
+                      log_obs_bin_centers,
+                      SIGMA0_ANGSTROM,
                       resolution_matrices,
                       camerapix,
                       model_fluxes)
@@ -540,32 +528,22 @@ def find_peak_amplitudes_and_fluxes(line_parameters,
 def _build_model_core(line_parameters,
                       line_wavelengths,
                       redshift,
-                      log_obs_bin_edges,
-                      ibin_widths,
+                      log_obs_bin_centers,
+                      sigma_G,
                       resolution_matrices,
                       camerapix,
                       model_fluxes):
     """Compute resolution-convolved combined model fluxes, writing into ``model_fluxes``."""
 
     for icam, campix in enumerate(camerapix):
-
-        # start and end for obs fluxes of camera icam
         s, e = campix
-
-        # Actual inverse bin widths are in ibin_widths[s+1:e+2].
-        # Setup guarantees that at least one more array entry
-        # exists to either side of this range, so we can pass
-        # those in as dummies.
-        ibw = ibin_widths[s:e+3]
 
         mf = emline_model(line_wavelengths,
                           line_parameters,
-                          log_obs_bin_edges[s+icam:e+icam+1],
+                          log_obs_bin_centers[s:e],
                           redshift,
-                          ibw)
+                          sigma_G)
 
-        # convolve model with resolution matrix and store in
-        # this camera's subrange of model_fluxes
         resolution_matrices[icam].dot(mf, model_fluxes[s:e])
 
 
@@ -578,34 +556,22 @@ def _build_multimodel_core(line_parameters,
                            consumer_fun):
     """Compute sparse per-line models for each camera and pass each to ``consumer_fun``."""
 
-    log_obs_bin_edges, ibin_widths = _prepare_bins(obs_bin_centers,
-                                                   camerapix)
+    log_obs_bin_centers = np.log(obs_bin_centers)
 
     for icam, campix in enumerate(camerapix):
-
-        # start and end for obs fluxes of camera icam
         s, e = campix
 
-        # Actual inverse bin widths are in ibin_widths[s+1:e+2].
-        # Setup guarantees that at least one more array entry
-        # exists to either side of this range, so we can pass
-        # those in as dummies.
-        ibw = ibin_widths[s:e+3]
-
-        # compute model waveform for each spectral line
         line_models = emline_perline_models(line_wavelengths,
                                             line_parameters,
-                                            log_obs_bin_edges[s+icam:e+icam+1],
+                                            log_obs_bin_centers[s:e],
                                             redshift,
-                                            ibw,
+                                            SIGMA0_ANGSTROM,
                                             resolution_matrices[icam].ndiag)
 
-        # convolve each line's waveform with resolution matrix
         endpts, M = mulWMJ(np.ones(e - s),
                            resolution_matrices[icam].rowdata(),
                            line_models)
 
-        # adjust endpoints to reflect camera range
         endpts += s
 
         consumer_fun((endpts, M))
@@ -709,54 +675,3 @@ def mulWMJ(w, M, Jsp):
     return (endpts, J)
 
 
-@jit(nopython=True, nogil=True, cache=True)
-def _prepare_bins(centers, camerapix):
-    """Convert observed bin centers to log bin edges and inverse bin widths.
-
-    Parameters
-    ----------
-    centers : :class:`numpy.ndarray`
-        Center wavelength of each observed wavelength bin.
-    camerapix : :class:`numpy.ndarray` of int
-        Start and end wavelength bin indices for each camera.
-
-    Returns
-    -------
-    log_obs_bin_edges : :class:`numpy.ndarray`
-        Natural log of each bin edge wavelength.  Edges are placed
-        halfway between adjacent centers, with extrapolation at the ends.
-        One extra edge per camera gap is included.
-    ibin_widths : :class:`numpy.ndarray`
-        Inverse bin widths, zero-padded by one entry on each end.
-
-    """
-
-    ncameras = camerapix.shape[0]
-    edges = np.empty(len(centers) + ncameras, dtype=centers.dtype)
-    ibin_widths = np.empty(len(centers) + 2,  dtype=centers.dtype)
-
-    for icam, campix in enumerate(camerapix):
-
-        s, e = campix
-        icenters = centers[s:e]
-
-        #- interior edges are just points half way between bin centers
-        int_edges = 0.5 * (icenters[:-1] + icenters[1:])
-
-        #- exterior edges are extrapolation of interior bin sizes
-        edge_l = icenters[ 0] - (icenters[ 1] - int_edges[ 0])
-        edge_r = icenters[-1] + (icenters[-1] - int_edges[-1])
-
-        edges[s + icam]              = edge_l
-        edges[s + icam + 1:e + icam] = int_edges
-        edges[e + icam]              = edge_r
-
-        # add 1 to indices i ibin_widths to skip dummy at 0
-        ibin_widths[s+1:e+1] = 1. / np.diff(edges[s+icam : e+icam+1])
-
-    # dummies before and after widths are needed
-    # for corner cases in edge -> bin computation
-    ibin_widths[0]  = 0.
-    ibin_widths[-1] = 0.
-
-    return (np.log(edges), ibin_widths)

--- a/py/fastspecfit/emline_fit/jacobian.py
+++ b/py/fastspecfit/emline_fit/jacobian.py
@@ -98,9 +98,8 @@ def emline_model_jacobian(line_parameters,
             # dF/d(amplitude)
             dda_vals[i - lo] = g / amp
 
-            # dF/d(vshift): d(log_shifted_line)/d(vshift) = 1/C_LIGHT,
-            # so dx/d(vshift) = -1/C_LIGHT
-            ddv_vals[i - lo] = g * x * inv_sigma_eff_sq / C_LIGHT
+            # dF/d(vshift): d(log_shifted_line)/d(vshift) = 1/(C_LIGHT * line_shift)
+            ddv_vals[i - lo] = g * x * inv_sigma_eff_sq / (C_LIGHT * line_shift)
 
             # dF/d(line_sigma): written as (amp/sigma_eff)*exp*(...) rather than
             # g*(1/sigma - ...) to avoid 1/sigma -> inf when line_sigmas[j]=0;

--- a/py/fastspecfit/emline_fit/jacobian.py
+++ b/py/fastspecfit/emline_fit/jacobian.py
@@ -68,9 +68,10 @@ def emline_model_jacobian(line_parameters,
         shifted_line     = line_wavelengths[j] * line_shift
         log_shifted_line = np.log(shifted_line)
 
-        sigma_G_log = sigma_G / shifted_line
-        sigma_eff   = np.sqrt(sigma**2 + sigma_G_log**2)
-        amp_eff     = amp * sigma / sigma_eff
+        sigma_G_log        = sigma_G / shifted_line
+        sigma_eff          = np.sqrt(sigma**2 + sigma_G_log**2)
+        amp_eff            = amp * sigma / sigma_eff
+        amp_over_sigma_eff = amp / sigma_eff  # finite even when sigma=0
 
         lo = np.searchsorted(log_obs_bin_centers,
                              log_shifted_line - MAX_SDEV * sigma_eff,
@@ -90,8 +91,9 @@ def emline_model_jacobian(line_parameters,
         inv_sigma_eff_sq   = 1.  / sigma_eff**2
 
         for i in range(lo, hi):
-            x = log_obs_bin_centers[i] - log_shifted_line
-            g = amp_eff * np.exp(-x**2 * inv_2_sigma_eff_sq)
+            x     = log_obs_bin_centers[i] - log_shifted_line
+            gauss = np.exp(-x**2 * inv_2_sigma_eff_sq)
+            g     = amp_eff * gauss
 
             # dF/d(amplitude)
             dda_vals[i - lo] = g / amp
@@ -100,10 +102,11 @@ def emline_model_jacobian(line_parameters,
             # so dx/d(vshift) = -1/C_LIGHT
             ddv_vals[i - lo] = g * x * inv_sigma_eff_sq / C_LIGHT
 
-            # dF/d(line_sigma): chain rule through sigma = line_sigma / C_LIGHT
-            # dF/dsigma = g * [1/sigma - sigma*(1 - x^2*inv_sigma_eff_sq)*inv_sigma_eff_sq]
-            dds_vals[i - lo] = g / C_LIGHT * \
-                (1. / sigma - sigma * (1. - x**2 * inv_sigma_eff_sq) * inv_sigma_eff_sq)
+            # dF/d(line_sigma): written as (amp/sigma_eff)*exp*(...) rather than
+            # g*(1/sigma - ...) to avoid 1/sigma -> inf when line_sigmas[j]=0;
+            # the two forms are algebraically identical for sigma > 0
+            dds_vals[i - lo] = amp_over_sigma_eff * gauss / C_LIGHT * \
+                (1. - sigma**2 * (1. - x**2 * inv_sigma_eff_sq) * inv_sigma_eff_sq)
 
         starts[j] = lo
         ends[j]   = hi

--- a/py/fastspecfit/emline_fit/jacobian.py
+++ b/py/fastspecfit/emline_fit/jacobian.py
@@ -7,17 +7,15 @@ from fastspecfit.util import C_LIGHT
 from .utils import (
     MAX_SDEV,
     max_buffer_width,
-    norm_cdf,
-    norm_pdf
 )
 
 
 @jit(nopython=True, nogil=True, cache=True)
 def emline_model_jacobian(line_parameters,
-                          log_obs_bin_edges,
-                          ibin_widths,
+                          log_obs_bin_centers,
                           redshift,
                           line_wavelengths,
+                          sigma_G,
                           padding):
     """Compute the sparse Jacobian of :func:`emline_model`.
 
@@ -26,37 +24,30 @@ def emline_model_jacobian(line_parameters,
     line_parameters : :class:`numpy.ndarray`
         Concatenated array of amplitudes, velocity shifts, and sigmas for
         all lines.
-    log_obs_bin_edges : :class:`numpy.ndarray`
-        Natural logs of observed wavelength bin edges.
-    ibin_widths : :class:`numpy.ndarray`
-        Inverse widths of each observed wavelength bin.
+    log_obs_bin_centers : :class:`numpy.ndarray`
+        Natural logs of observed wavelength pixel centers.
     redshift : float
         Redshift of the observed spectrum.
     line_wavelengths : :class:`numpy.ndarray`
         Nominal rest-frame wavelengths of all fitted lines in Angstroms.
+    sigma_G : float
+        Gaussian pre-convolution width in Angstroms.
     padding : int
         Extra entries to pad each sparse row for later use.
 
     Returns
     -------
     endpts : :class:`numpy.ndarray` of int, shape (3*nlines, 2)
-        Start and end bin indices of the nonzero range for each parameter.
+        Start and end pixel indices of the nonzero range for each parameter.
     dd : :class:`numpy.ndarray`, shape (3*nlines, max_width)
-        Partial derivative values within each parameter's nonzero bin range.
+        Partial derivative values within each parameter's nonzero pixel range.
 
     """
-
-    SQRT_2PI = np.sqrt(2*np.pi)
-
-    nbins = len(log_obs_bin_edges) - 1
 
     line_amplitudes, line_vshifts, line_sigmas = \
         np.split(line_parameters, 3)
 
-    # buffers for per-parameter calculations, sized large
-    # enough for max possible range [s .. e), plus extra
-    # padding as directed by caller.
-    max_width = max_buffer_width(log_obs_bin_edges, line_sigmas, padding)
+    max_width = max_buffer_width(log_obs_bin_centers, line_sigmas, padding, sigma_G)
 
     nlines = len(line_wavelengths)
     dd     = np.empty((3 * nlines, max_width), dtype=line_amplitudes.dtype)
@@ -65,114 +56,70 @@ def emline_model_jacobian(line_parameters,
     starts = endpts[:, 0]
     ends   = endpts[:, 1]
 
-    # compute partial derivatives for avg values of all Gaussians
-    # inside each bin. For each Gaussian, we only compute
-    # contributions for bins where it is non-negligible.
-    for j in range(len(line_wavelengths)):
+    for j in range(nlines):
 
-        # line width
+        amp = line_amplitudes[j]
+        if amp == 0.:
+            continue
+
         sigma = line_sigmas[j] / C_LIGHT
 
-        c0 = SQRT_2PI * np.exp(0.5 * sigma**2)
-
-        # wavelength shift for spectral lines
-        line_shift = 1. + redshift + line_vshifts[j] / C_LIGHT
+        line_shift       = 1. + redshift + line_vshifts[j] / C_LIGHT
         shifted_line     = line_wavelengths[j] * line_shift
         log_shifted_line = np.log(shifted_line)
 
-        # leftmost edge i that needs a value (> 0) for this line
-        lo = np.searchsorted(log_obs_bin_edges,
-                             log_shifted_line - MAX_SDEV * sigma,
-                             side="left")
+        sigma_G_log = sigma_G / shifted_line
+        sigma_eff   = np.sqrt(sigma**2 + sigma_G_log**2)
+        amp_eff     = amp * sigma / sigma_eff
 
-        # leftmost edge i that does *not* need a value (== 1) for this line
-        hi = np.searchsorted(log_obs_bin_edges,
-                             log_shifted_line + MAX_SDEV * sigma,
+        lo = np.searchsorted(log_obs_bin_centers,
+                             log_shifted_line - MAX_SDEV * sigma_eff,
+                             side="left")
+        hi = np.searchsorted(log_obs_bin_centers,
+                             log_shifted_line + MAX_SDEV * sigma_eff,
                              side="right")
 
-        # check if entire Gaussian is outside bounds of log_obs_bin_edges
-        if hi == 0 or lo == len(log_obs_bin_edges):
+        if hi == 0 or lo == len(log_obs_bin_centers):
             continue
 
-        nedges = hi - lo + 2  # compute values at edges [lo - 1 ... hi]
-
-        # Compute contribs of each line to each partial derivative in place.
-        # No sharing of params between peaks means that we never have to
-        # add contributions from two peaks to same line.
         dda_vals = dd[           j]
         ddv_vals = dd[nlines   + j]
         dds_vals = dd[2*nlines + j]
 
-        offset = (log_shifted_line / sigma + sigma) if sigma > 0. else 0.
+        inv_2_sigma_eff_sq = 0.5 / sigma_eff**2
+        inv_sigma_eff_sq   = 1.  / sigma_eff**2
 
-        c = c0 * line_wavelengths[j]
-        A = c / C_LIGHT * line_amplitudes[j]
+        for i in range(lo, hi):
+            x = log_obs_bin_centers[i] - log_shifted_line
+            g = amp_eff * np.exp(-x**2 * inv_2_sigma_eff_sq)
 
-        # vals[i] --> edge i + lo - 1
+            # dF/d(amplitude)
+            dda_vals[i - lo] = g / amp
 
-        dda_vals[0] = 0. # edge lo - 1
-        ddv_vals[0] = 0.
-        dds_vals[0] = 0.
+            # dF/d(vshift): d(log_shifted_line)/d(vshift) = 1/C_LIGHT,
+            # so dx/d(vshift) = -1/C_LIGHT
+            ddv_vals[i - lo] = g * x * inv_sigma_eff_sq / C_LIGHT
 
-        for i in range(1, nedges - 1):
+            # dF/d(line_sigma): chain rule through sigma = line_sigma / C_LIGHT
+            # dF/dsigma = g * [1/sigma - sigma*(1 - x^2*inv_sigma_eff_sq)*inv_sigma_eff_sq]
+            dds_vals[i - lo] = g / C_LIGHT * \
+                (1. / sigma - sigma * (1. - x**2 * inv_sigma_eff_sq) * inv_sigma_eff_sq)
 
-            # x - offset = (log(lambda_j) - mu_i)/sigma - sigma,
-            # the argument of the Gaussian integral
+        starts[j] = lo
+        ends[j]   = hi
 
-            x = log_obs_bin_edges[i+lo-1]/sigma - offset
-            pdf = norm_pdf(x)
-            cdf = norm_cdf(x)
+    # replicate first third of endpts twice more, since the same pixel
+    # range applies to all three parameters of each line
+    for i in range(1, 3):
+        endpts[i*nlines:(i+1)*nlines, :] = endpts[:nlines, :]
 
-            dda_vals[i] = c * line_shift * sigma * cdf
-            ddv_vals[i] = A * (sigma * cdf - pdf)
-            dds_vals[i] = A * line_shift * \
-                ((1 + sigma**2) * cdf - (x + 2*sigma) * pdf)
-
-        dda_vals[nedges - 1] = c * line_shift * sigma     # edge hi
-        ddv_vals[nedges - 1] = A * sigma
-        dds_vals[nedges - 1] = A * line_shift * (1 + sigma**2)
-
-        # Compute partial derivs for bin i+lo-1 for 0 <= i < nedges - 1.
-        # But:
-        #  * if lo == 0, bin lo - 1 is not defined, so skip it
-        #  * if hi == |log_obs_bin_edges|, bin hi - 1 is not defined,
-        #      so skip it
-        # Implement skips by modifying range of computation loop.
-        #
-        # After loop, vals contains weighted partial derives of bins
-        # lo - 1 + dlo .. hi - dhi, plus up to two cells of
-        # trailing garbage.
-
-        dlo = 1 if lo == 0                      else 0
-        dhi = 1 if hi == len(log_obs_bin_edges) else 0
-
-        for i in range(dlo, nedges - 1 - dhi):
-            dda_vals[i-dlo] = (dda_vals[i+1] - dda_vals[i]) * ibin_widths[i+lo]
-            ddv_vals[i-dlo] = (ddv_vals[i+1] - ddv_vals[i]) * ibin_widths[i+lo]
-            dds_vals[i-dlo] = (dds_vals[i+1] - dds_vals[i]) * ibin_widths[i+lo]
-
-        # starts[j] is set to first valid bin
-        starts[j] = lo - 1 + dlo
-
-        # ends[j] is set one past last valid bin
-        ends[j]   = hi - dhi
-
-    # replicate first third of endpts (which is what we
-    # set above) twice more, since same endpts apply to
-    # all three params of each line
-    for i in range(1,3):
-        endpts[i*nlines:(i+1)*nlines,:] = endpts[:nlines,:]
-
-    # for lines with zero amplitude,
-    # partial derivatives w/r to their vshifts
-    # and sigmas are zero
+    # for lines with zero amplitude, derivatives w.r.t. vshift and sigma are zero
     for i, amp in enumerate(line_amplitudes):
         if amp == 0.:
-            endpts[i + nlines,  :] = 0
-            endpts[i + 2*nlines,:] = 0
+            endpts[i + nlines,   :] = 0
+            endpts[i + 2*nlines, :] = 0
 
-    # for lines with zero width, partial derivatives
-    # w/r to their amplitudes are zero.
+    # for lines with zero width, derivatives w.r.t. amplitude are zero
     for i, sig in enumerate(line_sigmas):
         if sig == 0.:
             endpts[i, :] = 0

--- a/py/fastspecfit/emline_fit/model.py
+++ b/py/fastspecfit/emline_fit/model.py
@@ -7,17 +7,16 @@ from fastspecfit.util import C_LIGHT
 from .utils import (
     MAX_SDEV,
     max_buffer_width,
-    norm_cdf
 )
 
 
 @jit(nopython=True, nogil=True, cache=True)
 def emline_model(line_wavelengths,
                  line_parameters,
-                 log_obs_bin_edges,
+                 log_obs_bin_centers,
                  redshift,
-                 ibin_widths):
-    """Compute average emission-line flux in each observed wavelength bin.
+                 sigma_G):
+    """Compute the Gaussian-convolved emission-line model at each observed pixel.
 
     Parameters
     ----------
@@ -26,34 +25,30 @@ def emline_model(line_wavelengths,
     line_parameters : :class:`numpy.ndarray`
         Concatenated array of amplitudes, velocity shifts, and sigmas for
         all lines.
-    log_obs_bin_edges : :class:`numpy.ndarray`
-        Natural logs of observed wavelength bin edges.
+    log_obs_bin_centers : :class:`numpy.ndarray`
+        Natural logs of observed wavelength bin centers.
     redshift : float
         Redshift of the observed spectrum.
-    ibin_widths : :class:`numpy.ndarray`
-        Inverse widths of each observed wavelength bin.
+    sigma_G : float
+        Gaussian pre-convolution width in Angstroms (must match the value
+        used to build the deconvolved resolution matrix W).
 
     Returns
     -------
     :class:`numpy.ndarray`
-        Average flux in each observed wavelength bin.
+        Model flux at each observed pixel center.
 
     """
 
     line_amplitudes, line_vshifts, line_sigmas = \
         np.split(line_parameters, 3)
 
-    # output per-bin fluxes
-    nbins = len(log_obs_bin_edges) - 1
+    nbins = len(log_obs_bin_centers)
     model_fluxes = np.zeros(nbins, dtype=line_amplitudes.dtype)
 
-    # temporary buffer for per-line calculations, sized large
-    # enough for whatever we may need to compute ( [s..e) )
-    bin_vals = np.empty(nbins + 2, dtype=line_amplitudes.dtype)
+    # temporary buffer for per-line calculations
+    bin_vals = np.empty(nbins, dtype=line_amplitudes.dtype)
 
-    # compute total area of all Gaussians inside each bin.
-    # For each Gaussian, we only compute area contributions
-    # for bins where it is non-negligible.
     for j in range(len(line_wavelengths)):
 
         if line_amplitudes[j] == 0.:
@@ -63,12 +58,11 @@ def emline_model(line_wavelengths,
                                  line_amplitudes[j],
                                  line_vshifts[j],
                                  line_sigmas[j],
-                                 log_obs_bin_edges,
+                                 log_obs_bin_centers,
                                  redshift,
-                                 ibin_widths,
+                                 sigma_G,
                                  bin_vals)
 
-        # add bin avgs for this peak to bins [s, e)
         model_fluxes[s:e] += bin_vals[:e-s]
 
     return model_fluxes
@@ -77,9 +71,9 @@ def emline_model(line_wavelengths,
 @jit(nopython=True, nogil=True, cache=True)
 def emline_perline_models(line_wavelengths,
                           line_parameters,
-                          log_obs_bin_edges,
+                          log_obs_bin_centers,
                           redshift,
-                          ibin_widths,
+                          sigma_G,
                           padding):
     """Compute the per-line emission-line flux profiles sparsely.
 
@@ -93,12 +87,12 @@ def emline_perline_models(line_wavelengths,
     line_parameters : :class:`numpy.ndarray`
         Concatenated array of amplitudes, velocity shifts, and sigmas for
         all lines.
-    log_obs_bin_edges : :class:`numpy.ndarray`
-        Natural logs of observed wavelength bin edges.
+    log_obs_bin_centers : :class:`numpy.ndarray`
+        Natural logs of observed wavelength bin centers.
     redshift : float
         Redshift of the observed spectrum.
-    ibin_widths : :class:`numpy.ndarray`
-        Inverse widths of each observed wavelength bin.
+    sigma_G : float
+        Gaussian pre-convolution width in Angstroms.
     padding : int
         Extra entries to pad each sparse row for later use.
 
@@ -114,20 +108,12 @@ def emline_perline_models(line_wavelengths,
     line_amplitudes, line_vshifts, line_sigmas = \
         np.split(line_parameters, 3)
 
-    nbins = len(log_obs_bin_edges) - 1
-
-    # buffers for per-line calculations, sized large
-    # enough for max possible range [s .. e), plus extra
-    # padding as directed by caller.
-    max_width = max_buffer_width(log_obs_bin_edges, line_sigmas, padding)
+    max_width = max_buffer_width(log_obs_bin_centers, line_sigmas, padding, sigma_G)
 
     nlines = len(line_wavelengths)
     line_profiles = np.empty((nlines, max_width), dtype=line_amplitudes.dtype)
     endpts        = np.zeros((nlines, 2), dtype=np.int32)
 
-    # compute total area of all Gaussians inside each bin.
-    # For each Gaussian, we only compute area contributions
-    # for bins where it is non-negligible.
     for j in range(nlines):
 
         if line_amplitudes[j] == 0.:
@@ -139,9 +125,9 @@ def emline_perline_models(line_wavelengths,
                                  line_amplitudes[j],
                                  line_vshifts[j],
                                  line_sigmas[j],
-                                 log_obs_bin_edges,
+                                 log_obs_bin_centers,
                                  redshift,
-                                 ibin_widths,
+                                 sigma_G,
                                  bin_vals)
 
         endpts[j,0] = s
@@ -155,15 +141,17 @@ def emline_model_core(line_wavelength,
                       line_amplitude,
                       line_vshift,
                       line_sigma,
-                      log_obs_bin_edges,
+                      log_obs_bin_centers,
                       redshift,
-                      ibin_widths,
+                      sigma_G,
                       vals):
-    """Compute the flux contribution of one spectral line to a model spectrum.
+    """Compute the Gaussian-convolved flux of one spectral line at each pixel.
 
-    Determines the range of bins where the line contributes flux, writes
-    those contributions to ``vals``, and returns the half-open bin range
-    ``[s, e)``.
+    Evaluates ``F_sigma(lambda_j) = A * (sigma/sigma_eff) * exp(-x_j^2 /
+    (2*sigma_eff^2))`` at each pixel center ``lambda_j`` in the nonzero
+    range, where ``sigma_eff = sqrt(sigma^2 + (sigma_G/lambda*)^2)`` accounts
+    for the Gaussian pre-convolution that the deconvolved resolution matrix W
+    expects as input.
 
     Parameters
     ----------
@@ -174,98 +162,60 @@ def emline_model_core(line_wavelength,
     line_vshift : float
         Velocity shift of the line in km/s.
     line_sigma : float
-        Gaussian width of the line in km/s.
-    log_obs_bin_edges : :class:`numpy.ndarray`
-        Natural logs of observed wavelength bin edges.
+        Intrinsic Gaussian width of the line in km/s.
+    log_obs_bin_centers : :class:`numpy.ndarray`
+        Natural logs of observed wavelength pixel centers.
     redshift : float
         Redshift of the observed spectrum.
-    ibin_widths : :class:`numpy.ndarray`
-        Inverse widths of each observed wavelength bin.
+    sigma_G : float
+        Gaussian pre-convolution width in Angstroms (must match the value
+        used to build the deconvolved resolution matrix W).
     vals : :class:`numpy.ndarray`
-        Output array in which nonzero bin fluxes are written.
+        Output array in which nonzero pixel fluxes are written starting at
+        ``vals[0]``.
 
     Returns
     -------
     s : int
-        Index of the first bin with nonzero flux.
+        Index of the first pixel with nonzero flux.
     e : int
-        One past the index of the last bin with nonzero flux.
+        One past the index of the last pixel with nonzero flux.
         ``vals[0:e-s]`` contains the fluxes. If ``s == e``, no nonzero
         fluxes were found.
 
-    Notes
-    -----
-    ``vals`` must have length at least two more than the maximum possible
-    number of nonzero bins. Entries beyond the returned range may be
-    set to arbitrary values.
-
     """
 
-    SQRT_2PI = np.sqrt(2 * np.pi)
-
-    # line width
+    # intrinsic line width in log-lambda units
     sigma = line_sigma / C_LIGHT
 
-    c = SQRT_2PI * sigma * np.exp(0.5 * sigma**2)
-
-    # wavelength shift for spectral lines
-    line_shift = 1. + redshift + line_vshift / C_LIGHT
-
+    # observed line center
+    line_shift       = 1. + redshift + line_vshift / C_LIGHT
     shifted_line     = line_wavelength * line_shift
     log_shifted_line = np.log(shifted_line)
 
-    # leftmost edge i that needs a value (> 0) for this line
-    lo = np.searchsorted(log_obs_bin_edges,
-                         log_shifted_line - MAX_SDEV * sigma,
-                         side="left")
+    # effective sigma in log-lambda after Gaussian pre-convolution;
+    # sigma_G / lambda* converts the linear-space sigma to log-space
+    sigma_G_log = sigma_G / shifted_line
+    sigma_eff   = np.sqrt(sigma**2 + sigma_G_log**2)
 
-    # leftmost edge i that does *not* need a value (== 1) for this line
-    hi = np.searchsorted(log_obs_bin_edges,
-                         log_shifted_line + MAX_SDEV * sigma,
+    # amplitude factor A * (sigma / sigma_eff)
+    amp_eff = line_amplitude * sigma / sigma_eff
+
+    # find range of pixels where line is non-negligible
+    lo = np.searchsorted(log_obs_bin_centers,
+                         log_shifted_line - MAX_SDEV * sigma_eff,
+                         side="left")
+    hi = np.searchsorted(log_obs_bin_centers,
+                         log_shifted_line + MAX_SDEV * sigma_eff,
                          side="right")
 
-    # check if entire Gaussian is outside bounds of log_obs_bin_edges
-    if hi == 0 or lo == len(log_obs_bin_edges):
-        return (0,0)
+    if hi == 0 or lo == len(log_obs_bin_centers):
+        return (0, 0)
 
-    nedges = hi - lo + 2  # compute values at edges [lo - 1 ... hi]
+    inv_2_sigma_eff_sq = 0.5 / sigma_eff**2
 
-    A = c * line_amplitude * shifted_line
-    offset = (log_shifted_line / sigma + sigma)  if sigma > 0. else 0.
+    for i in range(lo, hi):
+        x = log_obs_bin_centers[i] - log_shifted_line
+        vals[i - lo] = amp_eff * np.exp(-x**2 * inv_2_sigma_eff_sq)
 
-    # vals[i] --> edge i + lo - 1
-
-    vals[0] = 0.  # edge lo - 1
-
-    for i in range(1, nedges-1):
-
-        # x = (log(lambda_j) - mu_i)/sigma - sigma,
-        # the argument of the Gaussian integral
-
-        x = log_obs_bin_edges[i+lo-1]/sigma - offset
-        vals[i] = A * norm_cdf(x)
-
-    vals[nedges-1] = A  # edge hi
-
-    # Compute avg of bin i+lo-1 for 0 <= i < nedges - 1.
-    # But:
-    #  * if lo == 0, bin lo - 1 is not defined, so skip it
-    #  * if hi == |log_obs_bin_edges|, bin hi - 1 is not defined,
-    #      so skip it
-    # Implement skips by modifying range of computation loop.
-    #
-    # After loop, vals contains weighted area of bins
-    # lo - 1 + dlo .. hi - dhi, plus up to two cells of
-    # trailing garbage.
-    #
-    # We ensure that values for all valid bins are written
-    # starting at vals[0], and return the range of indices
-    # of the computed bins w/r to the input bin array.
-
-    dlo = 1 if lo == 0                      else 0
-    dhi = 1 if hi == len(log_obs_bin_edges) else 0
-
-    for i in range(dlo, nedges - 1 - dhi):
-        vals[i-dlo] = (vals[i+1] - vals[i]) * ibin_widths[i+lo]
-
-    return (lo - 1 + dlo, hi - dhi)
+    return (lo, hi)

--- a/py/fastspecfit/emline_fit/utils.py
+++ b/py/fastspecfit/emline_fit/utils.py
@@ -1,74 +1,12 @@
 import numpy as np
-from math import erf, erfc
 
 from numba import jit
 
 from fastspecfit.util import C_LIGHT
 
 
-# Do not bother computing normal PDF/CDF if more than this many
-# standard deviations from mean.
+# Do not bother computing the Gaussian outside this many standard deviations.
 MAX_SDEV = 5.
-
-
-@jit(nopython=True, nogil=True, cache=True)
-def norm_pdf(a):
-    """PDF of the standard normal distribution.
-
-    Parameters
-    ----------
-    a : float
-        Evaluation point.
-
-    Returns
-    -------
-    float
-        Probability density at ``a``.
-
-    """
-
-    SQRT_2PI = np.sqrt(2 * np.pi)
-
-    return 1/SQRT_2PI * np.exp(-0.5 * a**2)
-
-
-@jit(nopython=True, nogil=True, cache=True)
-def norm_cdf(a):
-    """Approximate the CDF of the standard normal distribution.
-
-    Parameters
-    ----------
-    a : float
-        Upper integration limit.
-
-    Returns
-    -------
-    float
-        Integral of the standard normal PDF from :math:`-\\infty` to ``a``.
-
-    """
-
-    SQRT1_2 = 1.0 / np.sqrt(2)
-
-    z = np.abs(a)
-
-    # Optimization (currently disabled because it is not needed): If
-    # |a| > MAX_SDEV, treat the value as extreme and return 0 or 1 as
-    # appropriate.
-
-    #if z > MAX_SDEV: # short-circuit extreme values
-    #    if a > 0:
-    #        y = 1.
-    #    else:
-    #        y = 0.
-    if z < 1.:
-        y = 0.5 + 0.5 * erf(a * SQRT1_2)
-    else:
-        y = 0.5 * erfc(z * SQRT1_2)
-        if a > 0:
-            y = 1.0 - y
-
-    return y
 
 
 @jit(nopython=True, nogil=True, cache=True)

--- a/py/fastspecfit/emline_fit/utils.py
+++ b/py/fastspecfit/emline_fit/utils.py
@@ -72,17 +72,19 @@ def norm_cdf(a):
 
 
 @jit(nopython=True, nogil=True, cache=True)
-def max_buffer_width(log_obs_bin_edges, line_sigmas, padding=0):
+def max_buffer_width(log_obs_bin_centers, line_sigmas, padding=0, sigma_G_angstrom=0.):
     """Estimate the maximum number of nonzero bins possible for any spectral line.
 
     Parameters
     ----------
-    log_obs_bin_edges : :class:`np.ndarray`
-        Log wavelengths of all observed bin edges.
+    log_obs_bin_centers : :class:`np.ndarray`
+        Log wavelengths of all observed bin centers.
     line_sigmas : :class:`np.ndarray`
         Gaussian widths of all spectral lines in km/s.
     padding : int, optional
         Extra bins to add on each side for future expansion. Defaults to 0.
+    sigma_G_angstrom : float, optional
+        Gaussian pre-convolution width in Angstroms. Defaults to 0.
 
     Returns
     -------
@@ -91,12 +93,14 @@ def max_buffer_width(log_obs_bin_edges, line_sigmas, padding=0):
 
     """
 
-    # Find the largest width sigma for any line, and
-    # allocate enough space for twice that much width
-    # in bins, given the smallest observed bin width.
-    # Add padding and a little fudge factor to be safe.
+    # Effective max sigma in log-lambda, including Gaussian pre-convolution floor.
+    sigma_max = np.max(line_sigmas) / C_LIGHT
+    lambda_min = np.exp(log_obs_bin_centers[0])
+    sigma_G_log = sigma_G_angstrom / lambda_min
+    sigma_eff_max = np.sqrt(sigma_max**2 + sigma_G_log**2)
+
     max_width = \
-        int(2*MAX_SDEV*np.max(line_sigmas/C_LIGHT) / \
-            np.min(np.diff(log_obs_bin_edges))) + \
+        int(2*MAX_SDEV*sigma_eff_max / \
+            np.min(np.diff(log_obs_bin_centers))) + \
             2*padding + 4
     return max_width

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -954,18 +954,9 @@ class EMFitTools(object):
 
                         # require amp > 0 (line not dropped) to compute the flux
                         if obsamps[line_amp] > TINY:
-                            # analytically integrated flux
-                            #flux = np.sqrt(2. * np.pi) * parameters[line_amp] * linezwave * linesigma0 / C_LIGHT
-                            # pixel-integrated model flux
-                            flux = line_fluxes[line_amp]
-                            #if np.isin(linename, ['OIII_5007', 'NII_6584', 'HALPHA', 'HBETA']):
-                            #    print(linename)
-                            #    print("observed amp:  ", obsamps[line_amp])
-                            #    print("model amp:     ", parameters[line_amp])
-                            #    print("sigma_kms:     ", values[line_sigma])
-                            #    print("FLUX-analytic: ", np.sqrt(2*np.pi) * parameters[line_amp] * linezwave * values[line_sigma] / C_LIGHT)
-                            #    print("FLUX-integral: ", flux)
-                            #    print("BOXFLUX:   ", boxflux)
+                            # intrinsic line flux: integral of the log-Gaussian A*exp(-(log lambda - mu)^2/(2*sigma^2))
+                            # = sqrt(2*pi) * A * sigma * lambda*, independent of the resolution matrix
+                            flux = np.sqrt(2. * np.pi) * parameters[line_amp] * linezwave * linesigma0 / C_LIGHT
 
                         # next, get the continuum level
                         borderindx = get_continuum_pixels(emlinewave_s, linezwave, linesigma_ang_window)

--- a/py/fastspecfit/test/test_emline_fit.py
+++ b/py/fastspecfit/test/test_emline_fit.py
@@ -279,6 +279,19 @@ class TestEmlineModelJacobian:
             assert np.allclose(analytic, fd, atol=1e-6, rtol=1e-3), \
                 f"Jacobian mismatch for parameter index {k}"
 
+    def test_zero_sigma_no_error(self, grid, single_line):
+        """Jacobian does not raise when line_sigma=0 (sigma derivative has a finite limit)."""
+        from fastspecfit.emline_fit.jacobian import emline_model_jacobian
+        lw, p = _line_arrays(single_line)
+        p = p.copy()
+        p[2] = 0.  # zero line width
+        endpts, dd = emline_model_jacobian(p, grid['log_centers'],
+                                           single_line['redshift'], lw, SIGMA_G, padding=0)
+        # sigma derivative row should be all finite (no NaN/inf)
+        nlines = len(lw)
+        s, e = endpts[2 * nlines]
+        assert np.all(np.isfinite(dd[2 * nlines, :e - s]))
+
 
 # ── flux recovery ─────────────────────────────────────────────────────────────
 

--- a/py/fastspecfit/test/test_emline_fit.py
+++ b/py/fastspecfit/test/test_emline_fit.py
@@ -83,48 +83,6 @@ def _mapping(nParms, isFree, tiedSources=None, tiedFactors=None,
                          doubletTargets, doubletSources)
 
 
-# ── norm_cdf ──────────────────────────────────────────────────────────────────
-
-class TestNormCDF:
-
-    def test_midpoint(self):
-        from fastspecfit.emline_fit.utils import norm_cdf
-        assert np.isclose(norm_cdf(0.), 0.5)
-
-    def test_symmetry(self):
-        from fastspecfit.emline_fit.utils import norm_cdf
-        for x in (0.5, 1.0, 2.0, 3.0):
-            assert np.isclose(norm_cdf(x) + norm_cdf(-x), 1.0, atol=1e-10)
-
-    def test_extremes(self):
-        from fastspecfit.emline_fit.utils import norm_cdf
-        assert norm_cdf(8.) > 1. - 1e-10
-        assert norm_cdf(-8.) < 1e-10
-
-    def test_monotone(self):
-        from fastspecfit.emline_fit.utils import norm_cdf
-        cdfs = np.array([norm_cdf(x) for x in np.linspace(-5, 5, 50)])
-        assert np.all(np.diff(cdfs) > 0)
-
-
-# ── norm_pdf ──────────────────────────────────────────────────────────────────
-
-class TestNormPDF:
-
-    def test_peak(self):
-        from fastspecfit.emline_fit.utils import norm_pdf
-        assert np.isclose(norm_pdf(0.), 1. / np.sqrt(2 * np.pi))
-
-    def test_symmetry(self):
-        from fastspecfit.emline_fit.utils import norm_pdf
-        for x in (0.5, 1.0, 2.0):
-            assert np.isclose(norm_pdf(x), norm_pdf(-x))
-
-    def test_positive(self):
-        from fastspecfit.emline_fit.utils import norm_pdf
-        assert all(norm_pdf(x) > 0 for x in np.linspace(-5, 5, 20))
-
-
 # ── max_buffer_width ──────────────────────────────────────────────────────────
 
 class TestMaxBufferWidth:

--- a/py/fastspecfit/test/test_emline_fit.py
+++ b/py/fastspecfit/test/test_emline_fit.py
@@ -17,27 +17,28 @@ SIGMA_G = 0.5  # Angstroms
 
 @pytest.fixture(scope='module')
 def grid():
-    """Uniform log-lambda bin grid spanning the DESI wavelength range."""
-    nbin = 5000
-    log_edges = np.linspace(np.log(3600.), np.log(9900.), nbin + 1)
-    log_centers = 0.5 * (log_edges[:-1] + log_edges[1:])
-    bin_widths = np.diff(np.exp(log_edges))  # pixel widths in Angstroms
-    return {'log_centers': log_centers, 'bin_widths': bin_widths, 'nbin': nbin}
+    """Linear-lambda grid matching the DESI wavelength spacing (0.8 Å/pixel)."""
+    dlambda = 0.8  # Angstroms, nominal DESI pixel scale
+    edges = np.arange(3600., 9825., dlambda)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    log_centers = np.log(centers)
+    bin_widths = np.full(len(centers), dlambda)
+    return {'log_centers': log_centers, 'bin_widths': bin_widths, 'nbin': len(centers)}
 
 
 @pytest.fixture(scope='module')
 def flux_grid():
-    """Compact log-lambda grid around Hα at z=0.1 with a DESI-like pixel scale."""
-    lam_center = 6563. * 1.1  # Hα observed at z=0.1
-    dloglam = 8e-5             # ~DESI pixel scale in log-lambda (~0.58 Å at 7200 Å)
+    """Linear-lambda grid around Hα at z=0.1 with DESI pixel scale (0.8 Å/pixel)."""
+    dlambda = 0.8  # Angstroms
+    lam_center = 6563. * 1.1  # Hα observed at z=0.1 (~7219 Å)
     nbin = 400
-    log_edges = np.linspace(np.log(lam_center) - (nbin / 2) * dloglam,
-                            np.log(lam_center) + (nbin / 2) * dloglam,
-                            nbin + 1)
-    log_centers = 0.5 * (log_edges[:-1] + log_edges[1:])
-    bin_widths = np.diff(np.exp(log_edges))
+    edges = lam_center + (np.arange(nbin + 1) - nbin / 2) * dlambda
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    log_centers = np.log(centers)
+    bin_widths = np.full(nbin, dlambda)
+    dloglam_center = dlambda / lam_center  # pixel width in log-lambda at line center
     return {'log_centers': log_centers, 'bin_widths': bin_widths,
-            'nbin': nbin, 'dloglam': dloglam}
+            'nbin': nbin, 'dloglam_center': dloglam_center}
 
 
 @pytest.fixture(scope='module')
@@ -347,7 +348,7 @@ class TestFluxRecovery:
 
         amp, rest_wave, redshift = 1.0, 6563., 0.1
         n_steps = 25
-        dloglam = flux_grid['dloglam']
+        dloglam = flux_grid['dloglam_center']
 
         for sigma_kms in [5., 15., 50.]:
             fluxes = []

--- a/py/fastspecfit/test/test_emline_fit.py
+++ b/py/fastspecfit/test/test_emline_fit.py
@@ -9,6 +9,9 @@ import pytest
 
 from fastspecfit.util import C_LIGHT
 
+# DESI Gaussian pre-convolution width (σ_G); must match resolution.SIGMA0_ANGSTROM
+SIGMA_G = 0.5  # Angstroms
+
 
 # ── shared fixtures ───────────────────────────────────────────────────────────
 
@@ -16,10 +19,25 @@ from fastspecfit.util import C_LIGHT
 def grid():
     """Uniform log-lambda bin grid spanning the DESI wavelength range."""
     nbin = 5000
-    edges = np.exp(np.linspace(np.log(3600.), np.log(9900.), nbin + 1))
-    log_edges = np.log(edges)
-    ibin_widths = 1. / np.diff(log_edges)
-    return {'log_edges': log_edges, 'ibin_widths': ibin_widths, 'nbin': nbin}
+    log_edges = np.linspace(np.log(3600.), np.log(9900.), nbin + 1)
+    log_centers = 0.5 * (log_edges[:-1] + log_edges[1:])
+    bin_widths = np.diff(np.exp(log_edges))  # pixel widths in Angstroms
+    return {'log_centers': log_centers, 'bin_widths': bin_widths, 'nbin': nbin}
+
+
+@pytest.fixture(scope='module')
+def flux_grid():
+    """Compact log-lambda grid around Hα at z=0.1 with a DESI-like pixel scale."""
+    lam_center = 6563. * 1.1  # Hα observed at z=0.1
+    dloglam = 8e-5             # ~DESI pixel scale in log-lambda (~0.58 Å at 7200 Å)
+    nbin = 400
+    log_edges = np.linspace(np.log(lam_center) - (nbin / 2) * dloglam,
+                            np.log(lam_center) + (nbin / 2) * dloglam,
+                            nbin + 1)
+    log_centers = 0.5 * (log_edges[:-1] + log_edges[1:])
+    bin_widths = np.diff(np.exp(log_edges))
+    return {'log_centers': log_centers, 'bin_widths': bin_widths,
+            'nbin': nbin, 'dloglam': dloglam}
 
 
 @pytest.fixture(scope='module')
@@ -113,19 +131,19 @@ class TestMaxBufferWidth:
 
     def test_positive(self, grid):
         from fastspecfit.emline_fit.utils import max_buffer_width
-        assert max_buffer_width(grid['log_edges'], np.array([100.])) > 0
+        assert max_buffer_width(grid['log_centers'], np.array([100.])) > 0
 
     def test_wider_sigma_gives_wider_buffer(self, grid):
         from fastspecfit.emline_fit.utils import max_buffer_width
-        w_narrow = max_buffer_width(grid['log_edges'], np.array([50.]))
-        w_wide   = max_buffer_width(grid['log_edges'], np.array([500.]))
+        w_narrow = max_buffer_width(grid['log_centers'], np.array([50.]))
+        w_wide   = max_buffer_width(grid['log_centers'], np.array([500.]))
         assert w_wide > w_narrow
 
     def test_padding(self, grid):
         from fastspecfit.emline_fit.utils import max_buffer_width
         sigmas = np.array([100.])
-        w0 = max_buffer_width(grid['log_edges'], sigmas, padding=0)
-        w5 = max_buffer_width(grid['log_edges'], sigmas, padding=5)
+        w0 = max_buffer_width(grid['log_centers'], sigmas, padding=0)
+        w5 = max_buffer_width(grid['log_centers'], sigmas, padding=5)
         assert w5 == w0 + 10  # 2*padding added per call
 
 
@@ -137,82 +155,67 @@ class TestEmlineModel:
         from fastspecfit.emline_fit.model import emline_model
         lw, p = _line_arrays(single_line)
         p = p.copy(); p[0] = 0.
-        model = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
-                             grid['ibin_widths'])
+        model = emline_model(lw, p, grid['log_centers'], single_line['redshift'], 0.)
         assert np.all(model == 0.)
 
     def test_out_of_range_line_gives_zeros(self, grid):
         from fastspecfit.emline_fit.model import emline_model
         lw = np.array([50000.])  # far redward of the grid
         p  = np.array([1., 0., 100.])
-        model = emline_model(lw, p, grid['log_edges'], 0., grid['ibin_widths'])
+        model = emline_model(lw, p, grid['log_centers'], 0., 0.)
         assert np.all(model == 0.)
 
     def test_nonnegative(self, grid, single_line):
         from fastspecfit.emline_fit.model import emline_model
         lw, p = _line_arrays(single_line)
-        model = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
-                             grid['ibin_widths'])
+        model = emline_model(lw, p, grid['log_centers'], single_line['redshift'], 0.)
         assert np.all(model >= 0.)
 
     def test_amplitude_scaling(self, grid, single_line):
         from fastspecfit.emline_fit.model import emline_model
         lw, p = _line_arrays(single_line)
-        m1 = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
-                          grid['ibin_widths'])
+        m1 = emline_model(lw, p, grid['log_centers'], single_line['redshift'], 0.)
         p3 = p.copy(); p3[0] *= 3.
-        m3 = emline_model(lw, p3, grid['log_edges'], single_line['redshift'],
-                          grid['ibin_widths'])
+        m3 = emline_model(lw, p3, grid['log_centers'], single_line['redshift'], 0.)
         assert np.allclose(3. * m1, m3)
 
     def test_flux_conservation(self, grid, single_line):
-        """Integrated model flux matches the expected Gaussian normalization."""
+        """Riemann sum F_σ · Δλ matches the analytic line flux sqrt(2π)·A·σ·λ*."""
         from fastspecfit.emline_fit.model import emline_model
         lw, p = _line_arrays(single_line)
-        model = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
-                             grid['ibin_widths'])
-        total    = np.sum(model / grid['ibin_widths'])
-        sigma    = single_line['sigma'] / C_LIGHT
-        lam_obs  = single_line['rest_wave'] * (1. + single_line['redshift'])
-        expected = (np.sqrt(2 * np.pi) * sigma * np.exp(0.5 * sigma**2)
-                    * single_line['amplitude'] * lam_obs)
-        assert np.isclose(total, expected, rtol=1e-3)
+        model   = emline_model(lw, p, grid['log_centers'], single_line['redshift'], 0.)
+        total   = np.sum(model * grid['bin_widths'])
+        sigma   = single_line['sigma'] / C_LIGHT
+        lam_obs = single_line['rest_wave'] * (1. + single_line['redshift'])
+        expected = np.sqrt(2 * np.pi) * single_line['amplitude'] * sigma * lam_obs
+        assert np.isclose(total, expected, rtol=2e-3)
 
     def test_peak_at_redshifted_wavelength(self, grid, single_line):
         from fastspecfit.emline_fit.model import emline_model
         lw, p = _line_arrays(single_line)
-        model = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
-                             grid['ibin_widths'])
-        pk = np.argmax(model)
-        log_edges    = grid['log_edges']
-        peak_lambda  = np.exp(0.5 * (log_edges[pk] + log_edges[pk + 1]))
-        expected_lam = single_line['rest_wave'] * (1. + single_line['redshift'])
-        assert abs(peak_lambda - expected_lam) < 5.  # within 5 Å
+        model       = emline_model(lw, p, grid['log_centers'], single_line['redshift'], 0.)
+        pk          = np.argmax(model)
+        peak_lambda = np.exp(grid['log_centers'][pk])
+        expected    = single_line['rest_wave'] * (1. + single_line['redshift'])
+        assert abs(peak_lambda - expected) < 5.  # within 5 Å
 
     def test_vshift_moves_peak_redward(self, grid, single_line):
         from fastspecfit.emline_fit.model import emline_model
         lw, p = _line_arrays(single_line)
-        m0    = emline_model(lw, p, grid['log_edges'], single_line['redshift'],
-                             grid['ibin_widths'])
+        m0    = emline_model(lw, p, grid['log_centers'], single_line['redshift'], 0.)
         p_red = p.copy(); p_red[1] = 500.  # 500 km/s positive shift
-        m_red = emline_model(lw, p_red, grid['log_edges'], single_line['redshift'],
-                             grid['ibin_widths'])
+        m_red = emline_model(lw, p_red, grid['log_centers'], single_line['redshift'], 0.)
         assert np.argmax(m_red) > np.argmax(m0)
 
     def test_perline_models_match_composite(self, grid, single_line):
         """Sum of per-line profiles equals the composite model."""
         from fastspecfit.emline_fit.model import emline_model, emline_perline_models
-        from fastspecfit.emline_fit.utils import max_buffer_width
         lw, p = _line_arrays(single_line)
         z     = single_line['redshift']
-        le    = grid['log_edges']
-        ibw   = grid['ibin_widths']
+        lc    = grid['log_centers']
 
-        composite = emline_model(lw, p, le, z, ibw)
-
-        sigmas = np.array([p[2]])  # one line
-        padding = 0
-        endpts, profiles = emline_perline_models(lw, p, le, z, ibw, padding)
+        composite          = emline_model(lw, p, lc, z, 0.)
+        endpts, profiles   = emline_perline_models(lw, p, lc, z, 0., padding=0)
 
         reconstructed = np.zeros_like(composite)
         for j in range(len(lw)):
@@ -285,9 +288,9 @@ class TestEmlineModelJacobian:
         from fastspecfit.emline_fit.jacobian import emline_model_jacobian
         lw, p = _line_arrays(single_line)
         z     = single_line['redshift']
-        model = emline_model(lw, p, grid['log_edges'], z, grid['ibin_widths'])
-        endpts, dd = emline_model_jacobian(p, grid['log_edges'], grid['ibin_widths'],
-                                          z, lw, padding=0)
+        lc    = grid['log_centers']
+        model      = emline_model(lw, p, lc, z, SIGMA_G)
+        endpts, dd = emline_model_jacobian(p, lc, z, lw, SIGMA_G, padding=0)
         s, e = endpts[0]
         analytic = np.zeros_like(model)
         analytic[s:e] = dd[0, :e - s]
@@ -298,19 +301,18 @@ class TestEmlineModelJacobian:
         from fastspecfit.emline_fit.model import emline_model
         from fastspecfit.emline_fit.jacobian import emline_model_jacobian
         lw, p = _line_arrays(single_line)
-        z   = single_line['redshift']
-        le  = grid['log_edges']
-        ibw = grid['ibin_widths']
+        z      = single_line['redshift']
+        lc     = grid['log_centers']
         nlines = len(lw)
 
-        endpts, dd = emline_model_jacobian(p, le, ibw, z, lw, padding=0)
+        endpts, dd = emline_model_jacobian(p, lc, z, lw, SIGMA_G, padding=0)
 
         for k in range(len(p)):  # amplitude, vshift, sigma
             h   = 1e-4 * max(1., abs(p[k]))
             dp  = p.copy(); dp[k] += h
             dm  = p.copy(); dm[k] -= h
-            fd  = (emline_model(lw, dp, le, z, ibw) -
-                   emline_model(lw, dm, le, z, ibw)) / (2 * h)
+            fd  = (emline_model(lw, dp, lc, z, SIGMA_G) -
+                   emline_model(lw, dm, lc, z, SIGMA_G)) / (2 * h)
 
             row = k * nlines
             s, e = endpts[row]
@@ -319,3 +321,93 @@ class TestEmlineModelJacobian:
 
             assert np.allclose(analytic, fd, atol=1e-6, rtol=1e-3), \
                 f"Jacobian mismatch for parameter index {k}"
+
+
+# ── flux recovery ─────────────────────────────────────────────────────────────
+
+class TestFluxRecovery:
+    """Verify that the Gaussian point-evaluation model recovers the correct
+    integrated flux, including independence of sub-pixel line center position.
+
+    The key formula: for a pre-convolved Gaussian
+      F_σ(λ_j) = A · (σ/σ_eff) · exp(-x_j² / (2·σ_eff²)),
+      x_j = log(λ_j) - log(λ*)
+      σ_eff = sqrt(σ² + (σ_G/λ*)²)
+    the Riemann sum Σ F_σ(λ_j)·Δλ_j ≈ sqrt(2π)·A·σ·λ* (the analytic line flux),
+    independently of where the line center falls within the pixel grid.
+    """
+
+    def test_model_core_formula(self, flux_grid):
+        """emline_model_core pixel values exactly match the analytic F_σ formula."""
+        from fastspecfit.emline_fit.model import emline_model_core
+
+        amp, vshift, sigma_kms = 2.5, 0., 80.
+        rest_wave, redshift = 6563., 0.1
+
+        vals = np.zeros(flux_grid['nbin'])
+        lo, hi = emline_model_core(rest_wave, amp, vshift, sigma_kms,
+                                   flux_grid['log_centers'], redshift, SIGMA_G, vals)
+
+        sigma            = sigma_kms / C_LIGHT
+        shifted_line     = rest_wave * (1. + redshift + vshift / C_LIGHT)
+        log_shifted_line = np.log(shifted_line)
+        sigma_G_log      = SIGMA_G / shifted_line
+        sigma_eff        = np.sqrt(sigma**2 + sigma_G_log**2)
+        amp_eff          = amp * sigma / sigma_eff
+        inv_2_sig2       = 0.5 / sigma_eff**2
+
+        expected = np.array([
+            amp_eff * np.exp(-(flux_grid['log_centers'][i] - log_shifted_line)**2 * inv_2_sig2)
+            for i in range(lo, hi)
+        ])
+        assert np.allclose(vals[:hi - lo], expected, rtol=1e-12)
+
+    def test_flux_conservation(self, flux_grid):
+        """Riemann sum F_σ·Δλ matches sqrt(2π)·A·σ·λ* to within 1% for a broad line."""
+        from fastspecfit.emline_fit.model import emline_model
+
+        amp, vshift, sigma_kms = 1.0, 0., 150.
+        rest_wave, redshift = 6563., 0.1
+        lw = np.array([rest_wave])
+        p  = np.array([amp, vshift, sigma_kms])
+
+        model   = emline_model(lw, p, flux_grid['log_centers'], redshift, SIGMA_G)
+        total   = np.sum(model * flux_grid['bin_widths'])
+        sigma   = sigma_kms / C_LIGHT
+        lam_obs = rest_wave * (1. + redshift)
+        expected = np.sqrt(2 * np.pi) * amp * sigma * lam_obs
+        assert np.isclose(total, expected, rtol=1e-2)
+
+    def test_flux_position_independence(self, flux_grid):
+        """Flux sum varies by < 2% RMS as the line center moves across one pixel.
+
+        Scans σ = [5, 15, 50] km/s.  At DESI resolution, σ_G = 0.5 Å dominates
+        the effective width for narrow lines, keeping σ_eff ≥ 0.87 pixels and
+        ensuring the Riemann sum is accurate regardless of sub-pixel position.
+        """
+        from fastspecfit.emline_fit.model import emline_model_core
+
+        amp, rest_wave, redshift = 1.0, 6563., 0.1
+        n_steps = 25
+        dloglam = flux_grid['dloglam']
+
+        for sigma_kms in [5., 15., 50.]:
+            fluxes = []
+            for step in range(n_steps):
+                # shift the line center by step/n_steps of one pixel
+                dvshift = (step / n_steps) * dloglam * C_LIGHT
+                vals = np.zeros(flux_grid['nbin'])
+                lo, hi = emline_model_core(rest_wave, amp, dvshift, sigma_kms,
+                                           flux_grid['log_centers'], redshift,
+                                           SIGMA_G, vals)
+                if hi > lo:
+                    fluxes.append(
+                        np.sum(vals[:hi - lo] * flux_grid['bin_widths'][lo:hi])
+                    )
+
+            fluxes = np.array(fluxes)
+            rms = np.std(fluxes) / np.mean(fluxes)
+            assert rms < 0.02, (
+                f"sigma={sigma_kms} km/s: sub-pixel flux RMS variation "
+                f"{100*rms:.2f}% exceeds 2% threshold"
+            )

--- a/py/fastspecfit/test/test_emline_fit.py
+++ b/py/fastspecfit/test/test_emline_fit.py
@@ -8,9 +8,7 @@ import numpy as np
 import pytest
 
 from fastspecfit.util import C_LIGHT
-
-# DESI Gaussian pre-convolution width (σ_G); must match resolution.SIGMA0_ANGSTROM
-SIGMA_G = 0.5  # Angstroms
+from fastspecfit.resolution import SIGMA0_ANGSTROM as SIGMA_G
 
 
 # ── shared fixtures ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace the Buhler per-bin CDF integration forward model with Gaussian point evaluation: `F_σ(λ_j) = A·(σ/σ_eff)·exp(-x_j²/(2·σ_eff²))`, where `σ_eff = sqrt(σ² + (σ_G/λ*)²)` folds in the `σ_G = 0.5 Å` Gaussian pre-convolution that the deconvolved resolution matrix W expects as input.  The old model fed bin-integrated fluxes into W, which was constructed to accept Gaussian-convolved point values, causing position-dependent flux biases of 5–30% for lines narrower than one DESI pixel.
- Switch reported line flux from the pixel-integrated model sum to the analytic formula `sqrt(2π)·A·λ*·σ_kms/c`, which is independent of the resolution matrix and pixel grid.
- Update the Jacobian (`emline_model_jacobian`) for the new forward model, with analytic derivatives with respect to amplitude, velocity shift, and line width.
- Remove `norm_cdf` and `norm_pdf` (dead code after the model change).
- Update and extend unit tests: switch to a linear-lambda (0.8 Å/pixel) test grid matching the actual DESI pixel scale; add `TestFluxRecovery` with tests for exact pixel-value formula, broad-line flux conservation, and sub-pixel position independence of the recovered flux.

## Test plan

- [ ] All existing unit tests pass (`pytest py/fastspecfit/test/test_emline_fit.py`)
- [ ] New `TestFluxRecovery` tests pass, including `test_flux_position_independence` for σ = 5, 15, 50 km/s
- [ ] Integration tests pass (`pytest py/fastspecfit/test/test_fastspecfit.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)