### PR TITLE
Fix VDISP bias and IVAR overflow bugs

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,7 +14,16 @@ Change Log
 * Fix ``WISE_VAR_QSO`` redshift update to require the QuasarNet confidence
   threshold (matching ``LSS.qso_cat_utils.qso_catalog_maker``); also update
   ``ZERR`` and, for DR2 and later productions, ``ZWARN`` [`PR #264`_].
+* Correct ``VDISP`` to intrinsic by adding the C3K template resolution
+  (~42.4 km/s) in quadrature; propagate the Jacobian correction to
+  ``VDISP_IVAR``; add ``Templates.SIGMA_C3K`` class attribute. Guard
+  ``TAUV_IVAR`` and ``DN4000_MODEL_IVAR`` against float32 overflow
+  (matching existing pattern for ``AGE_IVAR`` etc.) and zero out the
+  corresponding measurement when the guard fires. Tighten
+  ``can_compute_vdisp`` red-end threshold to 4900 Å (z ≲ 1.0) to
+  require coverage through Hβ [`PR #265`_].
 
+.. _`PR #265`: https://github.com/desihub/fastspecfit/pull/265
 .. _`PR #264`: https://github.com/desihub/fastspecfit/pull/264
 .. _`PR #262`: https://github.com/desihub/fastspecfit/pull/262
 .. _`PR #261`: https://github.com/desihub/fastspecfit/pull/261

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,23 +5,20 @@ Change Log
 3.5.0 (not released yet)
 ------------------------
 
+* Correct ``VDISP`` to intrinsic by adding the C3K template resolution
+  (~42.4 km/s) in quadrature and tighten ``can_compute_vdisp`` red-end
+  threshold to 4900 Å (z ≲ 1.0). Guard ``TAUV_IVAR`` and
+  ``DN4000_MODEL_IVAR`` against float32 overflow [`PR #265`_].
+* Fix ``WISE_VAR_QSO`` redshift update to require the QuasarNet
+  confidence threshold (matching
+  ``LSS.qso_cat_utils.qso_catalog_maker``); also update ``ZERR`` and,
+  for DR2 and later productions, ``ZWARN`` [`PR #264`_].
 * Add ``dt`` (age bin width) to template ``METADATA`` and compute the
   continuum-based ``SFR`` averaged over the most recent 100 Myr; bump
   templates to ``2.1.0`` [`PR #262`_].
 * Support new hierarchical healpixels (``uniqpix``) used for the first
   time in the ``Matterhorn`` (DR3) spectroscopic production [`PR
   #261`_].
-* Fix ``WISE_VAR_QSO`` redshift update to require the QuasarNet confidence
-  threshold (matching ``LSS.qso_cat_utils.qso_catalog_maker``); also update
-  ``ZERR`` and, for DR2 and later productions, ``ZWARN`` [`PR #264`_].
-* Correct ``VDISP`` to intrinsic by adding the C3K template resolution
-  (~42.4 km/s) in quadrature; propagate the Jacobian correction to
-  ``VDISP_IVAR``; add ``Templates.SIGMA_C3K`` class attribute. Guard
-  ``TAUV_IVAR`` and ``DN4000_MODEL_IVAR`` against float32 overflow
-  (matching existing pattern for ``AGE_IVAR`` etc.) and zero out the
-  corresponding measurement when the guard fires. Tighten
-  ``can_compute_vdisp`` red-end threshold to 4900 Å (z ≲ 1.0) to
-  require coverage through Hβ [`PR #265`_].
 
 .. _`PR #265`: https://github.com/desihub/fastspecfit/pull/265
 .. _`PR #264`: https://github.com/desihub/fastspecfit/pull/264

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1332,7 +1332,7 @@ def build_stellar_continuum(coeff, tauv, redshift, templates, cosmo, igm,
     return ztemplatewave, contmodel
 
 
-def can_compute_vdisp(redshift, specwave, min_restrange=(3800., 4800.), fit_restrange=(3800., 6000.)):
+def can_compute_vdisp(redshift, specwave, min_restrange=(3800., 4900.), fit_restrange=(3800., 6000.)):
     """Determine whether the spectrum has sufficient coverage to fit velocity dispersion.
 
     Parameters
@@ -1343,9 +1343,13 @@ def can_compute_vdisp(redshift, specwave, min_restrange=(3800., 4800.), fit_rest
         Observed-frame wavelength array in Angstroms.
     min_restrange : tuple, optional
         Minimum required rest-frame wavelength range (lo, hi) in Angstroms.
-        Defaults to (3800., 4800.).
+        The low end guards against missing blue-camera data (Ca H&K would be
+        absent); the high end sets the effective redshift gate. Defaults to
+        (3800., 4900.), which requires coverage through Hβ (4861 Å) and
+        corresponds to z ≲ 1.0 for DESI.
     fit_restrange : tuple, optional
-        Rest-frame wavelength range used when fitting velocity dispersion.
+        Rest-frame wavelength range used when fitting velocity dispersion,
+        covering Ca H&K, G band, Hβ, Mg b, and the Fe complex.
         Defaults to (3800., 6000.).
 
     Returns

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -2072,7 +2072,8 @@ def continuum_specfit(data, fastfit, specphot, templates, igm, phot,
     specphot['SEED'] = seed
     specphot['COEFF'][CTools.agekeep] = coeff
     specphot['RCHI2_PHOT'] = rchi2_phot
-    specphot['VDISP'] = vdisp # * u.kilometer/u.second
+    vdisp_intrinsic = np.sqrt(vdisp**2 + templates.SIGMA_C3K**2)
+    specphot['VDISP'] = vdisp_intrinsic
     if 0. < dn4000_model_ivar < F32MAX:
         specphot['DN4000_MODEL'] = dn4000_model
         specphot['DN4000_MODEL_IVAR'] = dn4000_model_ivar
@@ -2096,7 +2097,7 @@ def continuum_specfit(data, fastfit, specphot, templates, igm, phot,
             fastfit[f'APERCORR_{band.upper()}'] = apercorrs[iband]
         specphot['DN4000_OBS'] = dn4000
         specphot['DN4000_IVAR'] = dn4000_ivar
-        specphot['VDISP_IVAR'] = vdisp_ivar # * (u.second/u.kilometer)**2
+        specphot['VDISP_IVAR'] = vdisp_ivar * (vdisp / vdisp_intrinsic)**2
 
     # Compute K-corrections, rest-frame quantities, and physical properties.
     if not np.all(coeff == 0.):

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -59,6 +59,8 @@ class Templates(object):
     # https://github.com/cconroy20/fsps/tree/master/SPECTRA/C3K#readme
     PIXKMS = 25.  # [km/s]
     PIXKMS_BOUNDS = (2750., 9100.)
+    # Gaussian sigma of C3K templates: R(λ/FWHM)=3000 → σ = c/(R·2√(2 ln 2))
+    SIGMA_C3K = 2.998e5 / (3000. * np.sqrt(8. * np.log(2.)))  # [km/s] ≈ 42.4
 
     AGN_PIXKMS = 75.  # [km/s]
     AGN_PIXKMS_BOUNDS = (1075., 3090.)


### PR DESCRIPTION
## Summary

- Add `Templates.SIGMA_C3K` (~42.4 km/s) class attribute for the C3K template Gaussian sigma (R=3000)
- Correct reported `VDISP` to intrinsic by adding `SIGMA_C3K` in quadrature; propagate Jacobian correction to `VDISP_IVAR`
- Guard `TAUV_IVAR` and `DN4000_MODEL_IVAR` against float32 overflow (matching existing pattern for `AGE_IVAR` etc.); zero out the corresponding measurement when the IVAR guard fires and Monte Carlo was run
- Tighten `can_compute_vdisp` redshift gate from 4800 to 4900 Å (safely past Hβ), corresponding to z ≲ 1.0 for DESI; update docstring

## Test plan

- [ ] Run `pytest` to confirm existing tests pass
- [ ] Verify `VDISP` values increase by ~few km/s relative to previous catalogs (largest effect at low σ)
- [ ] Confirm no `inf` values in `TAUV_IVAR` or `DN4000_MODEL_IVAR` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)