### PR TITLE
keep sigma constrained in kinematic groups; nebular doublets should never decouple their kinematics

### DIFF
--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -14,7 +14,7 @@ from fastspecfit.logger import log
 def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=False,
                     sample=None, input_redshifts=False, outdir_data='.', templates=None,
                     templateversion=None, fphotodir=None, fphotofile=None, emlinesfile=None,
-                    mp_per_file=False):
+                    constraintsfile=None, mp_per_file=False):
     """Run fastspec, fastphot, or fastqa across MPI ranks.
 
     Parameters
@@ -45,6 +45,8 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
         Photometry configuration file override.
     emlinesfile : :class:`str` or None, optional
         Emission-line parameter file override.
+    constraintsfile : :class:`str` of None, optional
+        Emission-line constraints file override.
     mp_per_file : :class:`bool`, optional
         If ``True``, run multiple files in parallel (one file per worker).
 
@@ -256,6 +258,7 @@ def main():
     parser.add_argument('--fphotodir', type=str, default=None, help='Top-level location of the source photometry.')
     parser.add_argument('--fphotofile', type=str, default=None, help='Photometric information file.')
     parser.add_argument('--emlinesfile', type=str, default=None, help='Emission line parameter file.')
+    parser.add_argument('--constraintsfile', type=str, default=None, help='Emission-line kinematic constraint YAML file.')
 
     parser.add_argument('--merge', action='store_true', help='Merge all individual catalogs (for a given survey and program) into one large file.')
     parser.add_argument('--mergedir', type=str, help='Output directory for merged catalogs.')
@@ -425,7 +428,8 @@ def main():
                                   makeqa=args.makeqa, outdir_data=outdir_data, sample=sample,
                                   input_redshifts=args.input_redshifts, templates=args.templates,
                                   templateversion=args.templateversion, fphotodir=args.fphotodir,
-                                  fphotofile=args.fphotofile, emlinesfile=args.emlinesfile, mp_per_file=args.mp_per_file)
+                                  fphotofile=args.fphotofile, emlinesfile=args.emlinesfile, 
+                                  constraintsfile=args.constraintsfile, mp_per_file=args.mp_per_file)
 
         if args.profile:
             profiler.disable()

--- a/bin/mpi-fastspecfit
+++ b/bin/mpi-fastspecfit
@@ -45,7 +45,7 @@ def run_fastspecfit(args, comm=None, fastphot=False, specprod_dir=None, makeqa=F
         Photometry configuration file override.
     emlinesfile : :class:`str` or None, optional
         Emission-line parameter file override.
-    constraintsfile : :class:`str` of None, optional
+    constraintsfile : :class:`str` or None, optional
         Emission-line constraints file override.
     mp_per_file : :class:`bool`, optional
         If ``True``, run multiple files in parallel (one file per worker).

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,13 @@ Change Log
 3.4.3 (not released yet)
 ------------------------
 
+* Propagate ``--constraintsfile`` through ``mpi-fastspecfit``. Exclude
+  amplitude-constrained doublet pairs from kinematic relaxation in the
+  final optimization pass and update the default narrow-only
+  final-pass configuration to ``free_sigma: false`` [`PR #259`_].
+
+.. _`PR #259`: https://github.com/desihub/fastspecfit/pull/259
+
 3.4.2 (2026-06-03)
 ------------------
 

--- a/doc/technote/emline-model.tex
+++ b/doc/technote/emline-model.tex
@@ -560,20 +560,30 @@ two levels of granularity, both defined in \texttt{data/emline-constraints.yaml}
 \item \textbf{Per kinematic group}: each group carries \texttt{free\_vshift} and
   \texttt{free\_sigma} boolean flags.  When a flag is \texttt{true}, the corresponding
   parameter type ($\Delta v$ or $s$) is freed for every member of that group in the
-  relaxed model.  Groups with both flags \texttt{false} are not relaxed.
+  relaxed model, with one exception: lines that belong to any amplitude-constrained
+  doublet pair (Section~\ref{ssec:amp_constraints}) are never freed kinematically,
+  because releasing them individually would allow transitions originating from the same
+  upper level to acquire different velocity shifts or line widths.  Groups with both
+  flags \texttt{false} are not relaxed.
 
 \item \textbf{Per profile}: the fields \texttt{enabled}, \texttt{warm\_start},
   \texttt{adopt\_if}, and \texttt{inherit\_in\_mc} control whether the pass runs,
   how it is initialized, and when its result is adopted.
 \end{itemize}
 
-For the \emph{narrow-only} profile, both kinematic groups have \texttt{free\_vshift:
-true} and \texttt{free\_sigma: true}, so every line's $\Delta v$ and $s$ are freed
-independently.  For the \emph{narrow+broad} profile, all three groups currently have
-both flags set to \texttt{false}; the pass is nominally enabled but produces no free
-parameters, so it is a no-op in the current default configuration.  Amplitude
-constraints (fixed ratios and doublet ratios; Section~\ref{ssec:amp_constraints}) are
-never relaxed regardless of the per-group flags.
+In the default configuration, both kinematic groups of the \emph{narrow-only} profile
+have \texttt{free\_vshift: true} and \texttt{free\_sigma: false}: individual velocity
+shifts $\Delta v$ are freed so that each line can absorb small wavelength-calibration
+offsets, while line widths $s$ remain shared within the group.  Doublet-constrained
+lines---[O\,\textsc{ii}]~$\lambda\lambda$3726,3729;
+[S\,\textsc{ii}]~$\lambda\lambda$6716,6731;
+[N\,\textsc{ii}]~$\lambda\lambda$6548,6584;
+[O\,\textsc{iii}]~$\lambda\lambda$4959,5007;
+[O\,\textsc{ii}]~$\lambda\lambda$7320,7330;
+and Mg\,\textsc{ii}~$\lambda\lambda$2796,2803---retain their kinematic ties even when
+\texttt{free\_vshift} is \texttt{true}.  For the \emph{narrow+broad} profile, all three
+groups have both flags set to \texttt{false}; the pass is nominally enabled but produces
+no free parameters and is therefore a no-op in the current default configuration.
 
 \paragraph{Warm-start bounds.}
 Each freed parameter is initialized at its primary best-fit value (\texttt{warm\_start:

--- a/py/fastspecfit/data/emline-constraints.yaml
+++ b/py/fastspecfit/data/emline-constraints.yaml
@@ -206,7 +206,7 @@ profiles:
           - oii_7330      # amplitude also constrained via amplitude_constraints.fixed
           - siii_9069
           - siii_9532
-        final_pass: {free_vshift: true, free_sigma: true, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
+        final_pass: {free_vshift: true, free_sigma: false, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
 
       - name: narrow_balmer
         anchor: halpha
@@ -224,7 +224,7 @@ profiles:
           - hbeta
           - hei_4471
           - hei_5876
-        final_pass: {free_vshift: true, free_sigma: true, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
+        final_pass: {free_vshift: true, free_sigma: false, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
 
     free_lines: []
 

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -76,6 +76,16 @@ class EmlineConstraints:
         # named profiles + per-profile final_pass strategy
         self.profiles = raw['profiles']
 
+        # Lines that are members of amplitude-constrained doublets (both fixed
+        # ratios and free doublet ratios). These must never receive independent
+        # kinematics in the final pass: releasing them individually would give
+        # physically identical transitions different sigma or vshift.
+        doublet_lines = frozenset(
+            item
+            for entry in ac.get('fixed', []) + ac.get('doublet_ratios', [])
+            for item in (entry['line'], entry['ref'])
+        )
+
         def _parse_group_fp(g, context):
             """Parse and validate a kinematic group's final_pass block."""
             if 'final_pass' not in g:
@@ -90,11 +100,13 @@ class EmlineConstraints:
                         f"is missing required key '{key}'.")
             dvm = gfp.get('delta_vshift_max')
             dsm = gfp.get('delta_sigma_max')
+            members = set(g.get('members', [])) | {g.get('anchor', '')}
             return {
                 'free_vshift':      bool(gfp['free_vshift']),
                 'free_sigma':       bool(gfp['free_sigma']),
                 'delta_vshift_max': float(dvm) if dvm is not None else None,
                 'delta_sigma_max':  float(dsm) if dsm is not None else None,
+                'locked_members':   members & doublet_lines,
             }
 
         # group_final_pass: keyed by 'global.<name>' or '<profile>.<name>'
@@ -1784,6 +1796,9 @@ def emline_specfit(data, fastfit, specphot, continuummodel, smooth_continuum,
                 continue
             gfp = constraints.group_final_pass.get(linemodel_relax['group_name'][i])
             if gfp is None:
+                continue
+            line_name = EMFit.line_table['name'][EMFit.param_table['line'][i]]
+            if line_name in gfp['locked_members']:
                 continue
             param_type = EMFit.param_table['type'][i]
             if ((param_type == ParamType.VSHIFT and gfp['free_vshift']) or

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -742,6 +742,8 @@ def build_cmdargs(args, redrockfile, outfile, sample=None, fastphot=False,
             cmdargs += f' --fphotofile={args.fphotofile}'
         if args.emlinesfile:
             cmdargs += f' --emlinesfile={args.emlinesfile}'
+        if args.constraintsfile:
+            cmdargs += f' --constraintsfile={args.constraintsfile}'
         if args.nmonte:
             cmdargs += f' --nmonte={args.nmonte}'
         if args.vdisp_nominal:

--- a/py/fastspecfit/test/test_emline_constraints.py
+++ b/py/fastspecfit/test/test_emline_constraints.py
@@ -103,6 +103,44 @@ class TestLoading:
         assert gfp['global.ciii_aliii']['delta_vshift_max'] == 500.0
         assert gfp['global.mgii_pair']['delta_sigma_max']   == 1000.0
 
+    def test_locked_members(self, ec):
+        gfp = ec.group_final_pass
+
+        # Every group must carry a locked_members set.
+        for key, val in gfp.items():
+            assert 'locked_members' in val, f"'{key}' missing locked_members"
+
+        # narrow_only.forbidden: every amplitude-constrained doublet line that
+        # belongs to the group (members + anchor) must be locked.
+        forbidden_locked = gfp['narrow_only.forbidden']['locked_members']
+        for line in (
+            'oii_3726',  'oii_3729',   # doublet_ratios
+            'sii_6716',  'sii_6731',   # doublet_ratios
+            'nii_6548',  'nii_6584',   # amplitude_constraints.fixed
+            'oiii_4959', 'oiii_5007',  # amplitude_constraints.fixed (anchor)
+            'oii_7320',  'oii_7330',   # amplitude_constraints.fixed
+        ):
+            assert line in forbidden_locked, \
+                f"Expected '{line}' in narrow_only.forbidden locked_members"
+
+        # Non-doublet members of the forbidden group must not be locked.
+        for line in ('neiii_3869', 'nev_3346', 'ariii_7135', 'oi_6300', 'siii_9069'):
+            assert line not in forbidden_locked, \
+                f"'{line}' should not be in narrow_only.forbidden locked_members"
+
+        # narrow_balmer has no doublet members.
+        assert gfp['narrow_only.narrow_balmer']['locked_members'] == set()
+
+        # global mgii_pair: both MgII doublet lines must be locked.
+        mgii_locked = gfp['global.mgii_pair']['locked_members']
+        assert 'mgii_2796' in mgii_locked
+        assert 'mgii_2803' in mgii_locked
+
+        # narrow_broad.oiii_doublet: the member and anchor are both doublet lines.
+        oiii_locked = gfp['narrow_broad.oiii_doublet']['locked_members']
+        assert 'oiii_4959' in oiii_locked
+        assert 'oiii_5007' in oiii_locked
+
 
 # ── Group 2: consistency check ────────────────────────────────────────────────
 

--- a/py/fastspecfit/test/test_emline_constraints.py
+++ b/py/fastspecfit/test/test_emline_constraints.py
@@ -78,9 +78,9 @@ class TestLoading:
 
         # narrow_only: both groups release vshift and sigma
         assert gfp['narrow_only.forbidden']['free_vshift']   is True
-        assert gfp['narrow_only.forbidden']['free_sigma']    is True
+        assert gfp['narrow_only.forbidden']['free_sigma']    is False
         assert gfp['narrow_only.narrow_balmer']['free_vshift'] is True
-        assert gfp['narrow_only.narrow_balmer']['free_sigma']  is True
+        assert gfp['narrow_only.narrow_balmer']['free_sigma']  is False
 
         # narrow_broad: narrow_all frees vshift only
         assert gfp['narrow_broad.narrow_all']['free_vshift']  is False


### PR DESCRIPTION
Hi @moustakas .. mpi-fastspec is not grabbing a custom emline constraints file.. 

I added the argument to mpi-fastspecfit but it is not grabbing the constraints file yet. I must be forgetting somewhere else I should pass this... but somehow I cannot find it.