### PR TITLE
update redshift for small fraction of WISE_VAR_QSO targets

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,7 +11,11 @@ Change Log
 * Support new hierarchical healpixels (``uniqpix``) used for the first
   time in the ``Matterhorn`` (DR3) spectroscopic production [`PR
   #261`_].
+* Fix ``WISE_VAR_QSO`` redshift update to require the QuasarNet confidence
+  threshold (matching ``LSS.qso_cat_utils.qso_catalog_maker``); also update
+  ``ZERR`` and, for DR2 and later productions, ``ZWARN`` [`PR #264`_].
 
+.. _`PR #264`: https://github.com/desihub/fastspecfit/pull/264
 .. _`PR #262`: https://github.com/desihub/fastspecfit/pull/262
 .. _`PR #261`: https://github.com/desihub/fastspecfit/pull/261
 

--- a/doc/vacs.rst
+++ b/doc/vacs.rst
@@ -124,12 +124,12 @@ determined by Redrock is incorrect. To mitigate this issue, the DESI team has
 developed an approach to rectify the redshift nominally measured by Redrock
 using the machine-learning algorithm ``QuasarNet``.
 
-We update the Redrock redshift ``Z`` for affected QSO targets using the
-`QuasarNet catalog`_ and `MgII catalog`_ afterburners distributed alongside
-each Redrock output file. The original Redrock redshift and ``ZWARNING``
-bitmask are preserved in the ``Z_RR`` and ``ZWARN_RR`` output columns (see the
-:ref:`fastspec data model<fastspec datamodel>`); note that only ``Z`` is
-modified, not ``ZWARN``.
+We update the Redrock redshift ``Z`` and its uncertainty ``ZERR`` for affected
+QSO targets using the `QuasarNet catalog`_ and `MgII catalog`_ afterburners
+distributed alongside each Redrock output file. The original Redrock redshift
+and ``ZWARNING`` bitmask are preserved in the ``Z_RR`` and ``ZWARN_RR`` output
+columns (see the :ref:`fastspec data model<fastspec datamodel>`). For DR2 (Loa)
+and later productions, ``ZWARN`` is also updated from the afterburner.
 
 The update is applied separately to two classes of targets:
 
@@ -143,10 +143,11 @@ threshold. For DR2 (Loa) this threshold is 0.99; for DR1 (Iron) it was 0.95.
 
 **Variable WISE QSO secondary targets** (``WISE_VAR_QSO`` secondary targeting
 bit, present in main-survey and some SV programs but not CMX data) are updated
-under a broader criterion: ``IS_QSO_QN_NEW_RR`` must be set and at least one
-of the following must hold — the Redrock spectral type is ``QSO``, the MgII
-afterburner identifies the object as a QSO (``IS_QSO_MGII``), or the maximum
-QuasarNet line confidence exceeds the threshold above.
+under a broader criterion: ``IS_QSO_QN_NEW_RR`` must be set, the QuasarNet
+confidence threshold must be exceeded, and at least one of the following must
+hold — the Redrock spectral type is ``QSO``, the MgII afterburner identifies
+the object as a QSO (``IS_QSO_MGII``), or the maximum QuasarNet line
+confidence exceeds the threshold above.
 
 
 Issues

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -974,7 +974,7 @@ class DESISpectra(object):
             # updated for Jura, Kibo, Loa, ...
             QNthresh = 0.99
             QNCOLS = ['TARGETID', 'Z_NEW', 'ZWARN_NEW', 'IS_QSO_QN_NEW_RR', ] + QNLINES
-            new_zwarn = False
+            new_zwarn = True
 
         surv_target, surv_mask, surv = main_cmx_or_sv(meta, scnd=True)
         if surv == 'cmx':
@@ -1006,7 +1006,7 @@ class DESISpectra(object):
             if np.sum(IWISE_VAR_QSO) > 0:
                 mgii = Table(fitsio.read(mgiifile, 'MGII', rows=fitindx, columns=MGIICOLS))
                 assert(np.all(mgii['TARGETID'] == meta['TARGETID']))
-                iwise_var_qso = (((zb['SPECTYPE'] == 'QSO') | mgii['IS_QSO_MGII'] | qn['IS_QSO_QN_099']) & (IWISE_VAR_QSO & qn['IS_QSO_QN_NEW_RR']))
+                iwise_var_qso = (((zb['SPECTYPE'] == 'QSO') | mgii['IS_QSO_MGII'] | qn['IS_QSO_QN_099']) & (IWISE_VAR_QSO & qn['IS_QSO_QN_NEW_RR'] & qn['IS_QSO_QN_099']))
                 if np.sum(iwise_var_qso) > 0:
                     zb['Z'][iwise_var_qso] = qn['Z_NEW'][iwise_var_qso]
                     #zb['Z_ERR'][iwise_var_qso] = qn['ZERR_NEW'][iwise_var_qso]

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -963,17 +963,20 @@ class DESISpectra(object):
     def update_qso_redshifts(zb, meta, qnfile, mgiifile, fitindx, specprod):
         """Update QSO redshifts using the afterburners.
 
+        Updates Z, ZERR, and (for modern specprods) ZWARN from the QN afterburner
+        for QSO-targeted and WISE_VAR_QSO secondary targets, matching the logic of
+        qso_catalog_maker in LSS/py/LSS/qso_cat_utils.py.
         """
         from desitarget.targets import main_cmx_or_sv
 
         if specprod in ['fuji', 'guadalupe', 'himalayas', 'iron']:
             QNthresh = 0.95
-            QNCOLS = ['TARGETID', 'Z_NEW', 'IS_QSO_QN_NEW_RR', ] + QNLINES
+            QNCOLS = ['TARGETID', 'Z_NEW', 'ZERR_NEW', 'IS_QSO_QN_NEW_RR', ] + QNLINES
             new_zwarn = False
         else:
             # updated for Jura, Kibo, Loa, ...
             QNthresh = 0.99
-            QNCOLS = ['TARGETID', 'Z_NEW', 'ZWARN_NEW', 'IS_QSO_QN_NEW_RR', ] + QNLINES
+            QNCOLS = ['TARGETID', 'Z_NEW', 'ZERR_NEW', 'ZWARN_NEW', 'IS_QSO_QN_NEW_RR', ] + QNLINES
             new_zwarn = True
 
         surv_target, surv_mask, surv = main_cmx_or_sv(meta, scnd=True)
@@ -1001,6 +1004,7 @@ class DESISpectra(object):
             iqso = IQSO * qn['IS_QSO_QN_NEW_RR'] * qn['IS_QSO_QN_099']
             if np.sum(iqso) > 0:
                 zb['Z'][iqso] = qn['Z_NEW'][iqso]
+                zb['ZERR'][iqso] = qn['ZERR_NEW'][iqso]
                 if new_zwarn:
                     zb['ZWARN'][iqso] = qn['ZWARN_NEW'][iqso]
             if np.sum(IWISE_VAR_QSO) > 0:
@@ -1009,7 +1013,7 @@ class DESISpectra(object):
                 iwise_var_qso = (((zb['SPECTYPE'] == 'QSO') | mgii['IS_QSO_MGII'] | qn['IS_QSO_QN_099']) & (IWISE_VAR_QSO & qn['IS_QSO_QN_NEW_RR'] & qn['IS_QSO_QN_099']))
                 if np.sum(iwise_var_qso) > 0:
                     zb['Z'][iwise_var_qso] = qn['Z_NEW'][iwise_var_qso]
-                    #zb['Z_ERR'][iwise_var_qso] = qn['ZERR_NEW'][iwise_var_qso]
+                    zb['ZERR'][iwise_var_qso] = qn['ZERR_NEW'][iwise_var_qso]
                     if new_zwarn:
                         zb['ZWARN'][iwise_var_qso] = qn['ZWARN_NEW'][iwise_var_qso]
                 del mgii


### PR DESCRIPTION
A small fraction of `WISE_VAR_QSO` targets were not getting their redshifts updated, as the documentation claimed, making `FastSpecFit` diverge from the LSS/QSO pipeline, as documented here--
  https://github.com/desihub/fastspecfit/issues/263

This PR fixes this bug and also updates `ZWARN` (and `ZERR`, although `ZERR` isn't in the output data model), again, in order to match the algorithmic choices in `LSS.qso_cat_utils.qso_catalog_maker`.

Docs were also updated although no VAC currently exists with these fixes (oops).