### PR TITLE
Introduce YAML-based emission-line kinematic constraint system

### DIFF
--- a/bin/generate-fast-slurm
+++ b/bin/generate-fast-slurm
@@ -39,10 +39,6 @@ _ACCOUNT   = 'desi'
 _QOS       = 'regular'
 _MAIL_USER = 'jmoustakas@siena.edu'
 
-# Pick up OUTDIR_DATA from the environment (set by fastspecfit-env.sh) or fall
-# back to the standard PSCRATCH location.
-_OUTDIR = os.environ.get('OUTDIR_DATA') or os.path.expandvars('$PSCRATCH/fastspecfit/data')
-
 def _default_env_script():
     # Prefer a locally-edited copy in the current working directory (the normal
     # production workflow copies etc/fastspecfit-env.sh to $OUTDIR_DATA and edits it there).
@@ -54,7 +50,40 @@ def _default_env_script():
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
         'etc', 'fastspecfit-env.sh')
 
+
+def _outdir_from_env_script(env_script):
+    """Parse OUTDIR_DATA from env_script without sourcing the full file.
+
+    Finds the ``export OUTDIR_DATA=...`` line and evaluates it in a minimal
+    bash subshell so that shell variables like ``$PSCRATCH`` still expand.
+    Returns None if the file cannot be read or the line is not found.
+    """
+    import re, subprocess
+    try:
+        with open(env_script) as fh:
+            for line in fh:
+                m = re.match(r'\s*export\s+OUTDIR_DATA\s*=(.*)', line)
+                if m:
+                    val = m.group(1).strip()
+                    r = subprocess.run(['bash', '-c', f'echo {val}'],
+                                       capture_output=True, text=True, timeout=5)
+                    result = r.stdout.strip()
+                    if result:
+                        return result
+    except Exception:
+        pass
+    return None
+
+
 _ENV_SCRIPT = _default_env_script()
+
+# OUTDIR_DATA priority:
+#   1. already set in the environment (user sourced the env script manually)
+#   2. parsed from the local fastspecfit-env.sh (user edited but did not source)
+#   3. standard PSCRATCH fallback
+_OUTDIR = (os.environ.get('OUTDIR_DATA')
+           or _outdir_from_env_script(_ENV_SCRIPT)
+           or os.path.expandvars('$PSCRATCH/fastspecfit/data'))
 
 # Maximum wall-clock hours allowed for the chosen QOS (used when --time is not given).
 _MAX_HOURS = {'regular': 12, 'debug': 0.5, 'premium': 24}

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,16 @@ Change Log
 3.4.2 (not released yet)
 ------------------------
 
+* Introduce a YAML-based emission-line constraint system: add
+  ``data/emline-constraints.yaml`` to define kinematic groups, doublet
+  bounds, amplitude constraints, and fitting-strategy parameters; add
+  ``EmlineConstraints`` class wired through ``EMFitTools``, ``linemasker``,
+  and ``qa``; enable the final per-line optimization pass by default
+  [`PR #257`_].
 * Use original resolution matrix for continuum-fitting; major bug fix
   in resolution matrix deconvolution [`PR #256`_].
 
+.. _`PR #257`: https://github.com/desihub/fastspecfit/pull/257
 .. _`PR #256`: https://github.com/desihub/fastspecfit/pull/256
 
 3.4.1 (2026-05-26)

--- a/doc/fastspec.rst
+++ b/doc/fastspec.rst
@@ -390,6 +390,8 @@ Name                        Type         Units                         Descripti
           INIT_BALMER_BROAD         bool                               Boolean flag indicating whether a broad Balmer emission line was initially identified in the spectral range.
              DELTA_LINECHI2      float32                               Chi-squared difference between an emission-line model without and with broad lines.
              DELTA_LINENDOF        int32                               Difference in the degrees of freedom between an emission-line model without and with broad lines.
+             DELTA_KINECHI2      float32                               Chi-squared difference between the constrained and relaxed emission-line model.
+             DELTA_KINENDOF        int32                               Difference in the degrees of freedom between the constrained and relaxed emission-line model.
          MGII_DOUBLET_RATIO      float32                               MgII 2796 / 2803 doublet line-ratio.
     MGII_DOUBLET_RATIO_IVAR      float32                               Inverse variance in MGII_DOUBLET_RATIO.
           OII_DOUBLET_RATIO      float32                               [OII] 3726 / 3729 doublet line-ratio.

--- a/doc/technote/emline-model.tex
+++ b/doc/technote/emline-model.tex
@@ -404,12 +404,133 @@ vector to and from the per-line parameter array before calling
 the functions described here.
 
 
+\section{Kinematic Groups and Parameter Constraints}
+\label{sec:kinematics}
+
+\textsc{FastSpecFit} fits all emission lines simultaneously subject to astrophysically
+motivated constraints that reduce the number of free kinematic parameters.  Lines within
+a \emph{kinematic group} share a common velocity shift $\Delta v$ and line-width $s$,
+tied to a single \emph{anchor} line with a fixed multiplicative factor of unity.  The
+groupings differ between the two models described below.
+
+Lines that belong to neither group---primarily UV and broad AGN lines (Ly$\alpha$,
+[N\,v]~$\lambda$1240, O\,\textsc{i}~$\lambda$1304, Si\,\textsc{iv}~$\lambda$1396,
+C\,\textsc{iv}~$\lambda$1549, He\,\textsc{ii}~$\lambda$1640, Al\,\textsc{iii}~$\lambda$1857,
+Si\,\textsc{iii}]~$\lambda$1892, C\,\textsc{iii}]~$\lambda$1908,
+Mg\,\textsc{ii}~$\lambda\lambda$2796,2803, and He\,\textsc{ii}~$\lambda$4686)---carry
+independently free kinematics in both models.
+
+\subsection{Narrow-only model (\texttt{linemodel\_nobroad})}
+\label{ssec:nobroad}
+
+The narrow-only model is preferred when no significant broad Balmer component is
+detected; all broad Balmer amplitudes are fixed to zero.  It has two kinematic
+groups summarized in Table~\ref{tab:groups_nobroad}.
+
+\begin{table}[h]
+\centering
+\renewcommand{\arraystretch}{1.5}
+\begin{tabular}{@{}llp{8cm}@{}}
+\toprule
+Group & Anchor & Member lines \\
+\midrule
+Forbidden & [O\,\textsc{iii}]~$\lambda$5007
+  & [Ne\,v]~$\lambda\lambda$3346,3426;
+    [O\,\textsc{ii}]~$\lambda\lambda$3726,3729;
+    [Ne\,\textsc{iii}]~$\lambda$3869;
+    [O\,\textsc{iii}]~$\lambda$4363;
+    [O\,\textsc{iii}]~$\lambda\lambda$4959,5007;
+    [N\,\textsc{ii}]~$\lambda$5755;
+    [O\,\textsc{i}]~$\lambda$6300;
+    [S\,\textsc{iii}]~$\lambda$6312;
+    [N\,\textsc{ii}]~$\lambda\lambda$6548,6584;
+    [S\,\textsc{ii}]~$\lambda\lambda$6716,6731;
+    [Ar\,\textsc{iii}]~$\lambda$7135;
+    [O\,\textsc{ii}]~$\lambda\lambda$7320,7330;
+    [S\,\textsc{iii}]~$\lambda\lambda$9069,9532 \\[4pt]
+Narrow Balmer + He\,\textsc{i} & H$\alpha$
+  & H6~($\lambda$3890), H$\epsilon$, H$\delta$, H$\gamma$,
+    H$\beta$, H$\alpha$,
+    He\,\textsc{i}~$\lambda$4471, He\,\textsc{i}~$\lambda$5876 \\
+\bottomrule
+\end{tabular}
+\caption{Kinematic groups in the narrow-only model.  All lines within a group share
+  the anchor's $\Delta v$ and $s$.  [O\,\textsc{iii}]~$\lambda$4959 is also subject to a
+  fixed amplitude constraint relative to [O\,\textsc{iii}]~$\lambda$5007
+  (Table~\ref{tab:amp_constraints}).}
+\label{tab:groups_nobroad}
+\end{table}
+
+\subsection{Narrow+broad model (\texttt{linemodel\_broad})}
+\label{ssec:broad}
+
+The narrow+broad model is preferred when a significant broad Balmer
+component is detected.  It has three kinematic groups summarized in
+Table~\ref{tab:groups_broad}.  A notable difference from the
+narrow-only model is that all narrow lines---Balmer, He\,\textsc{i},
+and forbidden alike---are collapsed into a single kinematic group
+anchored to [N\,\textsc{ii}]~$\lambda$6584; the [O\,\textsc{iii}]
+doublet retains its own separate kinematics.
+
+\begin{table}[h]
+\centering
+\renewcommand{\arraystretch}{1.5}
+\begin{tabular}{@{}llp{7.5cm}@{}}
+\toprule
+Group & Anchor & Member lines \\
+\midrule
+Narrow (all) & [N\,\textsc{ii}]~$\lambda$6584
+  & All narrow Balmer + He\,\textsc{i} lines listed in
+    Table~\ref{tab:groups_nobroad}, plus all
+    forbidden lines except [O\,\textsc{iii}]~$\lambda\lambda$4959,5007 \\[4pt]
+[O\,\textsc{iii}] doublet & [O\,\textsc{iii}]~$\lambda$5007
+  & [O\,\textsc{iii}]~$\lambda$4959, [O\,\textsc{iii}]~$\lambda$5007 \\[4pt]
+Broad Balmer & H$\alpha_{\mathrm{broad}}$
+  & H$\beta_{\mathrm{broad}}$,
+    H$\gamma_{\mathrm{broad}}$,
+    H$\delta_{\mathrm{broad}}$,
+    H$\epsilon_{\mathrm{broad}}$,
+    H6$_{\mathrm{broad}}$ \\
+\bottomrule
+\end{tabular}
+\caption{Kinematic groups in the narrow+broad model.}
+\label{tab:groups_broad}
+\end{table}
+
+\subsection{Amplitude constraints}
+\label{ssec:amp_constraints}
+
+Several line pairs carry additional constraints on their relative amplitudes,
+independent of the kinematic model chosen.  Three doublet ratios are fixed to
+theoretical values; three others are fitted as free parameters
+(Table~\ref{tab:amp_constraints}).
+
+\begin{table}[h]
+\centering
+\renewcommand{\arraystretch}{1.5}
+\begin{tabular}{@{}llll@{}}
+\toprule
+Constrained line & Reference line & Amplitude factor & Type \\
+\midrule
+$[$N\,\textsc{ii}$]$~$\lambda$6548  & $[$N\,\textsc{ii}$]$~$\lambda$6584  & $1/3.0326$ & Fixed \\
+$[$O\,\textsc{iii}$]$~$\lambda$4959 & $[$O\,\textsc{iii}$]$~$\lambda$5007 & $1/2.9643$ & Fixed \\
+$[$O\,\textsc{ii}$]$~$\lambda$7330  & $[$O\,\textsc{ii}$]$~$\lambda$7320  & $1/1.225$  & Fixed \\
+$[$O\,\textsc{ii}$]$~$\lambda$3726  & $[$O\,\textsc{ii}$]$~$\lambda$3729  & $r$ (free) & Doublet ratio \\
+$[$S\,\textsc{ii}$]$~$\lambda$6731  & $[$S\,\textsc{ii}$]$~$\lambda$6716  & $r$ (free) & Doublet ratio \\
+Mg\,\textsc{ii}~$\lambda$2796        & Mg\,\textsc{ii}~$\lambda$2803       & $r$ (free) & Doublet ratio \\
+\bottomrule
+\end{tabular}
+\caption{Amplitude constraints applied in both models.  Fixed ratios are derived
+  from atomic emissivities (see code comments in \texttt{emlines.py}); doublet
+  ratios are fitted free parameters that encode density-sensitive flux ratios.}
+\label{tab:amp_constraints}
+\end{table}
+
+
 \section*{Acknowledgments}
 
 The deconvolved-resolution-matrix framework follows the implementation
 by Sergey Koposov (rvspecfit) and the original bin-integration model
-is due to Buhler (2024). The reconciliation presented here, and the
-corrected Jacobian, were developed during \textsc{FastSpecFit}
-PR\,\#252.
+is due to Buhler (2024).
 
 \end{document}

--- a/doc/technote/emline-model.tex
+++ b/doc/technote/emline-model.tex
@@ -403,6 +403,18 @@ and $s$.  The Jacobian rows for those lines are assembled by the sparse
 vector to and from the per-line parameter array before calling
 the functions described here.
 
+\paragraph{Output for heavily masked lines.}
+When more than 30\% of the pixels in the original inverse-variance spectrum within
+a line's spectral window are masked, the pixel-level measurements (BOXFLUX, CONT,
+CHI2) cannot be computed reliably.  For lines whose amplitude, $\Delta v$, and $s$
+are all tied to a kinematic anchor, however, the model-derived quantities (AMP,
+VSHIFT, SIGMA, MODELAMP, and the analytic flux $\Phi = \sqrt{2\pi}\,A\,\lstar\,s/\C$;
+equation~\ref{eq:flux_phys}) are still valid and are reported with the pixel-level
+fields set to zero.  This primarily benefits the fixed-ratio doublet members such as
+[O\,\textsc{iii}]~$\lambda$4959, [N\,\textsc{ii}]~$\lambda$6548, and
+[O\,\textsc{ii}]~$\lambda$7330 (Table~\ref{tab:amp_constraints}), whose parameters
+are fully determined by their bright reference lines.
+
 
 \section{Kinematic Groups and Parameter Constraints}
 \label{sec:kinematics}
@@ -541,28 +553,47 @@ Mg\,\textsc{ii}~$\lambda$2796        & Mg\,\textsc{ii}~$\lambda$2803       & $r$
 \label{ssec:final_pass}
 
 After the primary constrained fit \textsc{FastSpecFit} optionally runs a second
-optimization whose behavior is specified independently for each kinematic profile via a
-\texttt{final\_pass} block embedded within that profile's entry in
-\texttt{data/emline-constraints.yaml}.
+optimization pass in which some kinematic ties are relaxed.  The pass is controlled at
+two levels of granularity, both defined in \texttt{data/emline-constraints.yaml}:
 
-For the \emph{narrow-only} profile, the final pass is enabled by default in
-\texttt{per\_line} mode: all kinematic ties between groups are released so that every
-line's $\Delta v$ and $s$ snap independently to their $\chi^2$ minimum.  Amplitude
+\begin{itemize}
+\item \textbf{Per kinematic group}: each group carries \texttt{free\_vshift} and
+  \texttt{free\_sigma} boolean flags.  When a flag is \texttt{true}, the corresponding
+  parameter type ($\Delta v$ or $s$) is freed for every member of that group in the
+  relaxed model.  Groups with both flags \texttt{false} are not relaxed.
+
+\item \textbf{Per profile}: the fields \texttt{enabled}, \texttt{warm\_start},
+  \texttt{adopt\_if}, and \texttt{inherit\_in\_mc} control whether the pass runs,
+  how it is initialized, and when its result is adopted.
+\end{itemize}
+
+For the \emph{narrow-only} profile, both kinematic groups have \texttt{free\_vshift:
+true} and \texttt{free\_sigma: true}, so every line's $\Delta v$ and $s$ are freed
+independently.  For the \emph{narrow+broad} profile, all three groups currently have
+both flags set to \texttt{false}; the pass is nominally enabled but produces no free
+parameters, so it is a no-op in the current default configuration.  Amplitude
 constraints (fixed ratios and doublet ratios; Section~\ref{ssec:amp_constraints}) are
-always preserved regardless of mode.  The pass is warm-started from the primary
-best-fit values, and the relaxed solution is adopted only if the improvement in $\chi^2$
-is significant relative to the number of additional free parameters (criterion
-\texttt{chi2\_improves}); otherwise the primary constrained result is retained.
+never relaxed regardless of the per-group flags.
 
-For the \emph{narrow+broad} profile, the final pass is disabled by default because the
-three-group structure (narrow lines, [O\,\textsc{iii}] doublet, and broad Balmer; see
-Table~\ref{tab:broad_groups}) already provides substantial kinematic freedom, making
-further per-line relaxation of limited benefit.
+\paragraph{Warm-start bounds.}
+Each freed parameter is initialized at its primary best-fit value (\texttt{warm\_start:
+true}) and constrained to remain within a symmetric window of half-width
+$\delta_v$\,(km\,s$^{-1}$) for velocity shifts or $\delta_s$\,(km\,s$^{-1}$) for
+line widths, both specified per kinematic group.  If the warm-start value lies within
+1\,km\,s$^{-1}$ of the existing optimizer boundary the tightening is skipped for that
+parameter, preventing ill-constrained parameters from being anchored near a wall.
+Default values are $\delta_v = 100$\,km\,s$^{-1}$ and $\delta_s = 100$\,km\,s$^{-1}$
+for narrow-line groups, and $\delta_v = 500$\,km\,s$^{-1}$ and
+$\delta_s = 1{,}000$\,km\,s$^{-1}$ for broad-line groups.
 
-Monte Carlo realizations mirror whichever model was adopted for the nominal spectrum and
-do not independently re-evaluate the adoption criterion (\texttt{inherit\_in\_mc: true}).
-The mode, adoption criterion, warm-start flag, and Monte Carlo inheritance setting can
-all be adjusted independently per profile.
+\paragraph{Adoption.}
+The relaxed solution is adopted only if the global $\chi^2$ improvement exceeds the
+number of additional free parameters (\texttt{chi2\_improves}); otherwise the primary
+result is retained.  The adoption decision is a single global comparison rather than
+per-group, because the total $\chi^2$ is not decomposable by kinematic group when line
+profiles overlap spectrally.  Monte Carlo realizations use the structure of whichever
+model was adopted for the nominal fit and do not independently re-evaluate the adoption
+criterion (\texttt{inherit\_in\_mc: true}).
 
 
 \section*{Acknowledgments}

--- a/doc/technote/emline-model.tex
+++ b/doc/technote/emline-model.tex
@@ -476,8 +476,8 @@ component is detected.  It has three kinematic groups summarized in
 Table~\ref{tab:groups_broad}.  A notable difference from the
 narrow-only model is that all narrow lines---Balmer, He\,\textsc{i},
 and forbidden alike---are collapsed into a single kinematic group
-anchored to [N\,\textsc{ii}]~$\lambda$6584; the [O\,\textsc{iii}]
-doublet retains its own separate kinematics.
+anchored to the narrow H$\alpha$ line; the [O\,\textsc{iii}] doublet
+retains its own separate kinematics.
 
 \begin{table}[h]
 \centering
@@ -486,7 +486,7 @@ doublet retains its own separate kinematics.
 \toprule
 Group & Anchor & Member lines \\
 \midrule
-Narrow (all) & [N\,\textsc{ii}]~$\lambda$6584
+Narrow (all) & H$\alpha$
   & All narrow Balmer + He\,\textsc{i} lines listed in
     Table~\ref{tab:groups_nobroad}, plus all
     forbidden lines except [O\,\textsc{iii}]~$\lambda\lambda$4959,5007 \\[4pt]
@@ -540,17 +540,29 @@ Mg\,\textsc{ii}~$\lambda$2796        & Mg\,\textsc{ii}~$\lambda$2803       & $r$
 \subsection{Final optimization pass}
 \label{ssec:final_pass}
 
-By default, \textsc{FastSpecFit} runs a second optimization after the primary
-constrained fit.  This pass operates in \texttt{per\_line} mode: all kinematic ties
-between groups are released so that every line's $\Delta v$ and $s$ snap independently
-to their $\chi^2$ minimum, while amplitude constraints (fixed ratios and doublet ratios;
-Section~\ref{ssec:amp_constraints}) are always preserved.  The pass is warm-started from
-the primary best-fit values.  The relaxed solution is adopted only if the improvement in
-$\chi^2$ is significant accounting for the additional free parameters (criterion
-\texttt{chi2\_improves}); otherwise the primary constrained result is retained.  Monte
-Carlo realizations mirror whichever model was adopted for the nominal spectrum, so they
-do not independently re-evaluate the adoption criterion.  All of these defaults are
-governed by the \texttt{fitting\_strategy} block in \texttt{data/emline-constraints.yaml}.
+After the primary constrained fit \textsc{FastSpecFit} optionally runs a second
+optimization whose behavior is specified independently for each kinematic profile via a
+\texttt{final\_pass} block embedded within that profile's entry in
+\texttt{data/emline-constraints.yaml}.
+
+For the \emph{narrow-only} profile, the final pass is enabled by default in
+\texttt{per\_line} mode: all kinematic ties between groups are released so that every
+line's $\Delta v$ and $s$ snap independently to their $\chi^2$ minimum.  Amplitude
+constraints (fixed ratios and doublet ratios; Section~\ref{ssec:amp_constraints}) are
+always preserved regardless of mode.  The pass is warm-started from the primary
+best-fit values, and the relaxed solution is adopted only if the improvement in $\chi^2$
+is significant relative to the number of additional free parameters (criterion
+\texttt{chi2\_improves}); otherwise the primary constrained result is retained.
+
+For the \emph{narrow+broad} profile, the final pass is disabled by default because the
+three-group structure (narrow lines, [O\,\textsc{iii}] doublet, and broad Balmer; see
+Table~\ref{tab:broad_groups}) already provides substantial kinematic freedom, making
+further per-line relaxation of limited benefit.
+
+Monte Carlo realizations mirror whichever model was adopted for the nominal spectrum and
+do not independently re-evaluate the adoption criterion (\texttt{inherit\_in\_mc: true}).
+The mode, adoption criterion, warm-start flag, and Monte Carlo inheritance setting can
+all be adjusted independently per profile.
 
 
 \section*{Acknowledgments}

--- a/doc/technote/emline-model.tex
+++ b/doc/technote/emline-model.tex
@@ -411,14 +411,20 @@ the functions described here.
 motivated constraints that reduce the number of free kinematic parameters.  Lines within
 a \emph{kinematic group} share a common velocity shift $\Delta v$ and line-width $s$,
 tied to a single \emph{anchor} line with a fixed multiplicative factor of unity.  The
-groupings differ between the two models described below.
+groupings differ between the two models described below.  All constraints---kinematic
+groups, amplitude ratios, optimizer bounds, and fitting strategy---are read at startup
+from the bundled configuration file \texttt{data/emline-constraints.yaml}.
 
-Lines that belong to neither group---primarily UV and broad AGN lines (Ly$\alpha$,
-[N\,v]~$\lambda$1240, O\,\textsc{i}~$\lambda$1304, Si\,\textsc{iv}~$\lambda$1396,
-C\,\textsc{iv}~$\lambda$1549, He\,\textsc{ii}~$\lambda$1640, Al\,\textsc{iii}~$\lambda$1857,
-Si\,\textsc{iii}]~$\lambda$1892, C\,\textsc{iii}]~$\lambda$1908,
-Mg\,\textsc{ii}~$\lambda\lambda$2796,2803, and He\,\textsc{ii}~$\lambda$4686)---carry
-independently free kinematics in both models.
+Eight UV and broad AGN lines carry independently free kinematics in both models:
+Ly$\alpha$, [N\,v]~$\lambda$1240, O\,\textsc{i}~$\lambda$1304,
+Si\,\textsc{iv}~$\lambda$1396, C\,\textsc{iv}~$\lambda$1549,
+He\,\textsc{ii}~$\lambda$1640, Al\,\textsc{iii}~$\lambda$1857, and
+He\,\textsc{ii}~$\lambda$4686.  Two additional global kinematic pairs are applied
+regardless of which profile is active: Si\,\textsc{iii}]~$\lambda$1892 is tied to
+C\,\textsc{iii}]~$\lambda$1908 (anchor), and Mg\,\textsc{ii}~$\lambda$2796 is tied to
+Mg\,\textsc{ii}~$\lambda$2803 (anchor, with the amplitude ratio a free doublet parameter;
+Section~\ref{ssec:amp_constraints}).  Both global pairs use the broad-line bounds
+($1 < s < 10{,}000$~km/s, $|\Delta v| < 2{,}500$~km/s).
 
 \subsection{Narrow-only model (\texttt{linemodel\_nobroad})}
 \label{ssec:nobroad}
@@ -450,12 +456,13 @@ Forbidden & [O\,\textsc{iii}]~$\lambda$5007
     [S\,\textsc{iii}]~$\lambda\lambda$9069,9532 \\[4pt]
 Narrow Balmer + He\,\textsc{i} & H$\alpha$
   & H6~($\lambda$3890), H$\epsilon$, H$\delta$, H$\gamma$,
-    H$\beta$, H$\alpha$,
+    H$\beta$,
     He\,\textsc{i}~$\lambda$4471, He\,\textsc{i}~$\lambda$5876 \\
 \bottomrule
 \end{tabular}
 \caption{Kinematic groups in the narrow-only model.  All lines within a group share
-  the anchor's $\Delta v$ and $s$.  [O\,\textsc{iii}]~$\lambda$4959 is also subject to a
+  the anchor's $\Delta v$ and $s$, subject to bounds $1 < s < 750$~km/s and
+  $|\Delta v| < 500$~km/s.  [O\,\textsc{iii}]~$\lambda$4959 is also subject to a
   fixed amplitude constraint relative to [O\,\textsc{iii}]~$\lambda$5007
   (Table~\ref{tab:amp_constraints}).}
 \label{tab:groups_nobroad}
@@ -493,7 +500,10 @@ Broad Balmer & H$\alpha_{\mathrm{broad}}$
     H6$_{\mathrm{broad}}$ \\
 \bottomrule
 \end{tabular}
-\caption{Kinematic groups in the narrow+broad model.}
+\caption{Kinematic groups in the narrow+broad model.  Narrow groups (\emph{narrow all}
+  and \emph{[O\,\textsc{iii}] doublet}) are bounded by $1 < s < 750$~km/s and
+  $|\Delta v| < 500$~km/s; the broad Balmer group by $1 < s < 10{,}000$~km/s and
+  $|\Delta v| < 2{,}500$~km/s.}
 \label{tab:groups_broad}
 \end{table}
 
@@ -525,6 +535,22 @@ Mg\,\textsc{ii}~$\lambda$2796        & Mg\,\textsc{ii}~$\lambda$2803       & $r$
   ratios are fitted free parameters that encode density-sensitive flux ratios.}
 \label{tab:amp_constraints}
 \end{table}
+
+
+\subsection{Final optimization pass}
+\label{ssec:final_pass}
+
+By default, \textsc{FastSpecFit} runs a second optimization after the primary
+constrained fit.  This pass operates in \texttt{per\_line} mode: all kinematic ties
+between groups are released so that every line's $\Delta v$ and $s$ snap independently
+to their $\chi^2$ minimum, while amplitude constraints (fixed ratios and doublet ratios;
+Section~\ref{ssec:amp_constraints}) are always preserved.  The pass is warm-started from
+the primary best-fit values.  The relaxed solution is adopted only if the improvement in
+$\chi^2$ is significant accounting for the additional free parameters (criterion
+\texttt{chi2\_improves}); otherwise the primary constrained result is retained.  Monte
+Carlo realizations mirror whichever model was adopted for the nominal spectrum, so they
+do not independently re-evaluate the adoption criterion.  All of these defaults are
+governed by the \texttt{fitting\_strategy} block in \texttt{data/emline-constraints.yaml}.
 
 
 \section*{Acknowledgments}

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -125,7 +125,7 @@ global:
         vshift: 0.0
       members:
         - siliii_1892   # amplitude free; kinematics tied to ciii_1908
-      final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
+      final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: 500.0, delta_sigma_max: 1000.0}
 
     - name: mgii_pair
       # MgII 2796 kinematics follow MgII 2803; amplitude ratio is a free
@@ -139,7 +139,7 @@ global:
         vshift: 0.0
       members:
         - mgii_2796
-      final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
+      final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: 500.0, delta_sigma_max: 1000.0}
 
 
 # =============================================================================
@@ -203,7 +203,7 @@ profiles:
           - oii_7330      # amplitude also constrained via amplitude_constraints.fixed
           - siii_9069
           - siii_9532
-        final_pass: {free_vshift: true, free_sigma: true, delta_vshift_max: null, delta_sigma_max: null}
+        final_pass: {free_vshift: true, free_sigma: true, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
 
       - name: narrow_balmer
         anchor: halpha
@@ -221,7 +221,7 @@ profiles:
           - hbeta
           - hei_4471
           - hei_5876
-        final_pass: {free_vshift: true, free_sigma: true, delta_vshift_max: null, delta_sigma_max: null}
+        final_pass: {free_vshift: true, free_sigma: true, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
 
     free_lines: []
 
@@ -290,7 +290,7 @@ profiles:
           - hei_5876
         # Free individual vshifts to absorb wavelength calibration offsets;
         # keep sigma tied so the line-width constraint stabilises the blend.
-        final_pass: {free_vshift: true, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
+        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
 
       - name: oiii_doublet
         anchor: oiii_5007
@@ -303,7 +303,7 @@ profiles:
         members:
           - oiii_4959   # amplitude also constrained via amplitude_constraints.fixed
         # Keep the doublet fully tied at all times.
-        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
+        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
 
       - name: broad_balmer
         anchor: halpha_broad
@@ -321,7 +321,7 @@ profiles:
           - h6_broad
         # Keep broad Balmer lines fully tied: faint higher-order members need
         # the constraint provided by the bright halpha_broad anchor.
-        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
+        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: 500.0, delta_sigma_max: 1000.0}
 
     free_lines:  []
     fixed_lines: []

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -51,10 +51,10 @@ amplitude_constraints:
   fixed:
     - line: nii_6548
       ref:  nii_6584
-      factor: 0.32960    # 1/3.0326  ([NII] flux ratio 3.049, lambda-corrected)
+      factor: 0.32975    # 1/3.0326  ([NII] flux ratio 3.049, lambda-corrected)
     - line: oiii_4959
       ref:  oiii_5007
-      factor: 0.33729    # 1/2.9643  ([OIII] flux ratio 2.993, lambda-corrected)
+      factor: 0.33735    # 1/2.9643  ([OIII] flux ratio 2.993, lambda-corrected)
     - line: oii_7330
       ref:  oii_7320
       factor: 0.81633    # 1/1.225

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -321,7 +321,7 @@ fitting_strategy:
     #
     # Amplitude constraints (fixed ratios and doublet ratios) are never
     # relaxed regardless of mode.
-    enabled:   false
+    enabled:   true
     mode:      per_line
     warm_start: true     # initialize from the primary best-fit values
     adopt_if:  chi2_improves   # "always" | "chi2_improves"

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -53,12 +53,15 @@ amplitude_constraints:
     - line: nii_6548
       ref:  nii_6584
       factor: 0.32975    # 1/3.0326  ([NII] flux ratio 3.049, lambda-corrected)
+      param_name: NII_DOUBLET_RATIO
     - line: oiii_4959
       ref:  oiii_5007
       factor: 0.33735    # 1/2.9643  ([OIII] flux ratio 2.993, lambda-corrected)
+      param_name: OIII_DOUBLET_RATIO
     - line: oii_7330
       ref:  oii_7320
       factor: 0.81633    # 1/1.225
+      param_name: OIIRED_DOUBLET_RATIO
 
   # Doublet ratios: amplitude ratio is a free fitted parameter.
   # The ratio is defined as line / ref, bounded as below.

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -90,7 +90,7 @@ global:
   # Default bounds and initial guesses for all lines in global.free_lines.
   # Individual lines can override these by using the long-form entry below.
   default_bounds:
-    sigma:  {min: 1.0, max: 1.0e4}
+    sigma:  {min: 1.0, max: 10000.0}
     vshift: {min: -2500.0, max: 2500.0}
   default_initial:
     sigma:  3000.0    # km/s; data-derived estimates override this at runtime
@@ -117,7 +117,7 @@ global:
       # SiIII] 1892 is tied to CIII] 1908; both are broad AGN-type lines.
       anchor: ciii_1908
       bounds:
-        sigma:  {min: 1.0,     max: 1.0e4}
+        sigma:  {min: 1.0,     max: 10000.0}
         vshift: {min: -2500.0, max: 2500.0}
       initial:
         sigma:  3000.0
@@ -130,7 +130,7 @@ global:
       # doublet parameter defined in amplitude_constraints.doublet_ratios.
       anchor: mgii_2803
       bounds:
-        sigma:  {min: 1.0,     max: 1.0e4}
+        sigma:  {min: 1.0,     max: 10000.0}
         vshift: {min: -2500.0, max: 2500.0}
       initial:
         sigma:  3000.0
@@ -284,7 +284,7 @@ profiles:
       - name: broad_balmer
         anchor: halpha_broad
         bounds:
-          sigma:  {min: 1.0,     max: 1.0e4}
+          sigma:  {min: 1.0,     max: 10000.0}
           vshift: {min: -2500.0, max: 2500.0}
         initial:
           sigma:  1000.0

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -1,0 +1,333 @@
+# FastSpecFit emission-line kinematic constraints
+# ================================================
+# Companion file to emlines.ecsv. Every line defined in emlines.ecsv
+# must appear exactly once in each profile, placed in one of:
+#   - a kinematic_group (as anchor or member)
+#   - free_lines  (independently fitted kinematics)
+#   - fixed_lines (amplitude fixed to zero, not fitted)
+# Lines in the global section are shared across all profiles and do not
+# need to be repeated in each profile. A startup consistency check
+# verifies that the union of placements equals the emlines.ecsv line list.
+#
+# Units:  sigma  [km/s],  vshift [km/s],  amplitude [10^-17 erg/s/cm^2/A]
+#
+# Schema rules (enforced at startup):
+#   - Every key under kinematic_groups.members, free_lines, and fixed_lines
+#     must be a name that exists in emlines.ecsv (or line_components below).
+#   - Every anchor must also exist in emlines.ecsv.
+#   - amplitude_constraints.fixed[].line and .ref must exist in emlines.ecsv.
+#   - amplitude_constraints.doublet_ratios[].line and .ref must exist in emlines.ecsv.
+#   - line_components[].base_line must exist in emlines.ecsv.
+#   - Within a profile, no line name may appear more than once across all placements.
+#   - bounds.sigma.min >= 0; bounds.sigma.min < bounds.sigma.max.
+#   - bounds.vshift.min < bounds.vshift.max.
+#   - fitting_strategy.final_pass.mode in {none, relax_inter_group, per_line}.
+#   - fitting_strategy.final_pass.adopt_if in {always, chi2_improves}.
+
+
+# =============================================================================
+# SECTION 1: Line component extensions
+# =============================================================================
+# Additional kinematic components beyond those in emlines.ecsv.
+# Add entries here when introducing outflow components, narrow sub-components
+# of broad lines, etc. Each entry must supply base_line (the existing
+# emlines.ecsv line at the same rest wavelength), and it must then appear
+# in a kinematic_group or free_lines in every profile.
+
+line_components: []
+
+
+# =============================================================================
+# SECTION 2: Amplitude constraints  (profile-independent)
+# =============================================================================
+# These apply regardless of which kinematic profile is active.
+
+amplitude_constraints:
+
+  # Fixed ratios: constrained amplitude = factor * reference amplitude.
+  # Factors encode the theoretical flux ratio corrected to velocity-space
+  # amplitudes (flux_ratio * lambda_constrained / lambda_reference).
+  # See comments in emlines.py for references.
+  fixed:
+    - line: nii_6548
+      ref:  nii_6584
+      factor: 0.32960    # 1/3.0326  ([NII] flux ratio 3.049, lambda-corrected)
+    - line: oiii_4959
+      ref:  oiii_5007
+      factor: 0.33729    # 1/2.9643  ([OIII] flux ratio 2.993, lambda-corrected)
+    - line: oii_7330
+      ref:  oii_7320
+      factor: 0.81633    # 1/1.225
+
+  # Doublet ratios: amplitude ratio is a free fitted parameter.
+  # The ratio is defined as line / ref, bounded as below.
+  # param_name is what appears in the output catalog.
+  doublet_ratios:
+    - line:       oii_3726
+      ref:        oii_3729
+      param_name: oii_doublet_ratio
+      bounds:     {min: 0.0, max: 2.0}
+      initial:    1.0
+    - line:       sii_6731
+      ref:        sii_6716
+      param_name: sii_doublet_ratio
+      bounds:     {min: 0.0, max: 2.0}
+      initial:    1.0
+    - line:       mgii_2796
+      ref:        mgii_2803
+      param_name: mgii_doublet_ratio
+      bounds:     {min: 0.0, max: 10.0}
+      initial:    1.0
+
+
+# =============================================================================
+# SECTION 3: Global placements  (apply to every profile)
+# =============================================================================
+# Lines here do not need to be listed again in any profile.
+
+global:
+
+  # Default bounds and initial guesses for all lines in global.free_lines.
+  # Individual lines can override these by using the long-form entry below.
+  default_bounds:
+    sigma:  {min: 1.0, max: 1.0e4}
+    vshift: {min: -2500.0, max: 2500.0}
+  default_initial:
+    sigma:  3000.0    # km/s; data-derived estimates override this at runtime
+    vshift: 0.0
+
+  # Lines with fully independent kinematics in every profile.
+  # These are UV and optical AGN/QSO-type lines (all isbroad=True,
+  # isbalmer=False in emlines.ecsv).
+  free_lines:
+    - lyalpha
+    - nv_1240
+    - oi_1304
+    - siliv_1396
+    - civ_1549
+    - heii_1640
+    - aliii_1857
+    - heii_4686
+
+  # Small kinematic pairs that are tied to each other but free from
+  # all profile-level groups. Bounds use the global UV/QSO defaults above.
+  kinematic_groups:
+
+    - name: ciii_aliii
+      # SiIII] 1892 is tied to CIII] 1908; both are broad AGN-type lines.
+      anchor: ciii_1908
+      bounds:
+        sigma:  {min: 1.0,     max: 1.0e4}
+        vshift: {min: -2500.0, max: 2500.0}
+      initial:
+        sigma:  3000.0
+        vshift: 0.0
+      members:
+        - siliii_1892   # amplitude free; kinematics tied to ciii_1908
+
+    - name: mgii_pair
+      # MgII 2796 kinematics follow MgII 2803; amplitude ratio is a free
+      # doublet parameter defined in amplitude_constraints.doublet_ratios.
+      anchor: mgii_2803
+      bounds:
+        sigma:  {min: 1.0,     max: 1.0e4}
+        vshift: {min: -2500.0, max: 2500.0}
+      initial:
+        sigma:  3000.0
+        vshift: 0.0
+      members:
+        - mgii_2796
+
+
+# =============================================================================
+# SECTION 4: Named kinematic profiles
+# =============================================================================
+# At runtime one profile pair (narrow_only + narrow_broad) is loaded.
+# Add new profiles here to experiment with different constraint schemes.
+#
+# Per-group fields:
+#   anchor  [string]  : line name; its vshift and sigma are the free parameters
+#   bounds  [mapping] : hard optimizer bounds applied to the anchor's vshift/sigma
+#   initial [mapping] : default starting point (overridden by data-derived estimates)
+#   members [list]    : lines tied to anchor with factor 1.0 for vshift and sigma
+#
+# Amplitude bounds (min: 0, max: data-derived) are set in _initial_guesses_and_bounds
+# and are not specified here.
+
+profiles:
+
+  # ---------------------------------------------------------------------------
+  narrow_only:
+  # ---------------------------------------------------------------------------
+  # Preferred when no significant broad Balmer component is detected.
+  # Two kinematic groups: all forbidden lines share [OIII] 5007; all narrow
+  # Balmer + HeI share Halpha. Broad Balmer amplitudes are fixed to zero.
+
+    kinematic_groups:
+
+      - name: forbidden
+        anchor: oiii_5007
+        bounds:
+          sigma:  {min: 1.0,    max: 750.0}
+          vshift: {min: -500.0, max: 500.0}
+        initial:
+          sigma:  150.0
+          vshift: 0.0
+        members:
+          - nev_3346
+          - nev_3426
+          - oii_3726      # amplitude also constrained via doublet_ratios
+          - oii_3729
+          - neiii_3869
+          - oiii_4363
+          - oiii_4959     # amplitude also constrained via amplitude_constraints.fixed
+          - nii_5755
+          - oi_6300
+          - siii_6312
+          - nii_6548      # amplitude also constrained via amplitude_constraints.fixed
+          - nii_6584
+          - sii_6716
+          - sii_6731      # amplitude also constrained via doublet_ratios
+          - ariii_7135
+          - oii_7320
+          - oii_7330      # amplitude also constrained via amplitude_constraints.fixed
+          - siii_9069
+          - siii_9532
+
+      - name: narrow_balmer
+        anchor: halpha
+        bounds:
+          sigma:  {min: 1.0,    max: 750.0}
+          vshift: {min: -500.0, max: 500.0}
+        initial:
+          sigma:  150.0
+          vshift: 0.0
+        members:
+          - h6
+          - hepsilon
+          - hdelta
+          - hgamma
+          - hbeta
+          - hei_4471
+          - hei_5876
+
+    free_lines: []
+
+    # Broad Balmer components are not fitted in this model.
+    fixed_lines:
+      - halpha_broad
+      - hbeta_broad
+      - hgamma_broad
+      - hdelta_broad
+      - hepsilon_broad
+      - h6_broad
+
+  # ---------------------------------------------------------------------------
+  narrow_broad:
+  # ---------------------------------------------------------------------------
+  # Preferred when a significant broad Balmer component is detected.
+  # Three kinematic groups: all narrow lines (Balmer + forbidden) share
+  # [NII] 6584; [OIII] 4959,5007 have separate kinematics; broad Balmer + HeI
+  # share Halpha_broad. The [OIII] doublet is kept separate because it
+  # frequently shows an outflow component distinct from the other forbidden lines.
+
+    kinematic_groups:
+
+      - name: narrow_all
+        # All narrow lines — Balmer, HeI, and forbidden — share one kinematic
+        # anchor. [OIII] 4959,5007 are excluded (handled in oiii_doublet below).
+        anchor: nii_6584
+        bounds:
+          sigma:  {min: 1.0,    max: 750.0}
+          vshift: {min: -500.0, max: 500.0}
+        initial:
+          sigma:  150.0
+          vshift: 0.0
+        members:
+          - nev_3346
+          - nev_3426
+          - oii_3726
+          - oii_3729
+          - neiii_3869
+          - oiii_4363
+          - nii_5755
+          - oi_6300
+          - siii_6312
+          - nii_6548
+          - halpha
+          - sii_6716
+          - sii_6731
+          - ariii_7135
+          - oii_7320
+          - oii_7330
+          - siii_9069
+          - siii_9532
+          - h6
+          - hepsilon
+          - hdelta
+          - hgamma
+          - hbeta
+          - hei_4471
+          - hei_5876
+
+      - name: oiii_doublet
+        anchor: oiii_5007
+        bounds:
+          sigma:  {min: 1.0,    max: 750.0}
+          vshift: {min: -500.0, max: 500.0}
+        initial:
+          sigma:  150.0
+          vshift: 0.0
+        members:
+          - oiii_4959   # amplitude also constrained via amplitude_constraints.fixed
+
+      - name: broad_balmer
+        anchor: halpha_broad
+        bounds:
+          sigma:  {min: 1.0,     max: 1.0e4}
+          vshift: {min: -2500.0, max: 2500.0}
+        initial:
+          sigma:  1000.0
+          vshift: 0.0
+        members:
+          - hbeta_broad
+          - hgamma_broad
+          - hdelta_broad
+          - hepsilon_broad
+          - h6_broad
+
+    free_lines:  []
+    fixed_lines: []
+
+
+# =============================================================================
+# SECTION 5: Fitting strategy
+# =============================================================================
+
+fitting_strategy:
+
+  final_pass:
+    # When enabled, a second optimization is run after the primary constrained
+    # fit, using the mode below. The result is adopted only if the chi2
+    # improvement (accounting for the additional free parameters via an
+    # F-test) clears the adoption threshold.
+    #
+    # mode options:
+    #   none              - no relaxation; primary constrained result is final
+    #   relax_inter_group - free the inter-group kinematic ties; within-group
+    #                       ties (e.g. Balmer lines tied to Halpha) are kept
+    #   per_line          - all kinematic parameters are freed; each line snaps
+    #                       independently to its chi2 minimum
+    #
+    # Amplitude constraints (fixed ratios and doublet ratios) are never
+    # relaxed regardless of mode.
+    enabled:   false
+    mode:      per_line
+    warm_start: true     # initialize from the primary best-fit values
+    adopt_if:  chi2_improves   # "always" | "chi2_improves"
+
+  monte_carlo:
+    # If true, each MC realization mirrors whatever the nominal fit adopted
+    # (primary only, or primary + final pass). The MC does not independently
+    # test whether to adopt the final pass result.
+    inherit_final_pass: true

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -21,7 +21,7 @@
 #   - Within a profile, no line name may appear more than once across all placements.
 #   - bounds.sigma.min >= 0; bounds.sigma.min < bounds.sigma.max.
 #   - bounds.vshift.min < bounds.vshift.max.
-#   - profiles.<name>.final_pass.mode in {none, relax_inter_group, per_line}.
+#   - Every kinematic group (global and profile-level) must contain a final_pass block.
 #   - profiles.<name>.final_pass.adopt_if in {always, chi2_improves}.
 #   - Every profile must contain a final_pass block with all required keys.
 
@@ -125,6 +125,7 @@ global:
         vshift: 0.0
       members:
         - siliii_1892   # amplitude free; kinematics tied to ciii_1908
+      final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
 
     - name: mgii_pair
       # MgII 2796 kinematics follow MgII 2803; amplitude ratio is a free
@@ -138,6 +139,7 @@ global:
         vshift: 0.0
       members:
         - mgii_2796
+      final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
 
 
 # =============================================================================
@@ -147,10 +149,17 @@ global:
 # Add new profiles here to experiment with different constraint schemes.
 #
 # Per-group fields:
-#   anchor  [string]  : line name; its vshift and sigma are the free parameters
-#   bounds  [mapping] : hard optimizer bounds applied to the anchor's vshift/sigma
-#   initial [mapping] : default starting point (overridden by data-derived estimates)
-#   members [list]    : lines tied to anchor with factor 1.0 for vshift and sigma
+#   anchor          [string]  : line name; its vshift and sigma are the free parameters
+#   bounds          [mapping] : hard optimizer bounds applied to the anchor's vshift/sigma
+#   initial         [mapping] : default starting point (overridden by data-derived estimates)
+#   members         [list]    : lines tied to anchor with factor 1.0 for vshift and sigma
+#   final_pass      [mapping] : per-group relaxation policy (see below)
+#
+# Per-group final_pass fields:
+#   free_vshift     [bool]    : release vshift ties for all members in the final pass
+#   free_sigma      [bool]    : release sigma ties for all members in the final pass
+#   delta_vshift_max [float|null] : reserved; max vshift deviation from warm-start (not yet used)
+#   delta_sigma_max  [float|null] : reserved; max sigma deviation from warm-start (not yet used)
 #
 # Amplitude bounds (min: 0, max: data-derived) are set in _initial_guesses_and_bounds
 # and are not specified here.
@@ -194,6 +203,7 @@ profiles:
           - oii_7330      # amplitude also constrained via amplitude_constraints.fixed
           - siii_9069
           - siii_9532
+        final_pass: {free_vshift: true, free_sigma: true, delta_vshift_max: null, delta_sigma_max: null}
 
       - name: narrow_balmer
         anchor: halpha
@@ -211,6 +221,7 @@ profiles:
           - hbeta
           - hei_4471
           - hei_5876
+        final_pass: {free_vshift: true, free_sigma: true, delta_vshift_max: null, delta_sigma_max: null}
 
     free_lines: []
 
@@ -223,13 +234,9 @@ profiles:
       - hepsilon_broad
       - h6_broad
 
-    # Fitting strategy for this profile.
-    # Per-line relaxation is worthwhile here because the two-group constraint
-    # (forbidden + narrow_balmer) is tight enough that individual lines often
-    # benefit from breaking free.
+    # Fitting strategy for this profile: what to relax is specified per group above.
     final_pass:
       enabled:       true
-      mode:          per_line
       warm_start:    true        # initialize from the primary best-fit values
       adopt_if:      chi2_improves   # "always" | "chi2_improves"
       inherit_in_mc: true        # MC realizations mirror the final-pass decision
@@ -281,6 +288,9 @@ profiles:
           - hbeta
           - hei_4471
           - hei_5876
+        # Free individual vshifts to absorb wavelength calibration offsets;
+        # keep sigma tied so the line-width constraint stabilises the blend.
+        final_pass: {free_vshift: true, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
 
       - name: oiii_doublet
         anchor: oiii_5007
@@ -292,6 +302,8 @@ profiles:
           vshift: 0.0
         members:
           - oiii_4959   # amplitude also constrained via amplitude_constraints.fixed
+        # Keep the doublet fully tied at all times.
+        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
 
       - name: broad_balmer
         anchor: halpha_broad
@@ -307,17 +319,16 @@ profiles:
           - hdelta_broad
           - hepsilon_broad
           - h6_broad
+        # Keep broad Balmer lines fully tied: faint higher-order members need
+        # the constraint provided by the bright halpha_broad anchor.
+        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: null, delta_sigma_max: null}
 
     free_lines:  []
     fixed_lines: []
 
-    # Fitting strategy for this profile.
-    # The three-group structure (narrow_all + oiii_doublet + broad_balmer)
-    # already provides substantial freedom; a per-line relaxation pass adds
-    # little and is therefore disabled by default.
+    # Fitting strategy for this profile: what to relax is specified per group above.
     final_pass:
-      enabled:       false
-      mode:          per_line
+      enabled:       true
       warm_start:    true
       adopt_if:      chi2_improves
       inherit_in_mc: true

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -21,8 +21,9 @@
 #   - Within a profile, no line name may appear more than once across all placements.
 #   - bounds.sigma.min >= 0; bounds.sigma.min < bounds.sigma.max.
 #   - bounds.vshift.min < bounds.vshift.max.
-#   - fitting_strategy.final_pass.mode in {none, relax_inter_group, per_line}.
-#   - fitting_strategy.final_pass.adopt_if in {always, chi2_improves}.
+#   - profiles.<name>.final_pass.mode in {none, relax_inter_group, per_line}.
+#   - profiles.<name>.final_pass.adopt_if in {always, chi2_improves}.
+#   - Every profile must contain a final_pass block with all required keys.
 
 
 # =============================================================================
@@ -222,6 +223,17 @@ profiles:
       - hepsilon_broad
       - h6_broad
 
+    # Fitting strategy for this profile.
+    # Per-line relaxation is worthwhile here because the two-group constraint
+    # (forbidden + narrow_balmer) is tight enough that individual lines often
+    # benefit from breaking free.
+    final_pass:
+      enabled:       true
+      mode:          per_line
+      warm_start:    true        # initialize from the primary best-fit values
+      adopt_if:      chi2_improves   # "always" | "chi2_improves"
+      inherit_in_mc: true        # MC realizations mirror the final-pass decision
+
   # ---------------------------------------------------------------------------
   narrow_broad:
   # ---------------------------------------------------------------------------
@@ -236,7 +248,7 @@ profiles:
       - name: narrow_all
         # All narrow lines — Balmer, HeI, and forbidden — share one kinematic
         # anchor. [OIII] 4959,5007 are excluded (handled in oiii_doublet below).
-        anchor: nii_6584
+        anchor: halpha
         bounds:
           sigma:  {min: 1.0,    max: 750.0}
           vshift: {min: -500.0, max: 500.0}
@@ -254,7 +266,7 @@ profiles:
           - oi_6300
           - siii_6312
           - nii_6548
-          - halpha
+          - nii_6584
           - sii_6716
           - sii_6731
           - ariii_7135
@@ -299,42 +311,20 @@ profiles:
     free_lines:  []
     fixed_lines: []
 
-
-# =============================================================================
-# SECTION 5: Fitting strategy
-# =============================================================================
-
-fitting_strategy:
-
-  final_pass:
-    # When enabled, a second optimization is run after the primary constrained
-    # fit, using the mode below. The result is adopted only if the chi2
-    # improvement (accounting for the additional free parameters via an
-    # F-test) clears the adoption threshold.
-    #
-    # mode options:
-    #   none              - no relaxation; primary constrained result is final
-    #   relax_inter_group - free the inter-group kinematic ties; within-group
-    #                       ties (e.g. Balmer lines tied to Halpha) are kept
-    #   per_line          - all kinematic parameters are freed; each line snaps
-    #                       independently to its chi2 minimum
-    #
-    # Amplitude constraints (fixed ratios and doublet ratios) are never
-    # relaxed regardless of mode.
-    enabled:   true
-    mode:      per_line
-    warm_start: true     # initialize from the primary best-fit values
-    adopt_if:  chi2_improves   # "always" | "chi2_improves"
-
-  monte_carlo:
-    # If true, each MC realization mirrors whatever the nominal fit adopted
-    # (primary only, or primary + final pass). The MC does not independently
-    # test whether to adopt the final pass result.
-    inherit_final_pass: true
+    # Fitting strategy for this profile.
+    # The three-group structure (narrow_all + oiii_doublet + broad_balmer)
+    # already provides substantial freedom; a per-line relaxation pass adds
+    # little and is therefore disabled by default.
+    final_pass:
+      enabled:       false
+      mode:          per_line
+      warm_start:    true
+      adopt_if:      chi2_improves
+      inherit_in_mc: true
 
 
 # =============================================================================
-# SECTION 6: Non-parametric spectral moments
+# SECTION 5: Non-parametric spectral moments
 # =============================================================================
 # Lines (or line groups) for which non-parametric flux moments are measured
 # in addition to the fitted Gaussian parameters.  Each entry maps an output

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -331,3 +331,23 @@ fitting_strategy:
     # (primary only, or primary + final pass). The MC does not independently
     # test whether to adopt the final pass result.
     inherit_final_pass: true
+
+
+# =============================================================================
+# SECTION 6: Non-parametric spectral moments
+# =============================================================================
+# Lines (or line groups) for which non-parametric flux moments are measured
+# in addition to the fitted Gaussian parameters.  Each entry maps an output
+# column prefix (label) to one or more line names from emlines.ecsv.
+# Multiple lines with the same label are aggregated before moment computation
+# (e.g. a doublet treated as a single feature).
+
+moments:
+  - label: CIV_1549
+    lines: [civ_1549]
+  - label: MGII_2800
+    lines: [mgii_2796, mgii_2803]
+  - label: HBETA
+    lines: [hbeta]
+  - label: OIII_5007
+    lines: [oiii_5007]

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1019,6 +1019,13 @@ class EMFitTools(object):
                 flux = 0.
                 cont, clipflux = 0., []
 
+                # Intrinsic line flux: integral of the log-Gaussian
+                # = sqrt(2*pi) * A * sigma * lambda*, independent of the resolution matrix.
+                # Computed from model parameters alone so it is available even when the
+                # local pixel window is heavily masked.
+                if obsamps[line_amp] > TINY:
+                    flux = np.sqrt(2. * np.pi) * parameters[line_amp] * linezwave * linesigma0 / C_LIGHT
+
                 # Are the pixels based on the original inverse spectrum fully masked?
                 if line_s == line_e or np.sum(oemlineivar_s[line_s:line_e] == 0.) > 0.3 * (line_e - line_s):
                     patchindx = [] # return null patch
@@ -1028,12 +1035,6 @@ class EMFitTools(object):
                         dwaves_patch = dwaves[patchindx]
                         emlineflux_patch = emlineflux_s[patchindx]
                         boxflux = np.sum(emlineflux_patch * dwaves_patch)
-
-                        # require amp > 0 (line not dropped) to compute the flux
-                        if obsamps[line_amp] > TINY:
-                            # intrinsic line flux: integral of the log-Gaussian A*exp(-(log lambda - mu)^2/(2*sigma^2))
-                            # = sqrt(2*pi) * A * sigma * lambda*, independent of the resolution matrix
-                            flux = np.sqrt(2. * np.pi) * parameters[line_amp] * linezwave * linesigma0 / C_LIGHT
 
                         # next, get the continuum level
                         borderindx = get_continuum_pixels(emlinewave_s, linezwave, linesigma_ang_window)
@@ -1100,15 +1101,37 @@ class EMFitTools(object):
             npix = len(patchindx)
             fastfit[f'{linename}_NPIX'] = npix
 
-            # Are the pixels based on the original inverse spectrum fully
-            # masked? If so, set everything to zero and move onto the next
-            # line.
+            # If the local pixel window is too heavily masked, check whether all
+            # three parameters of this line are tied to a kinematic anchor.  For
+            # such fully-tied lines the model-derived quantities (AMP, VSHIFT,
+            # SIGMA, MODELAMP, FLUX) are still valid; only pixel-level measurements
+            # (BOXFLUX, CONT, CHI2, FLUX_IVAR) are unavailable.
             if npix == 0:
-                obsamps[line_amp] = 0.
-                parameters[line_amp] = 0.
-                values[line_amp] = 0.
-                values[line_vshift] = 0.
-                values[line_sigma] = 0.
+                all_tied = (linemodel['tiedtoparam'][line_amp]    != -1 and
+                            linemodel['tiedtoparam'][line_vshift] != -1 and
+                            linemodel['tiedtoparam'][line_sigma]  != -1)
+                if all_tied:
+                    fastfit[f'{linename}_AMP']      = obsamps[line_amp]
+                    fastfit[f'{linename}_VSHIFT']   = values[line_vshift]
+                    fastfit[f'{linename}_SIGMA']    = values[line_sigma]
+                    fastfit[f'{linename}_MODELAMP'] = parameters[line_amp]
+                    fastfit[f'{linename}_FLUX']     = flux
+                    if results_monte is not None:
+                        obsamps_ivar = var2ivar(obsamps_var[line_amp])
+                        vshift_ivar  = var2ivar(values_var[line_vshift])
+                        sigma_ivar   = var2ivar(values_var[line_sigma])
+                        if obsamps_ivar < F32MAX:
+                            fastfit[f'{linename}_AMP_IVAR']    = obsamps_ivar
+                        if vshift_ivar < F32MAX:
+                            fastfit[f'{linename}_VSHIFT_IVAR'] = vshift_ivar
+                        if sigma_ivar < F32MAX:
+                            fastfit[f'{linename}_SIGMA_IVAR']  = sigma_ivar
+                else:
+                    obsamps[line_amp] = 0.
+                    parameters[line_amp] = 0.
+                    values[line_amp] = 0.
+                    values[line_vshift] = 0.
+                    values[line_sigma] = 0.
                 continue
 
             flux_ivar, cont_ivar = 0., 0. # defaults if not computed below

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -86,13 +86,17 @@ class EmlineConstraints:
     def line_bounds(self, line_name):
         """Return ``(sigma_min, sigma_max, vshift_max, sigma_init, vshift_init)`` in km/s.
 
-        Searches global groups, global free lines, then all profiles.
-        Returns all zeros for lines in a profile's ``fixed_lines``.
+        Searches global groups, global free lines, then all profiles' kinematic
+        groups, and finally ``fixed_lines``. Kinematic groups across all profiles
+        are checked before ``fixed_lines`` because a line may be fixed in one
+        profile (e.g. ``narrow_only``) but carry real bounds in another
+        (e.g. ``narrow_broad``).  Returns all zeros only for lines that appear
+        exclusively in ``fixed_lines`` and nowhere else.
 
         Raises
         ------
         ValueError
-            If the line is not found in the constraint file.
+            If the line is not found anywhere in the constraint file.
         """
         for g in self.global_kinematic_groups:
             if line_name == g['anchor'] or line_name in g.get('members', []):
@@ -101,10 +105,13 @@ class EmlineConstraints:
             db, di = self.global_default_bounds, self.global_default_initial
             return (db['sigma']['min'], db['sigma']['max'],
                     db['vshift']['max'], di['sigma'], di['vshift'])
+        # Check kinematic groups across ALL profiles before fixed_lines.
         for profile in self.profiles.values():
             for g in profile.get('kinematic_groups', []):
                 if line_name == g['anchor'] or line_name in g.get('members', []):
                     return self._unpack_bounds(g)
+        # Only return zeros if the line appears in no kinematic group at all.
+        for profile in self.profiles.values():
             if line_name in profile.get('fixed_lines', []):
                 return (0., 0., 0., 0., 0.)
         raise ValueError(
@@ -113,7 +120,8 @@ class EmlineConstraints:
     @staticmethod
     def _unpack_bounds(g):
         sb, vb, ig = g['bounds']['sigma'], g['bounds']['vshift'], g['initial']
-        return (sb['min'], sb['max'], vb['max'], ig['sigma'], ig['vshift'])
+        return (float(sb['min']), float(sb['max']), float(vb['max']),
+                float(ig['sigma']), float(ig['vshift']))
 
     def _check_consistency(self, line_table):
         emline_names = set(line_table['name'])

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -73,23 +73,32 @@ class EmlineConstraints:
         self.global_default_bounds   = g['default_bounds']
         self.global_default_initial  = g['default_initial']
 
-        # named profiles
+        # named profiles + per-profile final_pass strategy
         self.profiles = raw['profiles']
+        _fp_required = {'enabled', 'mode', 'warm_start', 'adopt_if', 'inherit_in_mc'}
+        self.final_pass = {}
+        for pname, profile in self.profiles.items():
+            if 'final_pass' not in profile:
+                raise ValueError(
+                    f"Constraint profile '{pname}' is missing required 'final_pass' block.")
+            fp = profile['final_pass']
+            missing_keys = _fp_required - set(fp)
+            if missing_keys:
+                raise ValueError(
+                    f"Profile '{pname}' final_pass is missing keys: {sorted(missing_keys)}")
+            self.final_pass[pname] = {
+                'enabled':       bool(fp['enabled']),
+                'mode':          str(fp['mode']),
+                'warm_start':    bool(fp['warm_start']),
+                'adopt_if':      str(fp['adopt_if']),
+                'inherit_in_mc': bool(fp['inherit_in_mc']),
+            }
 
         # non-parametric moment groups: {output_label: [line_names]}
         self.moments = {
             entry['label']: list(entry['lines'])
             for entry in raw.get('moments', [])
         }
-
-        # fitting strategy
-        fs = raw['fitting_strategy']
-        fp = fs['final_pass']
-        self.final_pass_enabled    = bool(fp['enabled'])
-        self.final_pass_mode       = str(fp['mode'])
-        self.final_pass_warm_start = bool(fp['warm_start'])
-        self.final_pass_adopt_if   = str(fp['adopt_if'])
-        self.mc_inherit_final_pass = bool(fs['monte_carlo']['inherit_final_pass'])
 
         if line_table is not None:
             self._check_consistency(line_table)
@@ -1699,9 +1708,12 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
         delta_linechi2_balmer, delta_linendof_balmer = 0, np.int32(0)
 
     # Optional final pass: relax kinematic ties and re-optimise.
-    if constraints.final_pass_enabled and constraints.final_pass_mode != 'none':
+    # Settings are per-profile: look up based on which model was adopted.
+    profile_name = 'narrow_broad' if adopt_broad else 'narrow_only'
+    fp = constraints.final_pass[profile_name]
+    if fp['enabled'] and fp['mode'] != 'none':
         t0 = time.time()
-        if constraints.final_pass_mode == 'per_line':
+        if fp['mode'] == 'per_line':
             linemodel_relax = linemodel_pref.copy()
             for i in range(len(linemodel_relax)):
                 if (not linemodel_relax['fixed'][i]
@@ -1711,26 +1723,26 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
                     linemodel_relax['tiedtoparam'][i] = -1
                     linemodel_relax['tiedfactor'][i]  = 0.
                     linemodel_relax['free'][i]        = True
-        elif constraints.final_pass_mode == 'relax_inter_group':
+        elif fp['mode'] == 'relax_inter_group':
             errmsg = "Relax_inter_group mode requires a dedicated profile in the constraint file."
             log.critical(errmsg)
             raise NotImplementedError(errmsg)
         else:
-            errmsg = f"Unknown final_pass mode: '{constraints.final_pass_mode}'"
+            errmsg = f"Unknown final_pass mode: '{fp['mode']}'"
             log.critical(errmsg)
             raise ValueError(errmsg)
 
         init_relax = (linemodel_pref['value'].value
-                      if constraints.final_pass_warm_start else initial_guesses)
+                      if fp['warm_start'] else initial_guesses)
         emlineflux_model_relax, nfree_relax, chi2_relax = linefit(
             EMFit, linemodel_relax, init_relax, param_bounds,
             emlinewave, emlineflux, emlineivar, weights, redshift,
             resolution_matrix, camerapix)
 
         adopt_relax = False
-        if constraints.final_pass_adopt_if == 'always':
+        if fp['adopt_if'] == 'always':
             adopt_relax = True
-        elif constraints.final_pass_adopt_if == 'chi2_improves':
+        elif fp['adopt_if'] == 'chi2_improves':
             nbins      = np.sum(emlineivar > 0)
             ndof_pref  = nbins - nfree_pref
             ndof_relax = nbins - nfree_relax
@@ -1743,22 +1755,21 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
             emlineflux_model_pref = emlineflux_model_relax
             chi2_pref             = chi2_relax
             nfree_pref            = nfree_relax
-            if constraints.final_pass_adopt_if == 'chi2_improves':
-                log.info(f'Adopting relaxed kinematic model ({constraints.final_pass_mode}): '
+            if fp['adopt_if'] == 'chi2_improves':
+                log.info(f'Adopting relaxed kinematic model ({fp["mode"]}): '
                          f'delta-chi2={delta_chi2:.1f} > delta-ndof={delta_ndof:.0f}')
             else:
-                log.info(f'Adopting relaxed kinematic model ({constraints.final_pass_mode}): '
-                         f'adopt_if=always')
+                log.info(f'Adopting relaxed kinematic model ({fp["mode"]}): adopt_if=always')
         else:
-            if constraints.final_pass_adopt_if == 'chi2_improves':
+            if fp['adopt_if'] == 'chi2_improves':
                 if delta_ndof <= 0:
-                    log.debug(f'Dropping relaxed kinematic model ({constraints.final_pass_mode}): '
+                    log.debug(f'Dropping relaxed kinematic model ({fp["mode"]}): '
                               f'no additional free parameters (delta-ndof={delta_ndof:.0f})')
                 else:
-                    log.debug(f'Dropping relaxed kinematic model ({constraints.final_pass_mode}): '
+                    log.debug(f'Dropping relaxed kinematic model ({fp["mode"]}): '
                               f'delta-chi2={delta_chi2:.1f} < delta-ndof={delta_ndof:.0f}')
         log.debug(fsftime('linefit_final_pass', time.time()-t0,
-                          context=f'targetid={data["uniqueid"]}, mode={constraints.final_pass_mode}'))
+                          context=f'targetid={data["uniqueid"]}, mode={fp["mode"]}'))
 
     # Residual spectrum with no emission lines
     specflux_nolines = specflux - emlineflux_model_pref

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -477,6 +477,15 @@ class EMFitTools(object):
             sigma_min, sigma_max, vshift_max, _, _ = \
                 self.constraints.line_bounds(line_name)
 
+            # Lines in a profile's fixed_lines have all-zero bounds.
+            # Clamp their initials to zero so the bounds check passes.
+            if sigma_max == 0.:
+                initials[vshift] = 0.
+                initials[sigma]  = 0.
+                bounds[vshift]   = (0., 0.)
+                bounds[sigma]    = (0., 0.)
+                continue
+
             if line_isbroad:
                 if line_isbalmer:  # broad He+Balmer lines
                     initials[vshift] = initial_linevshift_balmer_broad

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1730,10 +1730,22 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
             emlineflux_model_pref = emlineflux_model_relax
             chi2_pref             = chi2_relax
             nfree_pref            = nfree_relax
-        log.info(fsftime('linefit_final_pass', time.time()-t0,
-                         context=f'targetid={data["uniqueid"]}, '
-                         f'mode={constraints.final_pass_mode}, '
-                         f'adopted={adopt_relax}'))
+            if constraints.final_pass_adopt_if == 'chi2_improves':
+                log.info(f'Adopting relaxed kinematic model ({constraints.final_pass_mode}): '
+                         f'delta-chi2={delta_chi2:.1f} > delta-ndof={delta_ndof:.0f}')
+            else:
+                log.info(f'Adopting relaxed kinematic model ({constraints.final_pass_mode}): '
+                         f'adopt_if=always')
+        else:
+            if constraints.final_pass_adopt_if == 'chi2_improves':
+                if delta_ndof <= 0:
+                    log.debug(f'Dropping relaxed kinematic model ({constraints.final_pass_mode}): '
+                              f'no additional free parameters (delta-ndof={delta_ndof:.0f})')
+                else:
+                    log.debug(f'Dropping relaxed kinematic model ({constraints.final_pass_mode}): '
+                              f'delta-chi2={delta_chi2:.1f} < delta-ndof={delta_ndof:.0f}')
+        log.debug(fsftime('linefit_final_pass', time.time()-t0,
+                          context=f'targetid={data["uniqueid"]}, mode={constraints.final_pass_mode}'))
 
     # Residual spectrum with no emission lines
     specflux_nolines = specflux - emlineflux_model_pref

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -88,11 +88,13 @@ class EmlineConstraints:
                     raise ValueError(
                         f"Group '{g['name']}' final_pass in {context} "
                         f"is missing required key '{key}'.")
+            dvm = gfp.get('delta_vshift_max')
+            dsm = gfp.get('delta_sigma_max')
             return {
                 'free_vshift':      bool(gfp['free_vshift']),
                 'free_sigma':       bool(gfp['free_sigma']),
-                'delta_vshift_max': gfp.get('delta_vshift_max'),  # reserved; not yet used
-                'delta_sigma_max':  gfp.get('delta_sigma_max'),   # reserved; not yet used
+                'delta_vshift_max': float(dvm) if dvm is not None else None,
+                'delta_sigma_max':  float(dsm) if dsm is not None else None,
             }
 
         # group_final_pass: keyed by 'global.<name>' or '<profile>.<name>'
@@ -1769,8 +1771,47 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
         else:
             init_relax = (linemodel_pref['value'].value
                           if fp['warm_start'] else initial_guesses)
+
+            # Tighten bounds for freed parameters around their warm-start values
+            # using per-group delta_vshift_max / delta_sigma_max.
+            #
+            # Guardrails:
+            #   - Skip tightening if the warm-start is at (or within 1 km/s of)
+            #     an existing bound: a boundary-pinned value is unreliable as a
+            #     center, and the parameter is likely unconstrained anyway.
+            #   - Construction guarantees warm_val ∈ [new_lb, new_ub] whenever
+            #     delta > 0 and warm_val is strictly inside the original bounds.
+            #   - Sigma floor (param_bounds[i,0] >= 1 km/s for all sigma params)
+            #     prevents new_lb from going negative.
+            _BOUND_TOL = 1.0  # km/s; treat warm-start within this of a bound as pinned
+            param_bounds_relax = param_bounds.copy()
+            for i in range(len(linemodel_relax)):
+                if not linemodel_relax['free'][i]:
+                    continue
+                gfp = constraints.group_final_pass.get(linemodel_relax['group_name'][i])
+                if gfp is None:
+                    continue
+                param_type = EMFit.param_table['type'][i]
+                if param_type == ParamType.VSHIFT:
+                    delta = gfp['delta_vshift_max']
+                elif param_type == ParamType.SIGMA:
+                    delta = gfp['delta_sigma_max']
+                else:
+                    continue
+                if delta is None:
+                    continue
+                lb, ub   = param_bounds[i, 0], param_bounds[i, 1]
+                warm_val = init_relax[i]
+                if warm_val <= lb + _BOUND_TOL or warm_val >= ub - _BOUND_TOL:
+                    continue  # boundary-pinned; keep original bounds
+                new_lb = max(lb, warm_val - delta)
+                new_ub = min(ub, warm_val + delta)
+                if new_lb < new_ub:  # safety: only apply if bounds are non-degenerate
+                    param_bounds_relax[i, 0] = new_lb
+                    param_bounds_relax[i, 1] = new_ub
+
             emlineflux_model_relax, nfree_relax, chi2_relax = linefit(
-                EMFit, linemodel_relax, init_relax, param_bounds,
+                EMFit, linemodel_relax, init_relax, param_bounds_relax,
                 emlinewave, emlineflux, emlineivar, weights, redshift,
                 resolution_matrix, camerapix)
 

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -325,6 +325,15 @@ class EMFitTools(object):
         param_idx[:,ParamType.SIGMA]     = c + 2*nlines
         self.line_table['params'] = param_idx
 
+        # mapping from amplitude parameter index -> output catalog column name,
+        # for lines whose amplitude is constrained by a fixed ratio to another line.
+        self.amp_fixed_col = {}
+        for fc in constraints.amplitude_fixed:
+            pname = fc.get('param_name')
+            if pname and fc['line'] in self.line_map:
+                amp_idx = param_idx[self.line_map[fc['line']], ParamType.AMPLITUDE]
+                self.amp_fixed_col[int(amp_idx)] = pname
+
         # needed by emlinemodel_bestfit()
         self.param_table['modelname'] = \
             np.array([ s.replace('_amp', '_modelamp').upper() for s in param_names ])
@@ -1074,22 +1083,13 @@ class EMFitTools(object):
                     if doublet_ivar < F32MAX:
                         fastfit[f'{param_modelnames[line_amp]}_IVAR'] = doublet_ivar
 
-            # Also store the 'tied' doublet ratios (fragile...).
-            if linemodel['tiedtoparam'][line_amp] != -1:
-                ratio = linemodel['tiedfactor'][line_amp]
-                match linename:
-                    case 'OIII_4959':
-                        col = 'OIII_DOUBLET_RATIO'
-                    case 'NII_6548':
-                        col = 'NII_DOUBLET_RATIO'
-                    case 'OII_7330':
-                        col = 'OIIRED_DOUBLET_RATIO'
-                    case _:
-                        errmsg = 'Unrecognized tied doublet {linename}'
-                        log.critical(errmsg)
-                        raise ValueError(errmsg)
-                fastfit[col] = 1. / ratio
-                fastfit[f'{col}_IVAR'] = 0. # not optimized
+            # Store the fixed amplitude ratio for amplitude-constrained lines
+            # (e.g. [OIII] 4959, [NII] 6548, [OII] 7330).  The column name
+            # comes from amplitude_constraints.fixed[].param_name in the YAML.
+            col = self.amp_fixed_col.get(line_amp)
+            if col is not None:
+                fastfit[col] = 1. / linemodel['tiedfactor'][line_amp]
+                fastfit[f'{col}_IVAR'] = 0.  # not optimized
 
 
             (boxflux, flux, cont), extras = get_fluxes(

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -7,6 +7,7 @@ Methods and tools for fitting emission lines.
 """
 import os
 import time
+import logging
 import numpy as np
 from enum import IntEnum
 from itertools import chain
@@ -1219,26 +1220,6 @@ class EMFitTools(object):
                 line_stats[f'{groupname}_Z'] = redshift
 
 
-        import logging
-        if log.getEffectiveLevel() == logging.DEBUG:
-            for ln in self.line_table['name'].value:
-                linename = ln.upper()
-                for col in ('VSHIFT', 'SIGMA', 'MODELAMP', 'AMP', 'AMP_IVAR', 'CHI2', 'NPIX'):
-                    val = fastfit[f'{linename}_{col}']
-                    log.debug(f'{linename} {col}: {val:.4f}')
-                for col in ('FLUX', 'BOXFLUX', 'FLUX_IVAR', 'BOXFLUX_IVAR', 'CONT', 'CONT_IVAR', 'EW', 'EW_IVAR', 'FLUX_LIMIT'):
-                    val = fastfit[f'{linename}_{col}']
-                    log.debug(f'{linename} {col}: {val:.4f}')
-                print()
-
-            for lname in ['MGII', 'OII', 'SII']:
-                col = f'{lname}_DOUBLET_RATIO'
-                val = fastfit[col]
-                val_ivar = fastfit[f'{col}_IVAR']
-                log.debug(f'{col}: {val:.4f}')
-                log.debug(f'{col}_IVAR: {val_ivar:.4f}')
-            print()
-
         return line_stats
 
 
@@ -1912,7 +1893,7 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
 
     log.debug(fsftime('emline_specfit', time.time()-tall))
 
-    if debug_plots:
+    if debug_plots or log.isEnabledFor(logging.DEBUG):
         _fastfit_cols = [
             'RCHI2_LINE',
             'NARROW_Z', 'NARROW_ZRMS', 'BROAD_Z', 'BROAD_ZRMS',

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -76,6 +76,12 @@ class EmlineConstraints:
         # named profiles
         self.profiles = raw['profiles']
 
+        # non-parametric moment groups: {output_label: [line_names]}
+        self.moments = {
+            entry['label']: list(entry['lines'])
+            for entry in raw.get('moments', [])
+        }
+
         # fitting strategy
         fs = raw['fitting_strategy']
         fp = fs['final_pass']
@@ -155,6 +161,14 @@ class EmlineConstraints:
                     f"Constraint profile '{profile_name}' references "
                     f"lines not in emlines.ecsv: {sorted(extra)}")
 
+        # Validate moment line names.
+        for label, lines in self.moments.items():
+            unknown = set(lines) - emline_names
+            if unknown:
+                raise ValueError(
+                    f"Moment group '{label}' references lines not in "
+                    f"emlines.ecsv: {sorted(unknown)}")
+
 
 class EMFitTools(object):
     """Tools for fitting emission-line spectra from DESI spectroscopy.
@@ -189,9 +203,8 @@ class EMFitTools(object):
             isstrong = self.line_table['isstrong'].value
             self.line_table = self.line_table[isstrong]
 
-        # lines for which we want to measure moments
-        self.moment_lines = {'CIV_1549': ['civ_1549'], 'MGII_2800': ['mgii_2796', 'mgii_2803'],
-                             'HBETA': ['hbeta'], 'OIII_5007': ['oiii_5007']} #, 'HALPHA': ['halpha']}
+        # lines for which we want to measure non-parametric moments
+        self.moment_lines = constraints.moments
 
         # Build some convenience (Boolean) arrays that we'll use in many places:
         line_isbroad  = self.line_table['isbroad'].value

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -2030,33 +2030,75 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
     log.debug(fsftime('emline_specfit', time.time()-tall))
 
     if debug_plots or log.isEnabledFor(logging.DEBUG):
-        _fastfit_cols = [
-            'RCHI2_LINE',
-            'NARROW_Z', 'NARROW_ZRMS', 'BROAD_Z', 'BROAD_ZRMS',
-            'OII_DOUBLET_RATIO',
-            'OII_3726_FLUX', 'OII_3726_FLUX_IVAR',
-            'HBETA_FLUX', 'HBETA_FLUX_IVAR',
-            'OIII_5007_FLUX', 'OIII_5007_FLUX_IVAR',
-            'NII_6584_FLUX', 'NII_6584_FLUX_IVAR',
-            'HALPHA_FLUX', 'HALPHA_FLUX_IVAR',
-            'HALPHA_BROAD_FLUX', 'HALPHA_BROAD_FLUX_IVAR',
-            'SII_6731_FLUX', 'SII_6731_FLUX_IVAR',
-        ]
-        _specphot_cols = [
-            'RCHI2', 'RCHI2_CONT', 'RCHI2_PHOT',
-            'VDISP', 'VDISP_IVAR',
-            'AGE', 'ZZSUN', 'LOGMSTAR', 'SFR', 'AV',
-            'DN4000', 'DN4000_OBS', 'DN4000_MODEL',
-        ]
-        _fnames = fastfit.value.dtype.names
-        _snames = specphot.value.dtype.names
-        print(f'--- fastfit [{data["uniqueid"]}] ---')
-        for name in _fastfit_cols:
-            if name in _fnames:
-                print(f'  {name}: {fastfit[name]}')
-        print(f'--- specphot [{data["uniqueid"]}] ---')
-        for name in _specphot_cols:
-            if name in _snames:
-                print(f'  {name}: {specphot[name]}')
+        print(f'--- emline [{data["uniqueid"]}] ---')
+        print(f'  rchi2(line) = {specphot["RCHI2_LINE"]:.3f}')
+
+        # Kinematic group summary from line_stats (not stored in output table).
+        def _kfmt(dv, dverr, sig, sigerr):
+            dv_str  = f'{dv:+8.1f} ±{dverr:5.1f}' if dverr > 0. else f'{dv:+8.1f}       '
+            sig_str = f'{sig:5.0f} ±{sigerr:4.0f}' if sigerr > 0. else f'{sig:5.0f}     '
+            return f'dv = {dv_str} km/s    sigma = {sig_str} km/s'
+
+        print('  kinematics:')
+        print(f'    narrow   {_kfmt(C_LIGHT*(line_stats["NARROW_Z"][0]-redshift), C_LIGHT*line_stats["NARROW_ZRMS"][0], line_stats["NARROW_SIGMA"][0], line_stats["NARROW_SIGMARMS"][0])}')
+        if np.any(EMFit.isBalmerBroad & EMFit.line_in_range):
+            print(f'    broad    {_kfmt(C_LIGHT*(line_stats["BROAD_Z"][0]-redshift), C_LIGHT*line_stats["BROAD_ZRMS"][0], line_stats["BROAD_SIGMA"][0], line_stats["BROAD_SIGMARMS"][0])}')
+        if np.any(EMFit.isBroad & EMFit.line_in_range):
+            print(f'    UV       {_kfmt(C_LIGHT*(line_stats["UV_Z"][0]-redshift), C_LIGHT*line_stats["UV_ZRMS"][0], line_stats["UV_SIGMA"][0], line_stats["UV_SIGMARMS"][0])}')
+
+        # Strong in-range line fluxes and rest-frame EW.
+        isstrong_inrange = EMFit.line_table['isstrong'].value & EMFit.line_in_range
+        if np.any(isstrong_inrange):
+            fnames = fastfit.value.dtype.names
+            print('  strong lines in range  [flux | EW (Å)]:')
+            for lname in EMFit.line_table['name'].value[isstrong_inrange]:
+                ucol     = lname.upper()
+                ivar_col = f'{ucol}_FLUX_IVAR'
+                if ivar_col not in fnames:
+                    continue
+                ivar = float(fastfit[ivar_col])
+                if ivar <= 0.:
+                    continue
+                flux     = float(fastfit[f'{ucol}_FLUX'])
+                flux_err = 1. / np.sqrt(ivar)
+                snr      = flux * np.sqrt(ivar)
+                line_str = f'    {ucol:20s}  {flux:8.1f} ±{flux_err:5.1f}   S/N = {snr:5.1f}'
+                ew_col     = f'{ucol}_EW'
+                ewivar_col = f'{ucol}_EW_IVAR'
+                ew     = float(fastfit[ew_col])     if ew_col     in fnames else 0.
+                ewivar = float(fastfit[ewivar_col]) if ewivar_col in fnames else 0.
+                if ew > 0.:
+                    if ewivar > 0.:
+                        line_str += f'   EW = {ew:7.1f} ±{1./np.sqrt(ewivar):5.1f} Å'
+                    else:
+                        line_str += f'   EW = {ew:7.1f} Å'
+                print(line_str)
+
+        # Specphot summary.
+        snames = specphot.value.dtype.names
+
+        def _sv(col, fmt='.2f', unit=''):
+            """Value ± error (only when ivar > 0), with optional unit suffix."""
+            if col not in snames:
+                return '---'
+            v  = float(specphot[col])
+            ic = col + '_IVAR'
+            iv = float(specphot[ic]) if ic in snames else 0.
+            s  = format(v, fmt)
+            if iv > 0.:
+                s += f' ± {format(1./np.sqrt(iv), fmt)}'
+            return s + (f' {unit}' if unit else '')
+
+        print('  specphot:')
+        r2   = format(float(specphot['RCHI2']),      '.3f') if 'RCHI2'      in snames else '---'
+        r2c  = format(float(specphot['RCHI2_CONT']), '.3f') if 'RCHI2_CONT' in snames else '---'
+        r2p  = format(float(specphot['RCHI2_PHOT']), '.3f') if 'RCHI2_PHOT' in snames else '---'
+        print(f'    rchi2 = {r2}   rchi2_cont = {r2c}   rchi2_phot = {r2p}')
+        print(f'    vdisp = {_sv("VDISP", ".1f", "km/s")}   logmstar = {_sv("LOGMSTAR")}   age = {_sv("AGE", ".2f", "Gyr")}')
+        print(f'    sfr = {_sv("SFR", ".2f", "Msun/yr")}   zzsun = {_sv("ZZSUN")}   AV = {_sv("AV")}')
+        dn4000     = format(float(specphot['DN4000']),       '.3f') if 'DN4000'       in snames else '---'
+        dn4000_obs = format(float(specphot['DN4000_OBS']),   '.3f') if 'DN4000_OBS'   in snames else '---'
+        dn4000_mod = format(float(specphot['DN4000_MODEL']), '.3f') if 'DN4000_MODEL' in snames else '---'
+        print(f'    dn4000 = {dn4000}  (obs = {dn4000_obs},  model = {dn4000_mod})')
 
     return spectra_out

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -5,6 +5,7 @@ fastspecfit.emlines
 Methods and tools for fitting emission lines.
 
 """
+import os
 import time
 import numpy as np
 from enum import IntEnum
@@ -27,6 +28,117 @@ class ParamType(IntEnum):
     SIGMA = 2
 
 
+class EmlineConstraints:
+    """Parsed and validated emission-line kinematic constraint file.
+
+    Reads the companion YAML constraint file, runs a startup consistency
+    check against ``line_table``, and exposes the constraint data for use
+    by :class:`EMFitTools`.
+
+    Parameters
+    ----------
+    constraints_file : str or None
+        Path to the YAML constraint file. Uses the bundled default when
+        ``None``.
+    line_table : :class:`astropy.table.Table` or None
+        Full emission-line table. When provided, a consistency check
+        verifies that every line appears exactly once in each profile.
+
+    """
+
+    _DEFAULT_FILE = os.path.join(os.path.dirname(__file__), 'data',
+                                 'emline-constraints.yaml')
+
+    def __init__(self, constraints_file=None, line_table=None):
+        import yaml
+
+        self.file = constraints_file or self._DEFAULT_FILE
+        with open(self.file) as fh:
+            raw = yaml.safe_load(fh)
+
+        # amplitude constraints (profile-independent)
+        ac = raw['amplitude_constraints']
+        self.amplitude_fixed = ac.get('fixed', [])
+        self.doublet_ratios  = ac.get('doublet_ratios', [])
+
+        # global placements (shared across all profiles)
+        g = raw['global']
+        self.global_free_lines       = list(g.get('free_lines', []))
+        self.global_kinematic_groups = list(g.get('kinematic_groups', []))
+        self.global_default_bounds   = g['default_bounds']
+        self.global_default_initial  = g['default_initial']
+
+        # named profiles
+        self.profiles = raw['profiles']
+
+        # fitting strategy
+        fs = raw['fitting_strategy']
+        fp = fs['final_pass']
+        self.final_pass_enabled    = bool(fp['enabled'])
+        self.final_pass_mode       = str(fp['mode'])
+        self.final_pass_warm_start = bool(fp['warm_start'])
+        self.final_pass_adopt_if   = str(fp['adopt_if'])
+        self.mc_inherit_final_pass = bool(fs['monte_carlo']['inherit_final_pass'])
+
+        if line_table is not None:
+            self._check_consistency(line_table)
+
+    def line_bounds(self, line_name):
+        """Return ``(sigma_min, sigma_max, vshift_max, sigma_init, vshift_init)`` in km/s.
+
+        Searches global groups, global free lines, then all profiles.
+        Returns all zeros for lines in a profile's ``fixed_lines``.
+
+        Raises
+        ------
+        ValueError
+            If the line is not found in the constraint file.
+        """
+        for g in self.global_kinematic_groups:
+            if line_name == g['anchor'] or line_name in g.get('members', []):
+                return self._unpack_bounds(g)
+        if line_name in self.global_free_lines:
+            db, di = self.global_default_bounds, self.global_default_initial
+            return (db['sigma']['min'], db['sigma']['max'],
+                    db['vshift']['max'], di['sigma'], di['vshift'])
+        for profile in self.profiles.values():
+            for g in profile.get('kinematic_groups', []):
+                if line_name == g['anchor'] or line_name in g.get('members', []):
+                    return self._unpack_bounds(g)
+            if line_name in profile.get('fixed_lines', []):
+                return (0., 0., 0., 0., 0.)
+        raise ValueError(
+            f"Line '{line_name}' not found in constraint file '{self.file}'")
+
+    @staticmethod
+    def _unpack_bounds(g):
+        sb, vb, ig = g['bounds']['sigma'], g['bounds']['vshift'], g['initial']
+        return (sb['min'], sb['max'], vb['max'], ig['sigma'], ig['vshift'])
+
+    def _check_consistency(self, line_table):
+        emline_names = set(line_table['name'])
+        for profile_name, profile in self.profiles.items():
+            placed = set(self.global_free_lines)
+            for g in self.global_kinematic_groups:
+                placed.add(g['anchor'])
+                placed.update(g.get('members', []))
+            for g in profile.get('kinematic_groups', []):
+                placed.add(g['anchor'])
+                placed.update(g.get('members', []))
+            placed.update(profile.get('free_lines', []))
+            placed.update(profile.get('fixed_lines', []))
+            missing = emline_names - placed
+            extra   = placed - emline_names
+            if missing:
+                raise ValueError(
+                    f"Constraint profile '{profile_name}' is missing "
+                    f"lines from emlines.ecsv: {sorted(missing)}")
+            if extra:
+                raise ValueError(
+                    f"Constraint profile '{profile_name}' references "
+                    f"lines not in emlines.ecsv: {sorted(extra)}")
+
+
 class EMFitTools(object):
     """Tools for fitting emission-line spectra from DESI spectroscopy.
 
@@ -45,11 +157,12 @@ class EMFitTools(object):
 
     """
 
-    def __init__(self, emline_table, uniqueid=None, outfile_base='',
+    def __init__(self, emline_table, constraints, uniqueid=None, outfile_base='',
                  stronglines=False):
 
-        self.line_table = emline_table
-        self.uniqueid = uniqueid
+        self.line_table  = emline_table
+        self.constraints = constraints
+        self.uniqueid    = uniqueid
         self.outfile_base = outfile_base
 
         # restrict to just strong lines and assign to patches
@@ -89,12 +202,11 @@ class EMFitTools(object):
         # mapping to enable fast lookup of line number by name
         self.line_map = { line_name : line_idx for line_idx, line_name in enumerate(line_names) }
 
-        # info about tied doublet lines
+        # info about tied doublet lines — sourced from the constraint file
         doublet_lines = {
-            # indx           source         ratio name
-            'mgii_2796' : ( 'mgii_2803' , 'mgii_doublet_ratio' ) ,
-            'oii_3726'  : ( 'oii_3729'  , 'oii_doublet_ratio'  ) ,
-            'sii_6731'  : ( 'sii_6716'  , 'sii_doublet_ratio'  ) ,
+            dr['line']: (dr['ref'], dr['param_name'])
+            for dr in constraints.doublet_ratios
+            if dr['line'] in self.line_map and dr['ref'] in self.line_map
         }
 
         # mapping from target -> source for all tied doublets
@@ -159,25 +271,19 @@ class EMFitTools(object):
              (zlinewave < (wavelims[1] - wavepad)))
 
 
-    def build_linemodels(self, separate_oiii_fit=True):
+    def build_linemodels(self):
         """Build broad and narrow emission-line model tables.
 
-        Establishes fixed parameters, tying relationships, and doublet
-        constraints for each model. :meth:`compute_inrange_lines` must be
-        called first to populate in-range information.
-
-        Parameters
-        ----------
-        separate_oiii_fit : bool, optional
-            If ``True``, fit [OIII] 4959,5007 separately from the other
-            narrow forbidden lines. Defaults to ``True``.
+        Reads kinematic groups and amplitude constraints from
+        ``self.constraints`` (the ``narrow_broad`` and ``narrow_only``
+        profiles). :meth:`compute_inrange_lines` must be called first.
 
         Returns
         -------
         linemodel_broad : :class:`astropy.table.Table`
-            Line model allowing broad Balmer + helium components.
+            Line model using the ``narrow_broad`` constraint profile.
         linemodel_nobroad : :class:`astropy.table.Table`
-            Line model with broad components fixed to zero.
+            Line model using the ``narrow_only`` constraint profile.
 
         """
 
@@ -243,161 +349,54 @@ class EMFitTools(object):
             return linemodel
 
 
-        def tie_line(tying_info, line_params, source_linename, amp_factor=None):
-            """Tie parameters of given line to source line. We don't tie the
-            amplitude unless a tying factor is given for it.
+        def _build_tying_info(profile_name):
+            """Build fresh tying arrays from the named constraint profile."""
+            n_params    = len(self.param_table)
+            tiedtoparam = np.full(n_params, -1, np.int32)
+            tiedfactor  = np.empty(n_params, np.float64)
 
-            """
-            tiedtoparam, tiedfactor = tying_info
+            def _tie_kinematics(groups):
+                for g in groups:
+                    if g['anchor'] not in self.line_map:
+                        continue
+                    anchor_line = self.line_map[g['anchor']]
+                    _, src_vshift, src_sigma = self.line_table['params'][anchor_line]
+                    for member_name in g.get('members', []):
+                        if member_name not in self.line_map:
+                            continue
+                        member_line = self.line_map[member_name]
+                        _, vshift, sigma = self.line_table['params'][member_line]
+                        tiedfactor[vshift]  = 1.0
+                        tiedtoparam[vshift] = src_vshift
+                        tiedfactor[sigma]   = 1.0
+                        tiedtoparam[sigma]  = src_sigma
 
-            amp, vshift, sigma = line_params
+            _tie_kinematics(self.constraints.global_kinematic_groups)
+            _tie_kinematics(self.constraints.profiles[profile_name].get('kinematic_groups', []))
 
-            source_line = self.line_map[source_linename]
-            src_amp, src_vshift, src_sigma = self.line_table['params'][source_line]
+            for fc in self.constraints.amplitude_fixed:
+                if fc['line'] not in self.line_map or fc['ref'] not in self.line_map:
+                    continue
+                line     = self.line_map[fc['line']]
+                ref      = self.line_map[fc['ref']]
+                amp_line = self.line_table['params'][line, ParamType.AMPLITUDE]
+                amp_ref  = self.line_table['params'][ref,  ParamType.AMPLITUDE]
+                tiedfactor[amp_line]  = fc['factor']
+                tiedtoparam[amp_line] = amp_ref
 
-            if amp_factor != None:
-                tiedfactor[amp] = amp_factor
-                tiedtoparam[amp] = src_amp
+            return tiedtoparam, tiedfactor
 
-            tiedfactor[vshift] = 1.0
-            tiedtoparam[vshift] = src_vshift
+        # narrow_broad model: all narrow + [OIII] + broad Balmer groups
+        linemodel_broad = create_model(_build_tying_info('narrow_broad'))
 
-            tiedfactor[sigma] = 1.0
-            tiedtoparam[sigma] = src_sigma
-
-
-        # Build the relationship of "tied" parameters. In the 'tied' array, the
-        # non-zero value is the multiplicative factor by which the parameter
-        # represented in the 'tiedtoparam' index should be multiplied.
-
-        n_params = len(self.param_table)
-        tying_info = (
-            np.full(n_params, -1, np.int32), # source parameter for tying
-            np.empty(n_params, np.float64),  # multiplier between source and tied value
-        )
-
-        # Physical doublets and lines in the same ionization species should have
-        # their velocity shifts and line-widths always tied. In addition, set fixed
-        # doublet-ratios here. Note that these constraints must be set on *all*
-        # lines, not just those in range.
-        for line_name, line_isbalmer, line_isbroad, line_params in \
-                self.line_table.iterrows('name', 'isbalmer', 'isbroad', 'params'):
-
-            # broad He + Balmer
-            if line_isbalmer and line_isbroad and line_name != 'halpha_broad':
-                tie_line(tying_info, line_params, 'halpha_broad')
-            # narrow He + Balmer
-            elif line_isbalmer and not line_isbroad and line_name != 'halpha':
-                tie_line(tying_info, line_params, 'halpha')
-            else:
-                match line_name:
-                    case 'mgii_2796':
-                        tie_line(tying_info, line_params, 'mgii_2803')
-                    case 'oii_3726':
-                        tie_line(tying_info, line_params, 'oii_3729')
-                    case 'sii_6731':
-                        tie_line(tying_info, line_params, 'sii_6716')
-                    case 'nev_3346' | 'nev_3426': # should [NeIII] 3869 be tied to [NeV]???
-                        tie_line(tying_info, line_params, 'neiii_3869')
-
-                    case 'nii_5755' | 'oi_6300' | 'siii_6312':
-                        # Tentative! Tie auroral lines to [OIII] 4363 but maybe we shouldn't tie [OI] 6300 here...
-                        tie_line(tying_info, line_params, 'oiii_4363')
-                    case 'oiii_4959':
-                        """
-                        [O3] (4-->2): airwave: 4958.9097 vacwave: 4960.2937 emissivity: 1.172e-21
-                        [O3] (4-->3): airwave: 5006.8417 vacwave: 5008.2383 emissivity: 3.497e-21
-                        https://ui.adsabs.harvard.edu/abs/2007AIPC..895..313D/abstract
-
-                        Note: The theoretical [OIII] 4959,5007 doublet *flux*
-                        ratio is 2.993, so since we fit in velocity space the
-                        constrained amplitude ratio has to be
-                        2.993*4960.295/5008.240=2.9643.
-                        """
-                        tie_line(tying_info, line_params, 'oiii_5007', amp_factor=1./2.9643)
-                    case 'nii_6548':
-                        """
-                        [N2] (4-->2): airwave: 6548.0488 vacwave: 6549.8578 emissivity: 2.02198e-21
-                        [N2] (4-->3): airwave: 6583.4511 vacwave: 6585.2696 emissivity: 5.94901e-21
-                        https://ui.adsabs.harvard.edu/abs/2023AdSpR..71.1219D/abstract
-
-                        Note: The theoretical [NII] 6548,84 doublet *flux*
-                        ratio is 3.049, so since we fit in velocity space the
-                        constrained amplitude ratio has to be
-                        3.049*6549.861/6585.273=3.0326
-                        """
-                        tie_line(tying_info, line_params, 'nii_6584', amp_factor = 1./3.0326)
-                    case 'oii_7330':
-                        """
-                        [O2] (5-->2): airwave: 7318.9185 vacwave: 7320.9350 emissivity: 8.18137e-24
-                        [O2] (4-->2): airwave: 7319.9849 vacwave: 7322.0018 emissivity: 2.40519e-23
-                        [O2] (5-->3): airwave: 7329.6613 vacwave: 7331.6807 emissivity: 1.35614e-23
-                        [O2] (4-->3): airwave: 7330.7308 vacwave: 7332.7506 emissivity: 1.27488e-23
-
-                        This quadruplet ratio is sufficently poorly determined
-                        that we are not going to apply the wavelength
-                        correction used for [OIII] and [NII].
-
-                        """
-                        tie_line(tying_info, line_params, 'oii_7320', amp_factor = 1./1.225)
-                    case 'siii_9069':
-                        tie_line(tying_info, line_params, 'siii_9532')
-                    case 'siliii_1892':
-                        # Tentative! Tie SiIII] 1892 to CIII] 1908 because they're so close in wavelength.
-                        tie_line(tying_info, line_params, 'ciii_1908')
-
-            # Tie all the forbidden and narrow Balmer+helium lines *except
-            # [OIII] 4959,5007* to [NII] 6584 when we have broad lines. The
-            # [OIII] doublet frequently has an outflow component, so fit it
-            # separately. See the discussion at
-            # https://github.com/desihub/fastspecfit/issues/160
-            if separate_oiii_fit:
-                if not line_isbroad and not line_name in { 'nii_6584', 'oiii_4959', 'oiii_5007' }:
-                    tie_line(tying_info, line_params, 'nii_6584')
-            else:
-                if not line_isbroad and line_name != 'oiii_5007':
-                    tie_line(tying_info, line_params, 'oiii_5007')
-
-                ## Tie all forbidden lines to [OIII] 5007; the narrow Balmer and
-                ## helium lines are separately tied together.
-                #if not line_isbroad and not line_isbalmer and line_name != 'oiii_5007'):
-                #    tie_line(tying_info, line_params, 'oiii_5007')
-
-        linemodel_broad = create_model(tying_info)
-
-        # Model 2 - like Model 1, but additionally fix params of all
-        # broad lines.  we inherit tying info from Model 1, which we
-        # will modify below.
-
+        # narrow_only model: forbidden + narrow_balmer groups; broad fixed to zero
+        tiedtoparam_no, tiedfactor_no = _build_tying_info('narrow_only')
         forceFixed = []
-        for line_name, line_isbalmer, line_isbroad, line_params in \
-                self.line_table.iterrows('name', 'isbalmer', 'isbroad', 'params'):
-
-            if line_name == 'halpha_broad':
-                for p in line_params:  # all of amp, vshift, sigma
-                    forceFixed.append(p) # fix all of these
-
-            if line_isbalmer and line_isbroad and line_name != 'halpha_broad':
-                tie_line(tying_info, line_params, 'halpha_broad', amp_factor = 1.0)
-
-            if separate_oiii_fit:
-                # Tie the forbidden lines to [OIII] 5007.
-                if not line_isbalmer and not line_isbroad and line_name != 'oiii_5007':
-                    tie_line(tying_info, line_params, 'oiii_5007')
-
-                # Tie narrow Balmer and helium lines together.
-                if line_isbalmer and not line_isbroad:
-                    if line_name == 'halpha':
-                        tiedtoparam, _ = tying_info
-
-                        _, vshift, sigma = line_params
-                        for p in (vshift, sigma):
-                            # untie the params of this line
-                            tiedtoparam[p] = -1
-                    else:
-                        tie_line(tying_info, line_params, 'halpha')
-
-        linemodel_nobroad = create_model(tying_info, forceFixed)
+        for line_name in self.constraints.profiles['narrow_only'].get('fixed_lines', []):
+            if line_name in self.line_map:
+                for p in self.line_table['params'][self.line_map[line_name]]:
+                    forceFixed.append(p)
+        linemodel_nobroad = create_model((tiedtoparam_no, tiedfactor_no), forceFixed)
 
         return linemodel_broad, linemodel_nobroad
 
@@ -463,24 +462,11 @@ class EMFitTools(object):
         initials = np.empty(len(self.param_table), dtype=np.float64)
         bounds = np.empty((len(self.param_table), 2), dtype=np.float64)
 
-        # a priori initial guesses and bounds
-        minsigma_broad = 1. # 100.
-        minsigma_narrow = 1.
-        minsigma_balmer_broad = 1. # 100.0 # minsigma_narrow
-
-        maxsigma_broad = 1e4
-        maxsigma_narrow = 750.
-        maxsigma_balmer_broad = 1e4
-
-        maxvshift_broad = 2500.
-        maxvshift_narrow = 500.
-        maxvshift_balmer_broad = 2500.
-
         minamp = 0.
         maxamp = +1e5
 
-        for iline, (line_isbalmer, line_isbroad, line_params) in \
-            enumerate(self.line_table.iterrows('isbalmer', 'isbroad', 'params')):
+        for iline, (line_name, line_isbalmer, line_isbroad, line_params) in \
+            enumerate(self.line_table.iterrows('name', 'isbalmer', 'isbroad', 'params')):
 
             amp, vshift, sigma = line_params
 
@@ -488,22 +474,22 @@ class EMFitTools(object):
             initials[amp] = 1.
             bounds[amp] = (minamp, maxamp)
 
+            sigma_min, sigma_max, vshift_max, _, _ = \
+                self.constraints.line_bounds(line_name)
+
             if line_isbroad:
-                if line_isbalmer: # broad He+Balmer lines
+                if line_isbalmer:  # broad He+Balmer lines
                     initials[vshift] = initial_linevshift_balmer_broad
-                    initials[sigma] = initial_linesigma_balmer_broad
-                    bounds[vshift] = (-maxvshift_balmer_broad, +maxvshift_balmer_broad)
-                    bounds[sigma] = (minsigma_balmer_broad, maxsigma_balmer_broad)
-                else: # broad UV/QSO lines (non-Balmer)
+                    initials[sigma]  = initial_linesigma_balmer_broad
+                else:              # broad UV/QSO lines (non-Balmer)
                     initials[vshift] = initial_linevshift_broad
-                    initials[sigma] = initial_linesigma_broad
-                    bounds[vshift] = (-maxvshift_broad, +maxvshift_broad)
-                    bounds[sigma] = (minsigma_broad, maxsigma_broad)
-            else: # narrow He+Balmer lines, and forbidden lines
+                    initials[sigma]  = initial_linesigma_broad
+            else:                  # narrow He+Balmer lines and forbidden lines
                 initials[vshift] = initial_linevshift_narrow
-                initials[sigma] = initial_linesigma_narrow
-                bounds[vshift] = (-maxvshift_narrow, +maxvshift_narrow)
-                bounds[sigma] = (minsigma_narrow, maxsigma_narrow)
+                initials[sigma]  = initial_linesigma_narrow
+
+            bounds[vshift] = (-vshift_max, +vshift_max)
+            bounds[sigma]  = (sigma_min, sigma_max)
 
         # Replace a priori initial values based on the data, with optional local
         # continuum subtraction.
@@ -1517,7 +1503,7 @@ def linefit(EMFit, linemodel, initial_guesses, param_bounds,
 
 
 def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
-                   phot, emline_table, minsnr_balmer_broad=2.5,
+                   phot, emline_table, constraints, minsnr_balmer_broad=2.5,
                    minsigma_balmer_broad=250., continuummodel_monte=None,
                    specflux_monte=None, synthphot=True, broadlinefit=True,
                    debug_plots=False):
@@ -1573,7 +1559,7 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
 
     tall = time.time()
 
-    EMFit = EMFitTools(emline_table, uniqueid=data['uniqueid'],
+    EMFit = EMFitTools(emline_table, constraints, uniqueid=data['uniqueid'],
                        outfile_base=data.get('outfile_base', ''))
 
     redshift = data['redshift']
@@ -1620,7 +1606,7 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
     # get initial guesses for their parameters.  We'll fit both models
     # to the data below and pick the one that fits better.
 
-    linemodel_broad, linemodel_nobroad = EMFit.build_linemodels(separate_oiii_fit=True)
+    linemodel_broad, linemodel_nobroad = EMFit.build_linemodels()
     #EMFit.summarize_linemodel(linemodel_nobroad)
     #EMFit.summarize_linemodel(linemodel_broad)
 
@@ -1670,9 +1656,11 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
                              minsnr_balmer_broad, minsigma_balmer_broad)
 
         if adopt_broad:
-            linemodel_pref, emlineflux_model_pref, chi2_pref = linemodel_broad, emlineflux_model_broad, chi2_broad
+            linemodel_pref, emlineflux_model_pref, chi2_pref, nfree_pref = \
+                linemodel_broad, emlineflux_model_broad, chi2_broad, nfree_broad
         else:
-            linemodel_pref, emlineflux_model_pref, chi2_pref = linemodel_nobroad, emlineflux_model_nobroad, chi2_nobroad
+            linemodel_pref, emlineflux_model_pref, chi2_pref, nfree_pref = \
+                linemodel_nobroad, emlineflux_model_nobroad, chi2_nobroad, nfree_nobroad
     else:
         adopt_broad = False
         if not broadlinefit:
@@ -1680,8 +1668,56 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
         elif not data['balmerbroad']:
             log.info('Skipping broad-line fitting (no broad Balmer lines in the spectral range).')
 
-        linemodel_pref, emlineflux_model_pref, chi2_pref = linemodel_nobroad, emlineflux_model_nobroad, chi2_nobroad
+        linemodel_pref, emlineflux_model_pref, chi2_pref, nfree_pref = \
+            linemodel_nobroad, emlineflux_model_nobroad, chi2_nobroad, nfree_nobroad
         delta_linechi2_balmer, delta_linendof_balmer = 0, np.int32(0)
+
+    # Optional final pass: relax kinematic ties and re-optimise.
+    if constraints.final_pass_enabled and constraints.final_pass_mode != 'none':
+        t0 = time.time()
+        if constraints.final_pass_mode == 'per_line':
+            linemodel_relax = linemodel_pref.copy()
+            for i in range(len(linemodel_relax)):
+                if (not linemodel_relax['fixed'][i]
+                        and linemodel_relax['tiedtoparam'][i] != -1
+                        and EMFit.param_table['type'][i] in
+                            (ParamType.VSHIFT, ParamType.SIGMA)):
+                    linemodel_relax['tiedtoparam'][i] = -1
+                    linemodel_relax['tiedfactor'][i]  = 0.
+                    linemodel_relax['free'][i]        = True
+        elif constraints.final_pass_mode == 'relax_inter_group':
+            raise NotImplementedError("relax_inter_group mode requires a "
+                                      "dedicated profile in the constraint file")
+        else:
+            raise ValueError(f"Unknown final_pass mode: '{constraints.final_pass_mode}'")
+
+        init_relax = (linemodel_pref['value'].value
+                      if constraints.final_pass_warm_start else initial_guesses)
+        emlineflux_model_relax, nfree_relax, chi2_relax = linefit(
+            EMFit, linemodel_relax, init_relax, param_bounds,
+            emlinewave, emlineflux, emlineivar, weights, redshift,
+            resolution_matrix, camerapix)
+
+        adopt_relax = False
+        if constraints.final_pass_adopt_if == 'always':
+            adopt_relax = True
+        elif constraints.final_pass_adopt_if == 'chi2_improves':
+            nbins      = np.sum(emlineivar > 0)
+            ndof_pref  = nbins - nfree_pref
+            ndof_relax = nbins - nfree_relax
+            delta_chi2 = chi2_pref * ndof_pref - chi2_relax * ndof_relax
+            delta_ndof = ndof_pref - ndof_relax
+            adopt_relax = (delta_ndof > 0 and delta_chi2 > delta_ndof)
+
+        if adopt_relax:
+            linemodel_pref        = linemodel_relax
+            emlineflux_model_pref = emlineflux_model_relax
+            chi2_pref             = chi2_relax
+            nfree_pref            = nfree_relax
+        log.debug(fsftime('linefit_final_pass', time.time()-t0,
+                          context=f'targetid={data["uniqueid"]}, '
+                                  f'mode={constraints.final_pass_mode}, '
+                                  f'adopted={adopt_relax}'))
 
     # Residual spectrum with no emission lines
     specflux_nolines = specflux - emlineflux_model_pref

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1718,10 +1718,13 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
                     linemodel_relax['tiedfactor'][i]  = 0.
                     linemodel_relax['free'][i]        = True
         elif constraints.final_pass_mode == 'relax_inter_group':
-            raise NotImplementedError("relax_inter_group mode requires a "
-                                      "dedicated profile in the constraint file")
+            errmsg = "Relax_inter_group mode requires a dedicated profile in the constraint file."
+            log.critical(errmsg)
+            raise NotImplementedError(errmsg)
         else:
-            raise ValueError(f"Unknown final_pass mode: '{constraints.final_pass_mode}'")
+            errmsg = f"Unknown final_pass mode: '{constraints.final_pass_mode}'"
+            log.critical(errmsg)
+            raise ValueError(errmsg)
 
         init_relax = (linemodel_pref['value'].value
                       if constraints.final_pass_warm_start else initial_guesses)
@@ -1746,10 +1749,10 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
             emlineflux_model_pref = emlineflux_model_relax
             chi2_pref             = chi2_relax
             nfree_pref            = nfree_relax
-        log.debug(fsftime('linefit_final_pass', time.time()-t0,
-                          context=f'targetid={data["uniqueid"]}, '
-                                  f'mode={constraints.final_pass_mode}, '
-                                  f'adopted={adopt_relax}'))
+        log.info(fsftime('linefit_final_pass', time.time()-t0,
+                         context=f'targetid={data["uniqueid"]}, '
+                         f'mode={constraints.final_pass_mode}, '
+                         f'adopted={adopt_relax}'))
 
     # Residual spectrum with no emission lines
     specflux_nolines = specflux - emlineflux_model_pref

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -1770,7 +1770,11 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
     # What is relaxed is specified per kinematic group in the constraint file;
     # the adoption decision is a single global chi2 comparison.
     profile_name = 'narrow_broad' if adopt_broad else 'narrow_only'
+
     fp = constraints.final_pass[profile_name]
+    delta_kinechi2 = np.float32(0.) # initialize
+    delta_kinendof = np.int32(0)
+
     if fp['enabled']:
         t0 = time.time()
         linemodel_relax = linemodel_pref.copy()
@@ -1845,9 +1849,9 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
                 nbins      = np.sum(emlineivar > 0)
                 ndof_pref  = nbins - nfree_pref
                 ndof_relax = nbins - nfree_relax
-                delta_chi2 = chi2_pref * ndof_pref - chi2_relax * ndof_relax
-                delta_ndof = ndof_pref - ndof_relax
-                adopt_relax = (delta_ndof > 0 and delta_chi2 > delta_ndof)
+                delta_kinechi2 = chi2_pref * ndof_pref - chi2_relax * ndof_relax
+                delta_kinendof = ndof_pref - ndof_relax
+                adopt_relax = (delta_kinendof > 0 and delta_kinechi2 > delta_kinendof)
 
             if adopt_relax:
                 linemodel_pref        = linemodel_relax
@@ -1856,17 +1860,17 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
                 nfree_pref            = nfree_relax
                 if fp['adopt_if'] == 'chi2_improves':
                     log.info(f'Adopting relaxed kinematic model ({profile_name}): '
-                             f'delta-chi2={delta_chi2:.1f} > delta-ndof={delta_ndof:.0f}')
+                             f'delta-chi2={delta_kinechi2:.1f} > delta-ndof={delta_kinendof:.0f}')
                 else:
                     log.info(f'Adopting relaxed kinematic model ({profile_name}): adopt_if=always')
             else:
                 if fp['adopt_if'] == 'chi2_improves':
-                    if delta_ndof <= 0:
+                    if delta_kinendof <= 0:
                         log.debug(f'Dropping relaxed kinematic model ({profile_name}): '
-                                  f'no additional free parameters (delta-ndof={delta_ndof:.0f})')
+                                  f'no additional free parameters (delta-ndof={delta_kinendof:.0f})')
                     else:
                         log.debug(f'Dropping relaxed kinematic model ({profile_name}): '
-                                  f'delta-chi2={delta_chi2:.1f} < delta-ndof={delta_ndof:.0f}')
+                                  f'delta-chi2={delta_kinechi2:.1f} < delta-ndof={delta_kinendof:.0f}')
             log.debug(fsftime('linefit_final_pass', time.time()-t0,
                               context=f'targetid={data["uniqueid"]}, profile={profile_name}, '
                                       f'nfreed={nfreed}'))
@@ -1940,6 +1944,8 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
     #fastfit['NDOF_LINE'] = ndof_pref
     fastfit['DELTA_LINECHI2'] = delta_linechi2_balmer  # chi2_nobroad - chi2_broad
     fastfit['DELTA_LINENDOF'] = delta_linendof_balmer  # ndof_nobroad - ndof_broad
+    fastfit['DELTA_KINECHI2'] = delta_kinechi2 # chi2_constrained - chi2_relaxed
+    fastfit['DELTA_KINENDOF'] = delta_kinendof # ndof_constrained - ndof_relaxed
 
     # full-fit reduced chi2
     rchi2 = np.sum(oemlineivar * (specflux - (continuummodel + smooth_continuum + emlineflux_model_best))**2)

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -45,7 +45,6 @@ class EmlineConstraints:
         verifies that every line appears exactly once in each profile.
 
     """
-
     _DEFAULT_FILE = os.path.join(os.path.dirname(__file__), 'data',
                                  'emline-constraints.yaml')
 
@@ -97,6 +96,7 @@ class EmlineConstraints:
         ------
         ValueError
             If the line is not found anywhere in the constraint file.
+
         """
         for g in self.global_kinematic_groups:
             if line_name == g['anchor'] or line_name in g.get('members', []):
@@ -541,20 +541,22 @@ class EMFitTools(object):
                 initials[amp_idx] = amp
                 bounds[amp_idx] = np.array([0., mx])
 
-        # Specialized parameters on the MgII, [OII], and [SII] doublet ratios. See
-        # https://github.com/desihub/fastspecfit/issues/39.
+        # Doublet ratio bounds and initial values from the constraint file.
         doublet_bounds = {
-            'mgii_doublet_ratio' : (0.0, 10.0), # MgII 2796/2803
-            'oii_doublet_ratio'  : (0.0,  2.0), # [OII] 3726/3729 # (0.5, 1.5) # (0.66, 1.4)
-            'sii_doublet_ratio'  : (0.0,  2.0), # [SII] 6731/6716 # (0.5, 1.5) # (0.67, 1.2)
+            dr['param_name']: (float(dr['bounds']['min']), float(dr['bounds']['max']))
+            for dr in self.constraints.doublet_ratios
+        }
+        doublet_initials = {
+            dr['param_name']: float(dr['initial'])
+            for dr in self.constraints.doublet_ratios
         }
 
         param_names = self.param_table['name'].value
 
         for iparam in self.doublet_idx:
             param_name = param_names[iparam]
-            bounds[iparam] = doublet_bounds[param_name]
-            initials[iparam] = 1.
+            bounds[iparam]   = doublet_bounds[param_name]
+            initials[iparam] = doublet_initials[param_name]
 
         # Make sure all parameters lie within their respective bounds.
         for iparam, param_name in enumerate(self.param_table['name'].value):

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -75,9 +75,36 @@ class EmlineConstraints:
 
         # named profiles + per-profile final_pass strategy
         self.profiles = raw['profiles']
-        _fp_required = {'enabled', 'mode', 'warm_start', 'adopt_if', 'inherit_in_mc'}
+
+        def _parse_group_fp(g, context):
+            """Parse and validate a kinematic group's final_pass block."""
+            if 'final_pass' not in g:
+                raise ValueError(
+                    f"Kinematic group '{g['name']}' in {context} "
+                    f"is missing required 'final_pass' block.")
+            gfp = g['final_pass']
+            for key in ('free_vshift', 'free_sigma'):
+                if key not in gfp:
+                    raise ValueError(
+                        f"Group '{g['name']}' final_pass in {context} "
+                        f"is missing required key '{key}'.")
+            return {
+                'free_vshift':      bool(gfp['free_vshift']),
+                'free_sigma':       bool(gfp['free_sigma']),
+                'delta_vshift_max': gfp.get('delta_vshift_max'),  # reserved; not yet used
+                'delta_sigma_max':  gfp.get('delta_sigma_max'),   # reserved; not yet used
+            }
+
+        # group_final_pass: keyed by 'global.<name>' or '<profile>.<name>'
+        self.group_final_pass = {}
+        for g in self.global_kinematic_groups:
+            self.group_final_pass[f'global.{g["name"]}'] = _parse_group_fp(g, 'global')
+
+        _fp_required = {'enabled', 'warm_start', 'adopt_if', 'inherit_in_mc'}
         self.final_pass = {}
         for pname, profile in self.profiles.items():
+            for g in profile.get('kinematic_groups', []):
+                self.group_final_pass[f'{pname}.{g["name"]}'] = _parse_group_fp(g, f"profile '{pname}'")
             if 'final_pass' not in profile:
                 raise ValueError(
                     f"Constraint profile '{pname}' is missing required 'final_pass' block.")
@@ -88,7 +115,6 @@ class EmlineConstraints:
                     f"Profile '{pname}' final_pass is missing keys: {sorted(missing_keys)}")
             self.final_pass[pname] = {
                 'enabled':       bool(fp['enabled']),
-                'mode':          str(fp['mode']),
                 'warm_start':    bool(fp['warm_start']),
                 'adopt_if':      str(fp['adopt_if']),
                 'inherit_in_mc': bool(fp['inherit_in_mc']),
@@ -343,7 +369,7 @@ class EMFitTools(object):
             n_params = len(self.param_table)
             isfixed = np.full(n_params, False, dtype=bool)
 
-            tiedtoparam, tiedfactor = tying_info
+            tiedtoparam, tiedfactor, group_name = tying_info
             tied_mask   = (tiedtoparam != -1)
             tied_source = tiedtoparam[tied_mask]
 
@@ -381,10 +407,11 @@ class EMFitTools(object):
 
             # construct the final linemodel
             linemodel = Table({
-                'free': ~isfixed & ~istied,
-                'fixed': isfixed,
+                'free':       ~isfixed & ~istied,
+                'fixed':      isfixed,
                 'tiedtoparam': tiedtoparam.copy(), # we reuse these later
                 'tiedfactor':  tiedfactor.copy(),
+                'group_name':  group_name,
             }, copy=False)
 
             return linemodel
@@ -395,25 +422,32 @@ class EMFitTools(object):
             n_params    = len(self.param_table)
             tiedtoparam = np.full(n_params, -1, np.int32)
             tiedfactor  = np.empty(n_params, np.float64)
+            group_name  = np.full(n_params, '', dtype=object)
 
-            def _tie_kinematics(groups):
+            def _tie_kinematics(groups, prefix):
                 for g in groups:
                     if g['anchor'] not in self.line_map:
                         continue
+                    gname = prefix + g['name']
                     anchor_line = self.line_map[g['anchor']]
                     _, src_vshift, src_sigma = self.line_table['params'][anchor_line]
+                    group_name[src_vshift] = gname
+                    group_name[src_sigma]  = gname
                     for member_name in g.get('members', []):
                         if member_name not in self.line_map:
                             continue
                         member_line = self.line_map[member_name]
                         _, vshift, sigma = self.line_table['params'][member_line]
+                        group_name[vshift] = gname
+                        group_name[sigma]  = gname
                         tiedfactor[vshift]  = 1.0
                         tiedtoparam[vshift] = src_vshift
                         tiedfactor[sigma]   = 1.0
                         tiedtoparam[sigma]  = src_sigma
 
-            _tie_kinematics(self.constraints.global_kinematic_groups)
-            _tie_kinematics(self.constraints.profiles[profile_name].get('kinematic_groups', []))
+            _tie_kinematics(self.constraints.global_kinematic_groups, prefix='global.')
+            _tie_kinematics(self.constraints.profiles[profile_name].get('kinematic_groups', []),
+                            prefix=f'{profile_name}.')
 
             for fc in self.constraints.amplitude_fixed:
                 if fc['line'] not in self.line_map or fc['ref'] not in self.line_map:
@@ -425,19 +459,19 @@ class EMFitTools(object):
                 tiedfactor[amp_line]  = fc['factor']
                 tiedtoparam[amp_line] = amp_ref
 
-            return tiedtoparam, tiedfactor
+            return tiedtoparam, tiedfactor, group_name
 
         # narrow_broad model: all narrow + [OIII] + broad Balmer groups
         linemodel_broad = create_model(_build_tying_info('narrow_broad'))
 
         # narrow_only model: forbidden + narrow_balmer groups; broad fixed to zero
-        tiedtoparam_no, tiedfactor_no = _build_tying_info('narrow_only')
+        tiedtoparam_no, tiedfactor_no, group_name_no = _build_tying_info('narrow_only')
         forceFixed = []
         for line_name in self.constraints.profiles['narrow_only'].get('fixed_lines', []):
             if line_name in self.line_map:
                 for p in self.line_table['params'][self.line_map[line_name]]:
                     forceFixed.append(p)
-        linemodel_nobroad = create_model((tiedtoparam_no, tiedfactor_no), forceFixed)
+        linemodel_nobroad = create_model((tiedtoparam_no, tiedfactor_no, group_name_no), forceFixed)
 
         return linemodel_broad, linemodel_nobroad
 
@@ -1707,69 +1741,71 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
             linemodel_nobroad, emlineflux_model_nobroad, chi2_nobroad, nfree_nobroad
         delta_linechi2_balmer, delta_linendof_balmer = 0, np.int32(0)
 
-    # Optional final pass: relax kinematic ties and re-optimise.
-    # Settings are per-profile: look up based on which model was adopted.
+    # Optional final pass: relax per-group kinematic ties and re-optimise.
+    # What is relaxed is specified per kinematic group in the constraint file;
+    # the adoption decision is a single global chi2 comparison.
     profile_name = 'narrow_broad' if adopt_broad else 'narrow_only'
     fp = constraints.final_pass[profile_name]
-    if fp['enabled'] and fp['mode'] != 'none':
+    if fp['enabled']:
         t0 = time.time()
-        if fp['mode'] == 'per_line':
-            linemodel_relax = linemodel_pref.copy()
-            for i in range(len(linemodel_relax)):
-                if (not linemodel_relax['fixed'][i]
-                        and linemodel_relax['tiedtoparam'][i] != -1
-                        and EMFit.param_table['type'][i] in
-                            (ParamType.VSHIFT, ParamType.SIGMA)):
-                    linemodel_relax['tiedtoparam'][i] = -1
-                    linemodel_relax['tiedfactor'][i]  = 0.
-                    linemodel_relax['free'][i]        = True
-        elif fp['mode'] == 'relax_inter_group':
-            errmsg = "Relax_inter_group mode requires a dedicated profile in the constraint file."
-            log.critical(errmsg)
-            raise NotImplementedError(errmsg)
+        linemodel_relax = linemodel_pref.copy()
+        nfreed = 0
+        for i in range(len(linemodel_relax)):
+            if linemodel_relax['fixed'][i] or linemodel_relax['tiedtoparam'][i] == -1:
+                continue
+            gfp = constraints.group_final_pass.get(linemodel_relax['group_name'][i])
+            if gfp is None:
+                continue
+            param_type = EMFit.param_table['type'][i]
+            if ((param_type == ParamType.VSHIFT and gfp['free_vshift']) or
+                    (param_type == ParamType.SIGMA and gfp['free_sigma'])):
+                linemodel_relax['tiedtoparam'][i] = -1
+                linemodel_relax['tiedfactor'][i]  = 0.
+                linemodel_relax['free'][i]        = True
+                nfreed += 1
+
+        if nfreed == 0:
+            log.debug(f'Final pass ({profile_name}): no parameters freed; skipping.')
         else:
-            errmsg = f"Unknown final_pass mode: '{fp['mode']}'"
-            log.critical(errmsg)
-            raise ValueError(errmsg)
+            init_relax = (linemodel_pref['value'].value
+                          if fp['warm_start'] else initial_guesses)
+            emlineflux_model_relax, nfree_relax, chi2_relax = linefit(
+                EMFit, linemodel_relax, init_relax, param_bounds,
+                emlinewave, emlineflux, emlineivar, weights, redshift,
+                resolution_matrix, camerapix)
 
-        init_relax = (linemodel_pref['value'].value
-                      if fp['warm_start'] else initial_guesses)
-        emlineflux_model_relax, nfree_relax, chi2_relax = linefit(
-            EMFit, linemodel_relax, init_relax, param_bounds,
-            emlinewave, emlineflux, emlineivar, weights, redshift,
-            resolution_matrix, camerapix)
+            adopt_relax = False
+            if fp['adopt_if'] == 'always':
+                adopt_relax = True
+            elif fp['adopt_if'] == 'chi2_improves':
+                nbins      = np.sum(emlineivar > 0)
+                ndof_pref  = nbins - nfree_pref
+                ndof_relax = nbins - nfree_relax
+                delta_chi2 = chi2_pref * ndof_pref - chi2_relax * ndof_relax
+                delta_ndof = ndof_pref - ndof_relax
+                adopt_relax = (delta_ndof > 0 and delta_chi2 > delta_ndof)
 
-        adopt_relax = False
-        if fp['adopt_if'] == 'always':
-            adopt_relax = True
-        elif fp['adopt_if'] == 'chi2_improves':
-            nbins      = np.sum(emlineivar > 0)
-            ndof_pref  = nbins - nfree_pref
-            ndof_relax = nbins - nfree_relax
-            delta_chi2 = chi2_pref * ndof_pref - chi2_relax * ndof_relax
-            delta_ndof = ndof_pref - ndof_relax
-            adopt_relax = (delta_ndof > 0 and delta_chi2 > delta_ndof)
-
-        if adopt_relax:
-            linemodel_pref        = linemodel_relax
-            emlineflux_model_pref = emlineflux_model_relax
-            chi2_pref             = chi2_relax
-            nfree_pref            = nfree_relax
-            if fp['adopt_if'] == 'chi2_improves':
-                log.info(f'Adopting relaxed kinematic model ({fp["mode"]}): '
-                         f'delta-chi2={delta_chi2:.1f} > delta-ndof={delta_ndof:.0f}')
-            else:
-                log.info(f'Adopting relaxed kinematic model ({fp["mode"]}): adopt_if=always')
-        else:
-            if fp['adopt_if'] == 'chi2_improves':
-                if delta_ndof <= 0:
-                    log.debug(f'Dropping relaxed kinematic model ({fp["mode"]}): '
-                              f'no additional free parameters (delta-ndof={delta_ndof:.0f})')
+            if adopt_relax:
+                linemodel_pref        = linemodel_relax
+                emlineflux_model_pref = emlineflux_model_relax
+                chi2_pref             = chi2_relax
+                nfree_pref            = nfree_relax
+                if fp['adopt_if'] == 'chi2_improves':
+                    log.info(f'Adopting relaxed kinematic model ({profile_name}): '
+                             f'delta-chi2={delta_chi2:.1f} > delta-ndof={delta_ndof:.0f}')
                 else:
-                    log.debug(f'Dropping relaxed kinematic model ({fp["mode"]}): '
-                              f'delta-chi2={delta_chi2:.1f} < delta-ndof={delta_ndof:.0f}')
-        log.debug(fsftime('linefit_final_pass', time.time()-t0,
-                          context=f'targetid={data["uniqueid"]}, mode={fp["mode"]}'))
+                    log.info(f'Adopting relaxed kinematic model ({profile_name}): adopt_if=always')
+            else:
+                if fp['adopt_if'] == 'chi2_improves':
+                    if delta_ndof <= 0:
+                        log.debug(f'Dropping relaxed kinematic model ({profile_name}): '
+                                  f'no additional free parameters (delta-ndof={delta_ndof:.0f})')
+                    else:
+                        log.debug(f'Dropping relaxed kinematic model ({profile_name}): '
+                                  f'delta-chi2={delta_chi2:.1f} < delta-ndof={delta_ndof:.0f}')
+            log.debug(fsftime('linefit_final_pass', time.time()-t0,
+                              context=f'targetid={data["uniqueid"]}, profile={profile_name}, '
+                                      f'nfreed={nfreed}'))
 
     # Residual spectrum with no emission lines
     specflux_nolines = specflux - emlineflux_model_pref

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -45,13 +45,18 @@ class EmlineConstraints:
         verifies that every line appears exactly once in each profile.
 
     """
-    _DEFAULT_FILE = os.path.join(os.path.dirname(__file__), 'data',
-                                 'emline-constraints.yaml')
-
     def __init__(self, constraints_file=None, line_table=None):
         import yaml
+        from importlib import resources
 
-        self.file = constraints_file or self._DEFAULT_FILE
+        if constraints_file is None:
+            constraints_file = str(
+                resources.files('fastspecfit').joinpath('data/emline-constraints.yaml'))
+        self.file = constraints_file
+
+        if not os.path.isfile(self.file):
+            raise FileNotFoundError(
+                f'Emission-line constraint file {self.file} does not exist.')
         with open(self.file) as fh:
             raw = yaml.safe_load(fh)
 
@@ -81,6 +86,7 @@ class EmlineConstraints:
 
         if line_table is not None:
             self._check_consistency(line_table)
+
 
     def line_bounds(self, line_name):
         """Return ``(sigma_min, sigma_max, vshift_max, sigma_init, vshift_init)`` in km/s.
@@ -117,11 +123,13 @@ class EmlineConstraints:
         raise ValueError(
             f"Line '{line_name}' not found in constraint file '{self.file}'")
 
+
     @staticmethod
     def _unpack_bounds(g):
         sb, vb, ig = g['bounds']['sigma'], g['bounds']['vshift'], g['initial']
         return (float(sb['min']), float(sb['max']), float(vb['max']),
                 float(ig['sigma']), float(ig['vshift']))
+
 
     def _check_consistency(self, line_table):
         emline_names = set(line_table['name'])
@@ -158,13 +166,15 @@ class EMFitTools(object):
     ----------
     emline_table : :class:`astropy.table.Table`
         Table of emission lines to fit.
+    constraints : :class:`EmlineConstraints`
+        Parsed kinematic constraint file providing kinematic groups,
+        amplitude constraints, doublet ratio bounds, and fitting strategy.
     uniqueid : str or None, optional
         Unique identifier for the current object, used in log messages.
     stronglines : bool, optional
         If ``True``, restrict to strong lines only. Defaults to ``False``.
 
     """
-
     def __init__(self, emline_table, constraints, uniqueid=None, outfile_base='',
                  stronglines=False):
 
@@ -1545,6 +1555,9 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
         Photometry object providing filter curves for synthetic photometry.
     emline_table : :class:`astropy.table.Table`
         Table of emission lines to fit.
+    constraints : :class:`EmlineConstraints`
+        Parsed kinematic constraint file; controls kinematic groups,
+        amplitude constraints, and optional final relaxation pass.
     minsnr_balmer_broad : float, optional
         Minimum S/N required to adopt the broad Balmer component.
         Defaults to 2.5.

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -36,6 +36,7 @@ def make_init_sc_args(args, fastphot=False, fitstack=False):
     """
     return {
         'emlines_file':      getattr(args, 'emlinesfile', None),
+        'constraints_file':  getattr(args, 'constraintsfile', None),
         'fphotofile':        getattr(args, 'fphotofile', None),
         'fastphot':          fastphot,
         'fitstack':          fitstack,
@@ -100,6 +101,7 @@ def parse(options=None, rank=0):
     parser.add_argument('--fphotodir', type=str, default=None, help='Top-level location of the source photometry.')
     parser.add_argument('--fphotofile', type=str, default=None, help='Photometric information file.')
     parser.add_argument('--emlinesfile', type=str, default=None, help='Emission line parameter file.')
+    parser.add_argument('--constraintsfile', type=str, default=None, help='Emission-line kinematic constraint YAML file.')
     parser.add_argument('--redux_dir', type=str, default=None, help='Optional full path $DESI_SPECTRO_REDUX.')
     parser.add_argument('--specproddir', type=str, default=None, help='Optional directory name for the spectroscopic production.')
     parser.add_argument('--uncertainty-floor', type=float, default=0.01, help='Minimum fractional uncertainty to add in quadrature to the formal inverse variance spectrum.')
@@ -225,7 +227,8 @@ def fastspec_one(iobj, data, meta, fastfit_dtype, specphot_dtype, broadlinefit=T
         emmodel = None
     else:
         emmodel = emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
-                                 phot, emline_table, broadlinefit=broadlinefit,
+                                 phot, emline_table, sc_data.constraints,
+                                 broadlinefit=broadlinefit,
                                  minsnr_balmer_broad=minsnr_balmer_broad,
                                  debug_plots=debug_plots, specflux_monte=specflux_monte,
                                  continuummodel_monte=continuummodel_monte)
@@ -475,7 +478,8 @@ def fastspec(fastphot=False, fitstack=False, args=None, comm=None, verbose=False
             outfile=args.outfile, specprod=Spec.specprod, coadd_type=Spec.coadd_type,
             fphotofile=sc_data.photometry.fphotofile,
             template_file=sc_data.templates.file,
-            emlinesfile=sc_data.emlines.file, fastphot=fastphot,
+            emlinesfile=sc_data.emlines.file,
+            constraintsfile=sc_data.constraints.file, fastphot=fastphot,
             inputz=input_redshifts is not None,
             nmonte=args.nmonte, vdisp_nominal=args.vdisp_nominal,
             vdisp_bounds=args.vdisp_bounds,

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -297,6 +297,11 @@ def fastspec(fastphot=False, fitstack=False, args=None, comm=None, verbose=False
     if verbose:
         args.verbose = True
 
+    # --debug-plots implies --verbose: diagnostic plots are only useful
+    # alongside debug-level log output.
+    if getattr(args, 'debug_plots', False):
+        args.verbose = True
+
     targetids = None
     input_redshifts = None
     input_seeds = None

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -2053,6 +2053,8 @@ def get_output_dtype(specprod, phot, linetable, ncoeff, cameras=['B', 'R', 'Z'],
             #add_field('DOF_BROAD', dtype='i8')
             add_field('DELTA_LINECHI2', dtype='f4') # delta-reduced chi2 with and without broad line-emission
             add_field('DELTA_LINENDOF', dtype=np.int32)
+            add_field('DELTA_KINECHI2', dtype='f4') # delta-reduced chi2 with and without final-pass optimization
+            add_field('DELTA_KINENDOF', dtype=np.int32)
 
             # special columns for the fitted doublets
             add_field('MGII_DOUBLET_RATIO', dtype='f4')

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -243,7 +243,7 @@ def one_spectrum(specdata, meta, uncertainty_floor=0.01, RV=3.1,
         specdata['camerapix'][:, 1] = c_ends
 
         # use the coadded spectrum to build a robust emission-line mask
-        LM = LineMasker(sc_data.emlines.table)
+        LM = LineMasker(sc_data.emlines.table, sc_data.constraints)
         pix = LM.build_linemask(
             specdata['coadd_wave'], specdata['coadd_flux'],
             specdata['coadd_ivar'], specdata['coadd_res'],
@@ -397,7 +397,7 @@ def one_stacked_spectrum(specdata, meta, synthphot=True, debug_plots=False):
     specdata['camerapix'][:, 0] = c_starts
     specdata['camerapix'][:, 1] = c_ends
 
-    LM = LineMasker(sc_data.emlines.table)
+    LM = LineMasker(sc_data.emlines.table, sc_data.constraints)
     pix = LM.build_linemask(
         specdata['coadd_wave'], specdata['coadd_flux'],
         specdata['coadd_ivar'], specdata['coadd_res'],

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -1554,7 +1554,8 @@ def read_fastspecfit(fastfitfile, rows=None, metadata_columns=None, specphot_col
 
 def write_fastspecfit(meta, specphot, fastfit, modelspectra=None, outfile=None,
                       specprod=None, coadd_type=None, fphotofile=None,
-                      template_file=None, emlinesfile=None, fastphot=False,
+                      template_file=None, emlinesfile=None, constraintsfile=None,
+                      fastphot=False,
                       inputz=False, inputseeds=None, nmonte=50, vdisp_nominal=VDISP_NOMINAL,
                       vdisp_bounds=VDISP_BOUNDS, seed=1, uncertainty_floor=0.01,
                       minsnr_balmer_broad=2.5, nside=None, no_smooth_continuum=False,
@@ -1615,6 +1616,8 @@ def write_fastspecfit(meta, specphot, fastfit, modelspectra=None, outfile=None,
         setdep(primhdr, 'FTEMPLATES_FILE', os.path.basename(template_file))
     if emlinesfile:
         setdep(primhdr, 'EMLINES_FILE', str(emlinesfile))
+    if constraintsfile:
+        setdep(primhdr, 'CONSTRAINTS_FILE', str(constraintsfile))
 
     meta.meta['EXTNAME'] = 'METADATA'
     specphot.meta['EXTNAME'] = 'SPECPHOT'

--- a/py/fastspecfit/linemasker.py
+++ b/py/fastspecfit/linemasker.py
@@ -494,7 +494,8 @@ class LineMasker(object):
                                                   param_bounds, wave,
                                                   flux, weights, redshift,
                                                   resolution_matrix, camerapix,
-                                                  continuum_patches=continuum_patches)
+                                                  continuum_patches=continuum_patches,
+                                                  ftol=1e-3, xtol=1e-5)
 
                 # Update the initial guesses as well as linesigmas and
                 # linevshifts (for linepix_and_contpix, at the top of the

--- a/py/fastspecfit/linemasker.py
+++ b/py/fastspecfit/linemasker.py
@@ -20,6 +20,9 @@ class LineMasker(object):
     ----------
     emline_table : :class:`astropy.table.Table`
         Emission line table.
+    constraints : :class:`fastspecfit.emlines.EmlineConstraints`
+        Parsed kinematic constraint file; passed to :class:`~fastspecfit.emlines.EMFitTools`
+        for the preliminary patch-fitting step.
 
     """
     def __init__(self, emline_table, constraints):

--- a/py/fastspecfit/linemasker.py
+++ b/py/fastspecfit/linemasker.py
@@ -22,8 +22,9 @@ class LineMasker(object):
         Emission line table.
 
     """
-    def __init__(self, emline_table):
+    def __init__(self, emline_table, constraints):
         self.emline_table = emline_table
+        self.constraints  = constraints
 
 
     @staticmethod
@@ -551,13 +552,15 @@ class LineMasker(object):
                     maxsnr_broad = 0.
 
             if np.any(isNarrow):
-                linesigma_narrow = np.atleast_1d(linesigmas[isNarrow])[0]
+                # Use max across narrow groups: with separate forbidden/Balmer
+                # anchors the fitted sigmas can differ; max is conservative for masking.
+                linesigma_narrow = np.max(linesigmas[isNarrow])
                 linevshift_narrow = np.atleast_1d(linevshifts[isNarrow])[0]
                 maxsnr_narrow = np.max(linesnrs[isNarrow])
             else:
                 isNarrow = EMFit.isNarrow * Ifree
                 if np.any(isNarrow):
-                    linesigma_narrow = np.atleast_1d(linesigmas[isNarrow])[0]
+                    linesigma_narrow = np.max(linesigmas[isNarrow])
                     linevshift_narrow = np.atleast_1d(linevshifts[isNarrow])[0]
                     maxsnr_narrow = np.max(linesnrs[isNarrow])
                 else:
@@ -705,11 +708,12 @@ class LineMasker(object):
         camerapix = np.array([[0, len(wave)]]) # one camera
 
         # Read just the strong lines and determine which lines are in range of the camera.
-        EMFit = EMFitTools(emline_table=self.emline_table, uniqueid=uniqueid, stronglines=True)
+        EMFit = EMFitTools(emline_table=self.emline_table, constraints=self.constraints,
+                           uniqueid=uniqueid, stronglines=True)
         EMFit.compute_inrange_lines(redshift, wavelims=(np.min(wave), np.max(wave)))
 
         # Build the narrow and narrow+broad emission-line models.
-        linemodel_broad, linemodel_nobroad = EMFit.build_linemodels(separate_oiii_fit=False)
+        linemodel_broad, linemodel_nobroad = EMFit.build_linemodels()
 
         # ToDo: are there ever *no* "strong" lines in range?
         linetable = EMFit.line_table
@@ -784,7 +788,8 @@ class LineMasker(object):
 
         # Build the final pixel mask for *all* lines using our current best
         # knowledge of the broad Balmer lines....(comment continued below)
-        EMFit = EMFitTools(emline_table=self.emline_table, uniqueid=uniqueid, stronglines=False)
+        EMFit = EMFitTools(emline_table=self.emline_table, constraints=self.constraints,
+                           uniqueid=uniqueid, stronglines=False)
         EMFit.compute_inrange_lines(redshift, wavelims=(np.min(wave), np.max(wave)))
 
         linesigmas = np.zeros(len(EMFit.line_table))

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -965,7 +965,7 @@ def qa_fastspec(data, templates, metadata, specphot, fastspec=None,
     CTools = ContinuumTools(data, templates, phot, igm, fastphot=fastphot,
                             fluxnorm=1. if fitstack else FLUXNORM)
     if not fastphot:
-        EMFit = EMFitTools(emline_table=sc_data.emlines.table)
+        EMFit = EMFitTools(emline_table=sc_data.emlines.table, constraints=sc_data.constraints)
 
     filters = phot.synth_filters[metadata['PHOTSYS']]
     allfilters = phot.filters[metadata['PHOTSYS']]

--- a/py/fastspecfit/singlecopy.py
+++ b/py/fastspecfit/singlecopy.py
@@ -26,6 +26,7 @@ class Singletons(object):
 
     def initialize(self,
                    emlines_file=None,
+                   constraints_file=None,
                    fphotofile=None,
                    fastphot=False,
                    vdisp_nominal=VDISP_NOMINAL,
@@ -75,8 +76,8 @@ class Singletons(object):
         if log_verbose:
             log.setLevel(DEBUG)
 
-        key = (emlines_file, fphotofile, fastphot, fitstack, ignore_photometry,
-               template_file, template_version, template_imf,
+        key = (emlines_file, constraints_file, fphotofile, fastphot, fitstack,
+               ignore_photometry, template_file, template_version, template_imf,
                vdisp_nominal, tuple(vdisp_bounds) if vdisp_bounds is not None else None)
         if getattr(self, '_init_key', None) == key:
             return
@@ -96,6 +97,11 @@ class Singletons(object):
         # emission line table
         self.emlines = LineTable(emlines_file)
         log.debug(f'Cached emission-line table {self.emlines.file}')
+
+        # kinematic constraint file (validated against emlines at startup)
+        from fastspecfit.emlines import EmlineConstraints
+        self.constraints = EmlineConstraints(constraints_file, self.emlines.table)
+        log.debug(f'Cached emission-line constraints {self.constraints.file}')
 
         # photometry
         self.photometry = Photometry(fphotofile, fitstack,

--- a/py/fastspecfit/singlecopy.py
+++ b/py/fastspecfit/singlecopy.py
@@ -45,6 +45,10 @@ class Singletons(object):
         emlines_file : :class:`str` or None, optional
             Path to the emission-line parameter file; uses the bundled
             default when ``None``.
+        constraints_file : :class:`str` or None, optional
+            Path to the emission-line kinematic constraint YAML file; uses
+            the bundled default when ``None``. A consistency check against
+            ``emlines_file`` is run at startup.
         fphotofile : :class:`str` or None, optional
             Path to the photometric configuration YAML file; uses the
             bundled DR9 default when ``None``.

--- a/py/fastspecfit/test/test_emline_constraints.py
+++ b/py/fastspecfit/test/test_emline_constraints.py
@@ -1,0 +1,301 @@
+"""
+fastspecfit.test.test_emline_constraints
+=========================================
+Unit tests for EmlineConstraints and its integration with EMFitTools.
+Tests cover file loading, consistency validation, line_bounds correctness,
+amplitude constraint completeness, and EMFitTools wiring.  Fitting results
+are not tested here.
+"""
+import os
+import numpy as np
+import pytest
+
+
+# ── shared fixtures ───────────────────────────────────────────────────────────
+
+@pytest.fixture(scope='module')
+def ec():
+    from fastspecfit.emlines import EmlineConstraints
+    return EmlineConstraints()
+
+
+@pytest.fixture(scope='module')
+def line_table():
+    from fastspecfit.linetable import LineTable
+    return LineTable().table
+
+
+@pytest.fixture(scope='module')
+def emfit(line_table, ec):
+    from fastspecfit.emlines import EMFitTools
+    return EMFitTools(line_table, ec)
+
+
+# ── Group 1: loading and error handling ──────────────────────────────────────
+
+class TestLoading:
+
+    def test_default_file_exists(self, ec):
+        assert os.path.isfile(ec.file)
+
+    def test_default_path_via_importlib(self, ec):
+        # The path must be resolved through importlib.resources (same as LineTable),
+        # so it should contain the package name in its path.
+        assert 'fastspecfit' in ec.file
+
+    def test_explicit_path_roundtrip(self, tmp_path):
+        import shutil
+        from fastspecfit.emlines import EmlineConstraints
+        src = EmlineConstraints().file
+        dest = str(tmp_path / 'constraints_copy.yaml')
+        shutil.copy(src, dest)
+        ec2 = EmlineConstraints(constraints_file=dest)
+        assert ec2.file == dest
+        assert set(ec2.profiles.keys()) == {'narrow_only', 'narrow_broad'}
+
+    def test_missing_file_raises(self):
+        from fastspecfit.emlines import EmlineConstraints
+        with pytest.raises(FileNotFoundError, match='does not exist'):
+            EmlineConstraints(constraints_file='/nonexistent/path/constraints.yaml')
+
+    def test_profiles_present(self, ec):
+        assert 'narrow_only' in ec.profiles
+        assert 'narrow_broad' in ec.profiles
+
+    def test_fitting_strategy_defaults(self, ec):
+        assert ec.final_pass_enabled is False
+        assert ec.final_pass_mode == 'per_line'
+        assert ec.final_pass_warm_start is True
+        assert ec.final_pass_adopt_if == 'chi2_improves'
+        assert ec.mc_inherit_final_pass is True
+
+
+# ── Group 2: consistency check ────────────────────────────────────────────────
+
+class TestConsistencyCheck:
+
+    def test_bundled_files_pass(self, line_table):
+        from fastspecfit.emlines import EmlineConstraints
+        EmlineConstraints(line_table=line_table)   # must not raise
+
+    def test_missing_line_raises(self, line_table, tmp_path):
+        from astropy.table import vstack, Table
+        from fastspecfit.emlines import EmlineConstraints
+
+        fake_row = Table(line_table[:1])
+        fake_row['name'] = 'fake_line_9999'   # ≤14 chars to fit the fixed-width column
+        augmented = vstack([line_table, fake_row])
+
+        with pytest.raises(ValueError, match='missing'):
+            EmlineConstraints(line_table=augmented)
+
+    def test_extra_yaml_line_raises(self, line_table, tmp_path):
+        import yaml
+        from fastspecfit.emlines import EmlineConstraints
+
+        with open(EmlineConstraints().file) as fh:
+            raw = yaml.safe_load(fh)
+
+        # Inject a line name that does not exist in emlines.ecsv.
+        raw['profiles']['narrow_only'].setdefault('free_lines', [])
+        raw['profiles']['narrow_only']['free_lines'].append('nonexistent_line_xyz')
+
+        bad_yaml = tmp_path / 'bad_constraints.yaml'
+        with open(bad_yaml, 'w') as fh:
+            yaml.dump(raw, fh)
+
+        with pytest.raises(ValueError, match='references'):
+            EmlineConstraints(constraints_file=str(bad_yaml), line_table=line_table)
+
+
+# ── Group 3: line_bounds ──────────────────────────────────────────────────────
+
+class TestLineBounds:
+
+    def test_narrow_forbidden_anchor(self, ec):
+        # oiii_5007 is the anchor of the forbidden group in narrow_only.
+        sigma_min, sigma_max, vshift_max, sigma_init, vshift_init = \
+            ec.line_bounds('oiii_5007')
+        assert sigma_min >= 0.
+        assert 0. < sigma_max <= 1000.
+        assert vshift_max > 0.
+
+    def test_narrow_balmer_member(self, ec):
+        sigma_min, sigma_max, vshift_max, _, _ = ec.line_bounds('hbeta')
+        assert 0. < sigma_max <= 1000.
+        assert vshift_max <= 1000.
+
+    def test_broad_balmer_line(self, ec):
+        sigma_min, sigma_max, vshift_max, _, _ = ec.line_bounds('hbeta_broad')
+        assert sigma_max > 1000.    # broad Balmer group allows much wider sigma
+        assert vshift_max >= 2000.
+
+    def test_uv_free_line(self, ec):
+        # lyalpha is in global.free_lines and gets global default bounds.
+        sigma_min, sigma_max, vshift_max, _, _ = ec.line_bounds('lyalpha')
+        assert sigma_max > 1000.
+        assert vshift_max >= 2000.
+
+    def test_global_micro_group_line(self, ec):
+        # siliii_1892 is a member of the global ciii_aliii kinematic pair.
+        sigma_min, sigma_max, vshift_max, _, _ = ec.line_bounds('siliii_1892')
+        assert sigma_max > 0.
+
+    def test_fixed_in_one_profile_gets_real_bounds(self, ec):
+        """Regression: hgamma_broad is in narrow_only.fixed_lines but belongs to
+        the broad_balmer kinematic group in narrow_broad.  line_bounds must
+        return the non-zero bounds from the kinematic group, not zeros."""
+        sigma_min, sigma_max, vshift_max, _, _ = ec.line_bounds('hgamma_broad')
+        assert sigma_max > 0., \
+            'Expected non-zero sigma_max; got zeros because fixed_lines was checked first'
+
+    def test_all_bounds_are_floats(self, ec, line_table):
+        """Every line in emlines.ecsv must return float-typed bounds (not str)."""
+        for name in line_table['name']:
+            bounds = ec.line_bounds(name)
+            for val in bounds:
+                assert isinstance(val, float), \
+                    f"line '{name}': expected float bound, got {type(val).__name__} ({val!r})"
+
+    def test_all_sigma_bounds_ordered(self, ec, line_table):
+        """sigma_min <= sigma_max for every line that is not purely fixed."""
+        for name in line_table['name']:
+            sigma_min, sigma_max, *_ = ec.line_bounds(name)
+            assert sigma_min <= sigma_max, \
+                f"line '{name}': sigma_min={sigma_min} > sigma_max={sigma_max}"
+
+    def test_unknown_line_raises(self, ec):
+        with pytest.raises(ValueError, match='not found'):
+            ec.line_bounds('completely_unknown_line_zz99')
+
+
+# ── Group 4: doublet and amplitude constraints ────────────────────────────────
+
+class TestAmplitudeConstraints:
+
+    def test_doublet_ratios_all_present(self, ec):
+        names = {dr['param_name'] for dr in ec.doublet_ratios}
+        assert 'oii_doublet_ratio'  in names
+        assert 'sii_doublet_ratio'  in names
+        assert 'mgii_doublet_ratio' in names
+
+    def test_doublet_ratio_bounds_are_floats(self, ec):
+        for dr in ec.doublet_ratios:
+            lo = float(dr['bounds']['min'])
+            hi = float(dr['bounds']['max'])
+            assert isinstance(lo, float)
+            assert isinstance(hi, float)
+            assert lo < hi, f"{dr['param_name']}: min >= max"
+
+    def test_doublet_ratio_initial_within_bounds(self, ec):
+        for dr in ec.doublet_ratios:
+            lo  = float(dr['bounds']['min'])
+            hi  = float(dr['bounds']['max'])
+            ini = float(dr['initial'])
+            assert lo <= ini <= hi, \
+                f"{dr['param_name']}: initial {ini} outside [{lo}, {hi}]"
+
+    def test_amplitude_fixed_all_present(self, ec):
+        lines = {fc['line'] for fc in ec.amplitude_fixed}
+        assert 'nii_6548'  in lines
+        assert 'oiii_4959' in lines
+        assert 'oii_7330'  in lines
+
+    def test_amplitude_fixed_factors_correct(self, ec):
+        # Tolerance of 1e-3 catches gross errors while allowing for YAML
+        # floating-point representation (factors are ~0.3–0.8).
+        factors = {fc['line']: float(fc['factor']) for fc in ec.amplitude_fixed}
+        assert abs(factors['nii_6548']  - 1. / 3.0326) < 1e-3
+        assert abs(factors['oiii_4959'] - 1. / 2.9643) < 1e-3
+        assert abs(factors['oii_7330']  - 1. / 1.225)  < 1e-3
+
+
+# ── Group 5: EMFitTools wiring ────────────────────────────────────────────────
+
+class TestEMFitToolsIntegration:
+
+    def test_doublet_idx_count_matches_constraints(self, emfit, ec):
+        assert len(emfit.doublet_idx) == len(ec.doublet_ratios)
+
+    def test_doublet_param_names_match_constraints(self, emfit, ec):
+        expected = {dr['param_name'] for dr in ec.doublet_ratios}
+        actual   = set(emfit.param_table['name'][emfit.doublet_idx])
+        assert actual == expected
+
+    def test_no_bound_violations_after_initial_guesses(self, emfit):
+        """_initial_guesses_and_bounds must produce no out-of-bounds initials.
+
+        Regression: hgamma_broad_sigma had initial=1000 but bound=(0, 0).
+        """
+        dummy_linepix = {}
+        dummy_flux    = np.ones(1000)
+        initials, bounds = emfit._initial_guesses_and_bounds(
+            dummy_linepix, dummy_flux)
+
+        violations = []
+        for i, (iv, (lb, ub)) in enumerate(zip(initials, bounds)):
+            if lb == ub == 0.:
+                continue   # truly fixed parameter; optimizer never sees it
+            if iv < lb or iv > ub:
+                violations.append(
+                    (emfit.param_table['name'][i], iv, lb, ub))
+
+        assert violations == [], \
+            'Initial values outside bounds:\n' + '\n'.join(
+                f'  {n}: {iv:.4g} not in [{lb:.4g}, {ub:.4g}]'
+                for n, iv, lb, ub in violations)
+
+    def test_build_linemodels_returns_two_tables(self, emfit):
+        emfit.compute_inrange_lines(redshift=0.1)
+        broad, nobroad = emfit.build_linemodels()
+        assert set(broad.colnames)   >= {'free', 'fixed', 'tiedtoparam', 'tiedfactor'}
+        assert set(nobroad.colnames) >= {'free', 'fixed', 'tiedtoparam', 'tiedfactor'}
+        assert len(broad) == len(nobroad) == len(emfit.param_table)
+
+    def test_nobroad_broad_lines_are_fixed(self, emfit):
+        """narrow_only profile: broad Balmer lines must be fixed in linemodel_nobroad."""
+        emfit.compute_inrange_lines(redshift=0.1)
+        _, nobroad = emfit.build_linemodels()
+        for line_name in ('halpha_broad', 'hbeta_broad', 'hgamma_broad'):
+            if line_name not in emfit.line_map:
+                continue
+            for p in emfit.line_table['params'][emfit.line_map[line_name]]:
+                assert nobroad['fixed'][p], \
+                    f'{line_name} param {p} should be fixed in linemodel_nobroad'
+
+    def test_broad_broad_lines_are_free(self, emfit):
+        """narrow_broad profile: broad Balmer anchor must not be fixed in linemodel_broad."""
+        emfit.compute_inrange_lines(redshift=0.1)
+        broad, _ = emfit.build_linemodels()
+        anchor = 'halpha_broad'
+        if anchor in emfit.line_map:
+            amp, vshift, sigma = emfit.line_table['params'][emfit.line_map[anchor]]
+            # Amplitude may still be fixed if the line is out of range,
+            # but vshift and sigma should be free when in range.
+            if emfit.line_in_range[emfit.line_map[anchor]]:
+                assert broad['free'][vshift] or not broad['fixed'][vshift]
+                assert broad['free'][sigma]  or not broad['fixed'][sigma]
+
+
+# ── Group 6: singletons wiring ────────────────────────────────────────────────
+
+class TestSingletonsWiring:
+
+    def test_constraints_populated(self, templates):
+        from fastspecfit.singlecopy import sc_data
+        from fastspecfit.emlines import EmlineConstraints
+        sc_data.initialize(template_file=templates)
+        assert isinstance(sc_data.constraints, EmlineConstraints)
+        assert os.path.isfile(sc_data.constraints.file)
+
+    def test_custom_constraints_file(self, templates, tmp_path):
+        import shutil
+        from fastspecfit.singlecopy import sc_data
+        from fastspecfit.emlines import EmlineConstraints
+        src  = EmlineConstraints().file
+        dest = str(tmp_path / 'custom_constraints.yaml')
+        shutil.copy(src, dest)
+        sc_data.initialize(template_file=templates, constraints_file=dest)
+        assert sc_data.constraints.file == dest
+        # Restore default for subsequent tests.
+        sc_data.initialize(template_file=templates)

--- a/py/fastspecfit/test/test_emline_constraints.py
+++ b/py/fastspecfit/test/test_emline_constraints.py
@@ -63,7 +63,7 @@ class TestLoading:
         assert 'narrow_broad' in ec.profiles
 
     def test_fitting_strategy_defaults(self, ec):
-        assert ec.final_pass_enabled is False
+        assert ec.final_pass_enabled is True
         assert ec.final_pass_mode == 'per_line'
         assert ec.final_pass_warm_start is True
         assert ec.final_pass_adopt_if == 'chi2_improves'

--- a/py/fastspecfit/test/test_emline_constraints.py
+++ b/py/fastspecfit/test/test_emline_constraints.py
@@ -65,16 +65,39 @@ class TestLoading:
     def test_fitting_strategy_per_profile(self, ec):
         assert set(ec.final_pass.keys()) == {'narrow_only', 'narrow_broad'}
 
-        fp_no = ec.final_pass['narrow_only']
-        assert fp_no['enabled']       is True
-        assert fp_no['mode']          == 'per_line'
-        assert fp_no['warm_start']    is True
-        assert fp_no['adopt_if']      == 'chi2_improves'
-        assert fp_no['inherit_in_mc'] is True
+        for pname in ('narrow_only', 'narrow_broad'):
+            fp = ec.final_pass[pname]
+            assert fp['enabled']       is True
+            assert fp['warm_start']    is True
+            assert fp['adopt_if']      == 'chi2_improves'
+            assert fp['inherit_in_mc'] is True
+            assert 'mode' not in fp
 
-        fp_nb = ec.final_pass['narrow_broad']
-        assert fp_nb['enabled']       is False
-        assert fp_nb['inherit_in_mc'] is True
+    def test_group_final_pass(self, ec):
+        gfp = ec.group_final_pass
+
+        # narrow_only: both groups release vshift and sigma
+        assert gfp['narrow_only.forbidden']['free_vshift']   is True
+        assert gfp['narrow_only.forbidden']['free_sigma']    is True
+        assert gfp['narrow_only.narrow_balmer']['free_vshift'] is True
+        assert gfp['narrow_only.narrow_balmer']['free_sigma']  is True
+
+        # narrow_broad: narrow_all frees vshift only
+        assert gfp['narrow_broad.narrow_all']['free_vshift']  is True
+        assert gfp['narrow_broad.narrow_all']['free_sigma']   is False
+        # oiii_doublet and broad_balmer stay fully tied
+        assert gfp['narrow_broad.oiii_doublet']['free_vshift'] is False
+        assert gfp['narrow_broad.oiii_doublet']['free_sigma']  is False
+        assert gfp['narrow_broad.broad_balmer']['free_vshift'] is False
+        assert gfp['narrow_broad.broad_balmer']['free_sigma']  is False
+
+        # global groups stay fully tied
+        assert gfp['global.ciii_aliii']['free_vshift'] is False
+        assert gfp['global.mgii_pair']['free_vshift']  is False
+
+        # reserved fields present and null
+        assert gfp['narrow_broad.narrow_all']['delta_vshift_max'] is None
+        assert gfp['narrow_broad.narrow_all']['delta_sigma_max']  is None
 
 
 # ── Group 2: consistency check ────────────────────────────────────────────────

--- a/py/fastspecfit/test/test_emline_constraints.py
+++ b/py/fastspecfit/test/test_emline_constraints.py
@@ -62,12 +62,19 @@ class TestLoading:
         assert 'narrow_only' in ec.profiles
         assert 'narrow_broad' in ec.profiles
 
-    def test_fitting_strategy_defaults(self, ec):
-        assert ec.final_pass_enabled is True
-        assert ec.final_pass_mode == 'per_line'
-        assert ec.final_pass_warm_start is True
-        assert ec.final_pass_adopt_if == 'chi2_improves'
-        assert ec.mc_inherit_final_pass is True
+    def test_fitting_strategy_per_profile(self, ec):
+        assert set(ec.final_pass.keys()) == {'narrow_only', 'narrow_broad'}
+
+        fp_no = ec.final_pass['narrow_only']
+        assert fp_no['enabled']       is True
+        assert fp_no['mode']          == 'per_line'
+        assert fp_no['warm_start']    is True
+        assert fp_no['adopt_if']      == 'chi2_improves'
+        assert fp_no['inherit_in_mc'] is True
+
+        fp_nb = ec.final_pass['narrow_broad']
+        assert fp_nb['enabled']       is False
+        assert fp_nb['inherit_in_mc'] is True
 
 
 # ── Group 2: consistency check ────────────────────────────────────────────────

--- a/py/fastspecfit/test/test_emline_constraints.py
+++ b/py/fastspecfit/test/test_emline_constraints.py
@@ -83,7 +83,7 @@ class TestLoading:
         assert gfp['narrow_only.narrow_balmer']['free_sigma']  is True
 
         # narrow_broad: narrow_all frees vshift only
-        assert gfp['narrow_broad.narrow_all']['free_vshift']  is True
+        assert gfp['narrow_broad.narrow_all']['free_vshift']  is False
         assert gfp['narrow_broad.narrow_all']['free_sigma']   is False
         # oiii_doublet and broad_balmer stay fully tied
         assert gfp['narrow_broad.oiii_doublet']['free_vshift'] is False
@@ -95,9 +95,13 @@ class TestLoading:
         assert gfp['global.ciii_aliii']['free_vshift'] is False
         assert gfp['global.mgii_pair']['free_vshift']  is False
 
-        # reserved fields present and null
-        assert gfp['narrow_broad.narrow_all']['delta_vshift_max'] is None
-        assert gfp['narrow_broad.narrow_all']['delta_sigma_max']  is None
+        # delta bounds: narrow groups use 100/100, broad groups use 500/1000
+        assert gfp['narrow_broad.narrow_all']['delta_vshift_max']  == 100.0
+        assert gfp['narrow_broad.narrow_all']['delta_sigma_max']   == 100.0
+        assert gfp['narrow_broad.broad_balmer']['delta_vshift_max'] == 500.0
+        assert gfp['narrow_broad.broad_balmer']['delta_sigma_max']  == 1000.0
+        assert gfp['global.ciii_aliii']['delta_vshift_max'] == 500.0
+        assert gfp['global.mgii_pair']['delta_sigma_max']   == 1000.0
 
 
 # ── Group 2: consistency check ────────────────────────────────────────────────

--- a/py/fastspecfit/test/test_emlines.py
+++ b/py/fastspecfit/test/test_emlines.py
@@ -18,8 +18,8 @@ from astropy.table import Table
 
 def _make_emfit(**kwargs):
     from fastspecfit.linetable import LineTable
-    from fastspecfit.emlines import EMFitTools
-    return EMFitTools(LineTable().table, **kwargs)
+    from fastspecfit.emlines import EMFitTools, EmlineConstraints
+    return EMFitTools(LineTable().table, EmlineConstraints(), **kwargs)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
## Summary

- Add `data/emline-constraints.yaml` to define kinematic groups, tied-line moments, doublet bounds, and fitting-strategy parameters; add `EmlineConstraints` class that loads and validates the file at startup
- Wire `EmlineConstraints` through `EMFitTools`, `linemasker`, and `qa`; move per-line moment definitions and doublet bounds out of hard-coded Python into the constraints file
- Enable the final optimization pass (`per_line` mode, `chi2_improves` criterion) by default
- Update `doc/technote/emline-model.tex` to document kinematic groups, bounds, global pairs, and the final optimization pass

## Test plan

- [ ] `pytest py/fastspecfit/test/test_emline_constraints.py` — all constraint loading/validation tests pass
- [ ] `pytest py/fastspecfit/test/test_emlines.py` — EMFitTools initialization and linemodel tests pass
- [ ] `pytest py/fastspecfit/test/test_fastspecfit.py` — integration tests (fastspec + fastphot) pass end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)