### PR TITLE
Compute continuum-based SFR averaged over 100 Myr

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,7 @@ jobs:
               uses: actions/cache@v4
               with:
                 path: ${{ env.FTEMPLATES_CACHE_DIR }}
-                key: ${{ runner.os }}-fastspecfit-templates-2.0.0
+                key: ${{ runner.os }}-fastspecfit-templates-2.1.0
             - name: Run the test
               run: pytest
 
@@ -75,7 +75,7 @@ jobs:
               uses: actions/cache@v4
               with:
                 path: ${{ env.FTEMPLATES_CACHE_DIR }}
-                key: ${{ runner.os }}-fastspecfit-templates-2.0.0
+                key: ${{ runner.os }}-fastspecfit-templates-2.1.0
             - name: Run the test with coverage
               run: pytest --cov
             - name: Coveralls

--- a/bin/build-templates
+++ b/bin/build-templates
@@ -102,6 +102,8 @@ Notes
 
     micromamba create -y -n fsps python
     micromamba activate fsps
+    micromamba install -Y numpy scipy astropy
+    python -m pip install desispec fastspecfit
     cd $HOME/code
     git clone --recursive https://github.com/dfm/python-fsps.git
     export SPS_HOME=$HOME/code/python-fsps/src/fsps/libfsps
@@ -122,6 +124,7 @@ import os, time
 import numpy as np
 import numpy.ma as ma
 import fitsio
+import fsps
 from scipy.ndimage import gaussian_filter1d
 from scipy.interpolate import interpn
 
@@ -139,7 +142,6 @@ def _qa_dustem_templates(dustwave, mduste, qpah, umin, gamma, png):
     # check against FSPS using a simple (age-independent) Charlot & Fall
     # dust model
 
-    import fsps
     import seaborn as sns
 
     def attenuation(tauv, wave, alpha=-0.7):
@@ -556,7 +558,7 @@ def build_fsps_templates(models, logages, agebins=None, imf='chabrier',
 
         meta['mstar'][imodel] = sp.stellar_mass
         meta['sfr'][imodel] = sp.sfr
-        meta['dt'][imodel] = float(dt)   # [yr]
+        meta['dt'][imodel] = dt[0]   # [yr]
         #print(tage, sp.formed_mass, sp.stellar_mass)
         if sp.stellar_mass < 0:
             raise ValueError('Stellar mass is negative!')

--- a/bin/build-templates
+++ b/bin/build-templates
@@ -12,10 +12,10 @@ Usage
 -----
 ::
 
-  time python bin/build-templates --version 2.0.0 \\
+  time python bin/build-templates --version 2.1.0 \\
       --templatedir $DESI_ROOT/users/ioannis/fastspecfit/templates
 
-  time python bin/build-templates --version 2.0.0 \\
+  time python bin/build-templates --version 2.1.0 \\
       --templatedir $DESI_ROOT/users/ioannis/fastspecfit/templates \\
       --logmets=-1.,0.,0.3
 
@@ -477,6 +477,7 @@ def build_fsps_templates(models, logages, agebins=None, imf='chabrier',
     meta['zzsun'] = models['logmet']
     meta['mstar'] = np.zeros(nsed, 'f4')
     meta['sfr'] = np.zeros(nsed, 'f4')
+    meta['dt'] = np.zeros(nsed, 'f4')   # age bin width [yr]
 
     # https://dfm.io/python-fsps/current/stellarpop_api/
     imfdict = {'salpeter': 0, 'chabrier': 1, 'kroupa': 2}
@@ -555,6 +556,7 @@ def build_fsps_templates(models, logages, agebins=None, imf='chabrier',
 
         meta['mstar'][imodel] = sp.stellar_mass
         meta['sfr'][imodel] = sp.sfr
+        meta['dt'][imodel] = float(dt)   # [yr]
         #print(tage, sp.formed_mass, sp.stellar_mass)
         if sp.stellar_mass < 0:
             raise ValueError('Stellar mass is negative!')
@@ -605,7 +607,7 @@ def main(imf='chabrier', logmets=[0.0], qpah=1.0, umin=1., gamma=0.01,
         single-metallicity test run. Default is ``False``.
     version : :class:`str`, optional
         Version string embedded in the output filename and FITS header,
-        e.g. ``'2.0.0'``. Default is ``'1.0.0'``.
+        e.g. ``'2.1.0'``.
     templatedir : :class:`str` or None, optional
         Root template directory. Raw input files are read from
         ``<templatedir>/original/`` and the output FITS file is written
@@ -770,7 +772,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--templatedir', required=True, help='Location of original and output templates')
-    parser.add_argument('--version', required=True, help='Version number (e.g., 2.0.0)')
+    parser.add_argument('--version', required=True, help='Version number (e.g., 2.1.0)')
 
     # DL07 parameters
     # https://python-fsps.readthedocs.io/en/latest/stellarpop_api

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,8 +6,8 @@ Change Log
 ------------------------
 
 * Add ``dt`` (age bin width) to template ``METADATA`` and compute the
-  continuum-based ``SFR`` averaged over the most recent 100 Myr, following
-  Leja et al. (2019); requires templates v2.1.0+ [`PR #262`_].
+  continuum-based ``SFR`` averaged over the most recent 100 Myr; bump
+  templates to ``2.1.0`` [`PR #262`_].
 
 .. _`PR #262`: https://github.com/desihub/fastspecfit/pull/262
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,11 @@ Change Log
 3.5.0 (not released yet)
 ------------------------
 
-*
+* Add ``dt`` (age bin width) to template ``METADATA`` and compute the
+  continuum-based ``SFR`` averaged over the most recent 100 Myr, following
+  Leja et al. (2019); requires templates v2.1.0+ [`PR #262`_].
+
+.. _`PR #262`: https://github.com/desihub/fastspecfit/pull/262
 
 3.4.3 (2026-06-06)
 ------------------

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -2175,10 +2175,14 @@ def continuum_specfit(data, fastfit, specphot, templates, igm, phot,
                 zzsun = np.log10(coeff.dot(mstars * 10.**tinfo['zzsun']) / masstot) # mass-weighted
                 age = coeff.dot(tinfo['age']) / coefftot / 1e9           # luminosity-weighted [Gyr]
                 #age = coeff.dot(mstars * tinfo['age']) / masstot / 1e9  # mass-weighted [Gyr]
-                sfr_dt = 100e6  # [yr]
-                t_near = tinfo['age'] - tinfo['dt'] / 2.
-                frac = np.clip((np.minimum(tinfo['age'] + tinfo['dt'] / 2., sfr_dt) - t_near) / tinfo['dt'], 0., 1.)
-                sfr = CTools.massnorm * coeff.dot(frac) / sfr_dt         # [Msun/yr], averaged over 100 Myr
+                if 'dt' in tinfo.colnames:
+                    sfr_dt = 100e6  # [yr]
+                    t_near = tinfo['age'] - tinfo['dt'] / 2.
+                    frac = np.clip((np.minimum(tinfo['age'] + tinfo['dt'] / 2., sfr_dt) - t_near) / tinfo['dt'], 0., 1.)
+                    sfr = CTools.massnorm * coeff.dot(frac) / sfr_dt     # [Msun/yr], averaged over 100 Myr
+                else:
+                    # old templates (<v2.1.0) lack dt; fall back to sp.sfr-based estimate (~30 Myr)
+                    sfr = CTools.massnorm * coeff.dot(tinfo['sfr'])      # [Msun/yr]
             else:
                 logmstar, zzsun, age, sfr = 0., 0., 0., 0.
             return age, zzsun, logmstar, sfr

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -2175,7 +2175,10 @@ def continuum_specfit(data, fastfit, specphot, templates, igm, phot,
                 zzsun = np.log10(coeff.dot(mstars * 10.**tinfo['zzsun']) / masstot) # mass-weighted
                 age = coeff.dot(tinfo['age']) / coefftot / 1e9           # luminosity-weighted [Gyr]
                 #age = coeff.dot(mstars * tinfo['age']) / masstot / 1e9  # mass-weighted [Gyr]
-                sfr = CTools.massnorm * coeff.dot(tinfo['sfr'])          # [Msun/yr]
+                sfr_dt = 100e6  # [yr]
+                t_near = tinfo['age'] - tinfo['dt'] / 2.
+                frac = np.clip((np.minimum(tinfo['age'] + tinfo['dt'] / 2., sfr_dt) - t_near) / tinfo['dt'], 0., 1.)
+                sfr = CTools.massnorm * coeff.dot(frac) / sfr_dt         # [Msun/yr], averaged over 100 Myr
             else:
                 logmstar, zzsun, age, sfr = 0., 0., 0., 0.
             return age, zzsun, logmstar, sfr

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -63,7 +63,7 @@ class Templates(object):
     AGN_PIXKMS = 75.  # [km/s]
     AGN_PIXKMS_BOUNDS = (1075., 3090.)
 
-    DEFAULT_TEMPLATEVERSION = '2.0.0'
+    DEFAULT_TEMPLATEVERSION = '2.1.0'
     DEFAULT_IMF = 'chabrier'
 
     # highest vdisp for which we attempt to use cached FFTs
@@ -129,6 +129,9 @@ class Templates(object):
         self.flux_nolines_nomvdisp = self.convolve_vdisp(self.flux_nolines, vdisp_nominal)
 
         self.info = Table(templateinfo)
+
+        if 'dt' not in self.info.colnames:
+            log.warning('Template file lacks dt column; SFR will be averaged over ~30 Myr instead of 100 Myr.')
 
         if 'DUSTFLUX' in T and 'AGNFLUX' in T:
             from fastspecfit.util import trapz

--- a/py/fastspecfit/test/conftest.py
+++ b/py/fastspecfit/test/conftest.py
@@ -15,7 +15,7 @@ os.environ.setdefault('MPLBACKEND', 'Agg')
 
 @pytest.fixture(scope='session')
 def template_version():
-    yield '2.0.0'
+    yield '2.1.0'
 
 
 @pytest.fixture(scope='session')
@@ -41,7 +41,7 @@ def templates(templatedir, template_version):
     templates_file = f'ftemplates-chabrier-{template_version}.fits'
     templates = os.path.join(templatedir, templates_file)
 
-    url = f"https://data.desi.lbl.gov/public/external/templates/fastspecfit/2.0.0/{templates_file}"
+    url = f"https://data.desi.lbl.gov/public/external/templates/fastspecfit/{template_version}/{templates_file}"
     if not os.path.isfile(templates):
         urlretrieve(url, templates)
     yield templates

--- a/py/fastspecfit/test/test_fastspecfit.py
+++ b/py/fastspecfit/test/test_fastspecfit.py
@@ -4,7 +4,21 @@ fastspecfit.test.test_fastspecfit
 
 """
 import os
+import numpy as np
 import pytest
+
+
+# ---------------------------------------------------------------------------
+# Template tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.filterwarnings("ignore::astropy.units.UnitsWarning")
+def test_template_dt_column(templates):
+    """Templates >=2.1.0 must carry a dt column for 100-Myr SFR averaging."""
+    from fastspecfit.templates import Templates
+    T = Templates(template_file=templates)
+    assert 'dt' in T.info.colnames, 'dt column missing'
+    assert np.all(T.info['dt'] > 0), 'dt values must be positive'
 
 
 # ---------------------------------------------------------------------------
@@ -42,6 +56,17 @@ def test_fastspec(fastspec_output):
     for hdu in fits:
         if hdu.has_data():
             assert(hdu.get_extname() in ['METADATA', 'SPECPHOT', 'FASTSPEC', 'MODELS'])
+
+
+@pytest.mark.filterwarnings("ignore::astropy.units.UnitsWarning")
+def test_sfr_values(fastspec_output, fastphot_output):
+    """SFR in SPECPHOT must be finite and non-negative for all objects."""
+    import fitsio
+    for outfile in [fastspec_output, fastphot_output]:
+        data = fitsio.read(outfile, ext='SPECPHOT')
+        assert 'SFR' in data.dtype.names
+        assert np.all(data['SFR'] >= 0), f'negative SFR in {outfile}'
+        assert np.all(np.isfinite(data['SFR'])), f'non-finite SFR in {outfile}'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `dt` (age bin width, yr) column to template `METADATA`; requires regenerating templates at 2.1.0+
- Compute `SFR` in `_get_sps_properties` as total mass formed in the last 100 Myr divided by 100 Myr, following the Prospector/Leja+19 convention (previously used only the ~30 Myr youngest bin via `sp.sfr`)
- Graceful fallback for pre-2.1.0 templates: one-time `log.warning` at template load time, silent fallback in `_get_sps_properties`
- Bump `DEFAULT_TEMPLATEVERSION` to 2.1.0; update CI cache key and test fixtures accordingly
- Add `test_template_dt_column` and `test_sfr_values` unit tests

## Test plan

- [x] Build 2.1.0 templates with `bin/build-templates --version 2.1.0`
- [x] Run `pytest` with new templates
- [x] Verify `SFR` values are non-negative and finite in fastspec/fastphot output

🤖 Generated with [Claude Code](https://claude.com/claude-code)