### PR TITLE
use original resolution matrix when fitting the stellar continuum

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,11 @@ Change Log
 3.4.2 (not released yet)
 ------------------------
 
-*
+* Use original resolution matrix for continuum-fitting (deconvolved
+  resolution matrix was not being handled correctly, producing
+  spurious ringing [`PR #256`_].
+
+.. _`PR #256`: https://github.com/desihub/fastspecfit/pull/256
 
 3.4.1 (2026-05-26)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,8 @@ Change Log
 3.4.2 (not released yet)
 ------------------------
 
-* Use original resolution matrix for continuum-fitting (deconvolved
-  resolution matrix was not being handled correctly, producing
-  spurious ringing [`PR #256`_].
+* Use original resolution matrix for continuum-fitting; major bug fix
+  in resolution matrix deconvolution [`PR #256`_].
 
 .. _`PR #256`: https://github.com/desihub/fastspecfit/pull/256
 

--- a/py/fastspecfit/emline_fit/interface.py
+++ b/py/fastspecfit/emline_fit/interface.py
@@ -545,7 +545,7 @@ def _build_model_core(line_parameters,
                           redshift,
                           sigma_G)
 
-        resolution_matrices[icam].dot(mf, model_fluxes[s:e])
+        resolution_matrices[icam].dot_deconv(mf, model_fluxes[s:e])
 
 
 def _build_multimodel_core(line_parameters,

--- a/py/fastspecfit/resolution.py
+++ b/py/fastspecfit/resolution.py
@@ -154,20 +154,24 @@ class Resolution(object):
     """
     def __init__(self, data0):
         data = deconvolve_resolution_matrix(data0)
-        ndiag, dim  = data.shape
+        ndiag, dim  = data0.shape
         self.shape  = (dim, dim)
         self.ndiag  = ndiag
-        self.data   = data
-        self.rows   = None # compute on first use
+        self.data0  = data0  # raw resolution matrix R
+        self.data   = data   # deconvolved W = M^{-1} R, for emission-line fitting
+        self.rows   = None   # compute on first use
 
 
     def rowdata(self):
-        """Return the sparse row representation of the resolution matrix.
+        """Return the sparse row representation of the deconvolved matrix W.
+
+        Used by the emission-line Jacobian (``mulWMJ``). Always derived from
+        ``self.data`` (W = M^{-1} R), not the raw matrix.
 
         Returns
         -------
         rows : :class:`numpy.ndarray`, shape (dim, ndiag)
-            Nonzero entries for each row of the resolution matrix.
+            Nonzero entries for each row of W.
 
         """
         if self.rows is None:
@@ -176,7 +180,11 @@ class Resolution(object):
 
 
     def dot(self, v, out=None):
-        """Multiply the resolution matrix by vector ``v``.
+        """Multiply the raw resolution matrix R by vector ``v``.
+
+        Use for continuum models, which are always broader than a single pixel
+        and do not require the Gaussian pre-convolution assumed by the
+        deconvolved matrix. See :meth:`dot_deconv` for emission-line use.
 
         Parameters
         ----------
@@ -189,7 +197,34 @@ class Resolution(object):
         Returns
         -------
         out : :class:`numpy.ndarray`, shape (dim,)
-            Result of the matrix-vector product.
+            Result of the matrix-vector product R @ v.
+
+        """
+        if out is None:
+            out = np.empty(self.shape[0], dtype=v.dtype)
+
+        return self._matvec(self.data0, v, out)
+
+
+    def dot_deconv(self, v, out=None):
+        """Multiply the deconvolved matrix W = M^{-1} R by vector ``v``.
+
+        Use for emission-line models pre-convolved with the fiducial Gaussian
+        G (sigma = :data:`SIGMA0_ANGSTROM`). Do not use for continuum models;
+        see :meth:`dot`.
+
+        Parameters
+        ----------
+        v : :class:`numpy.ndarray`, shape (dim,)
+            Input vector.
+        out : :class:`numpy.ndarray` or None, optional
+            Pre-allocated output array of length ``dim``; allocated if
+            ``None``.
+
+        Returns
+        -------
+        out : :class:`numpy.ndarray`, shape (dim,)
+            Result of the matrix-vector product W @ v.
 
         """
         if out is None:
@@ -199,7 +234,10 @@ class Resolution(object):
 
 
     def matmat(self, V, out=None):
-        """Apply the resolution matrix to all rows of ``V`` (ntemplates × dim).
+        """Apply the raw resolution matrix R to all rows of ``V`` (ntemplates × dim).
+
+        Use for continuum template batches. See :meth:`matmat_deconv` for
+        emission-line use.
 
         Parameters
         ----------
@@ -210,6 +248,32 @@ class Resolution(object):
         Returns
         -------
         out : :class:`numpy.ndarray`, shape (ntemplates, dim)
+            Result of R @ V.T (applied row-wise).
+
+        """
+        if out is None:
+            out = np.empty_like(V)
+
+        return self._matmat(self.data0, V, out)
+
+
+    def matmat_deconv(self, V, out=None):
+        """Apply the deconvolved matrix W = M^{-1} R to all rows of ``V`` (ntemplates × dim).
+
+        Use for emission-line template batches pre-convolved with the fiducial
+        Gaussian G (sigma = :data:`SIGMA0_ANGSTROM`). See :meth:`matmat` for
+        continuum use.
+
+        Parameters
+        ----------
+        V : :class:`numpy.ndarray`, shape (ntemplates, dim)
+        out : :class:`numpy.ndarray` or None, optional
+            Pre-allocated output of the same shape; allocated if ``None``.
+
+        Returns
+        -------
+        out : :class:`numpy.ndarray`, shape (ntemplates, dim)
+            Result of W @ V.T (applied row-wise).
 
         """
         if out is None:

--- a/py/fastspecfit/resolution.py
+++ b/py/fastspecfit/resolution.py
@@ -80,9 +80,9 @@ def _mat_tocolumns(mat):
     w2 = w // 2
     result = np.empty((w, npix), dtype=mat.dtype)
     for r in range(w):
-        shift = r - w2
+        shift = w2 - r
         for j in range(npix):
-            result[r, j] = mat[r, (j - shift) % npix]
+            result[r, j] = mat[w - 1 - r, (j - shift) % npix]
     return result
 
 
@@ -130,6 +130,21 @@ def deconvolve_resolution_matrix(mat0,
         # Fallback for non-standard matrix widths
         gau_mat = _make_gaussian_matrix(width, sigma0_angstrom, pix_size_angstrom)
         mat_rows1 = scipy.linalg.solve(gau_mat, mat_rows)
+
+    # Renormalize the w2 edge columns of W_rows so their column sums match
+    # the interior median. Edge pixels of the DESI extraction have truncated
+    # kernels; without this step W under-weights flux at camera boundaries.
+    mult = float(np.median(mat_rows1.sum(axis=0)))
+    if mult == 0.:
+        mult = 1.
+    for i in range(w2):
+        N1 = mat_rows1[w2 - i:, i].sum()
+        if N1 != 0.:
+            mat_rows1[:, i] *= mult / N1
+        j = npix - 1 - i
+        N2 = mat_rows1[:w2 + 1 + i, j].sum()
+        if N2 != 0.:
+            mat_rows1[:, j] *= mult / N2
 
     return _mat_tocolumns(mat_rows1)
 

--- a/py/fastspecfit/test/test_resolution.py
+++ b/py/fastspecfit/test/test_resolution.py
@@ -47,6 +47,11 @@ class TestDiagConversions:
         from fastspecfit.resolution import _mat_torows
         assert np.allclose(_mat_torows(_mat_torows(diag_matrix)), diag_matrix)
 
+    def test_tocolumns_roundtrip(self, diag_matrix):
+        """_mat_tocolumns(_mat_torows(X)) recovers X exactly."""
+        from fastspecfit.resolution import _mat_torows, _mat_tocolumns
+        assert np.allclose(_mat_tocolumns(_mat_torows(diag_matrix)), diag_matrix)
+
     def test_torows_preserves_center_diagonal(self, diag_matrix):
         from fastspecfit.resolution import _mat_torows
         w2 = diag_matrix.shape[0] // 2

--- a/py/fastspecfit/test/test_resolution.py
+++ b/py/fastspecfit/test/test_resolution.py
@@ -94,6 +94,8 @@ class TestResolution:
     def test_ndiag(self, diag_matrix, res):
         assert res.ndiag == diag_matrix.shape[0]
 
+    # ── dot (raw R) ───────────────────────────────────────────────────────────
+
     def test_dot_output_shape(self, res):
         npix = res.shape[0]
         v = np.ones(npix)
@@ -124,6 +126,53 @@ class TestResolution:
     def test_dot_zero_vector(self, res):
         v = np.zeros(res.shape[0])
         assert np.all(res.dot(v) == 0.)
+
+    def test_dot_uses_raw_matrix(self, diag_matrix, res):
+        """dot applies data0 (raw R), not the deconvolved W."""
+        npix = res.shape[0]
+        v    = np.ones(npix)
+        # Reconstruct what a raw matvec should produce from data0 directly.
+        from fastspecfit.resolution import Resolution
+        ndiag = diag_matrix.shape[0]
+        expected = np.zeros(npix)
+        w2 = ndiag // 2
+        for i in range(ndiag):
+            k       = w2 - i
+            i_start = max(0, -k)
+            j_start = max(0,  k)
+            j_end   = min(npix + k, npix)
+            for n in range(j_end - j_start):
+                expected[i_start + n] += diag_matrix[i, j_start + n] * v[j_start + n]
+        assert np.allclose(res.dot(v), expected)
+
+    # ── dot_deconv (deconvolved W) ────────────────────────────────────────────
+
+    def test_dot_deconv_output_shape(self, res):
+        npix = res.shape[0]
+        v = np.ones(npix)
+        assert res.dot_deconv(v).shape == (npix,)
+
+    def test_dot_deconv_out_parameter(self, res):
+        npix = res.shape[0]
+        v   = np.ones(npix)
+        out = np.empty(npix)
+        result = res.dot_deconv(v, out=out)
+        assert result is out
+        assert np.allclose(result, res.dot_deconv(v))
+
+    def test_dot_deconv_linearity(self, res):
+        rng = np.random.default_rng(7)
+        v   = rng.standard_normal(res.shape[0])
+        a   = 2.5
+        assert np.allclose(res.dot_deconv(a * v), a * res.dot_deconv(v))
+
+    def test_dot_deconv_differs_from_dot(self, res):
+        """dot and dot_deconv operate on different matrices."""
+        rng = np.random.default_rng(99)
+        v   = rng.standard_normal(res.shape[0])
+        assert not np.allclose(res.dot(v), res.dot_deconv(v))
+
+    # ── rowdata ───────────────────────────────────────────────────────────────
 
     def test_rowdata_shape(self, res):
         rows = res.rowdata()


### PR DESCRIPTION
#244 implemented a deconvolved resolution matrix for the emission-line fitting, as recommended by @segasai. However, that same R matrix was being used for the stellar continuum fitting but never accounted for in the cached stellar templates, which showed up as high-frequency "ringing" in the model spectra (RHS vs LHS, for a tiny little bit of spectrum)--

<img width="605" height="219" alt="Screenshot 2026-05-28 at 9 31 06 AM" src="https://github.com/user-attachments/assets/5893b297-7089-43c5-8823-1f4d2931bf4d" />

In this PR we keep both the original and deconvolved resolution matrices and use the former for the continuum-fitting (which does not solve for any radial velocity shifts and the fit is performed over hundreds or thousands of pixels) and the latter in the emission-line fitting.

@dirkscholte please test on our MODS sample if you get a chance.