### PR TITLE
Improve velocity dispersion handling

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,12 @@ Change Log
 3.5.0 (not released yet)
 ------------------------
 
+* Fix inverted ``VDISP_IVAR`` Jacobian; lower ``VDISP_BOUNDS`` floor to
+  50 km/s; increase chi2 scan to 6 grid points; use a σ–M* scaling
+  relation as a fallback when vdisp cannot be measured; report
+  ``VDISP_NOMINAL = 150`` km/s as σ_stars so unfitted objects are
+  clearly flagged; validate ``vdisp_bounds`` ordering in
+  ``Templates``; new unit tests [`PR #267`_].
 * Correct ``VDISP`` to intrinsic by adding the C3K template resolution
   (~42.4 km/s) in quadrature and tighten ``can_compute_vdisp`` red-end
   threshold to 4900 Å (z ≲ 1.0). Guard ``TAUV_IVAR`` and
@@ -20,6 +26,7 @@ Change Log
   time in the ``Matterhorn`` (DR3) spectroscopic production [`PR
   #261`_].
 
+.. _`PR #267`: https://github.com/desihub/fastspecfit/pull/267
 .. _`PR #265`: https://github.com/desihub/fastspecfit/pull/265
 .. _`PR #264`: https://github.com/desihub/fastspecfit/pull/264
 .. _`PR #262`: https://github.com/desihub/fastspecfit/pull/262

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,12 +5,9 @@ Change Log
 3.5.0 (not released yet)
 ------------------------
 
-* Fix inverted ``VDISP_IVAR`` Jacobian; lower ``VDISP_BOUNDS`` floor to
-  50 km/s; increase chi2 scan to 6 grid points; use a σ–M* scaling
-  relation as a fallback when vdisp cannot be measured; report
-  ``VDISP_NOMINAL = 150`` km/s as σ_stars so unfitted objects are
-  clearly flagged; validate ``vdisp_bounds`` ordering in
-  ``Templates``; new unit tests [`PR #267`_].
+* Fix ``VDISP_IVAR`` bug; lower ``VDISP_BOUNDS`` floor to 50 km/s;
+  increase chi2 scan to 6 grid points; use a vdisp-mstar scaling
+  relation to estimate ``VDISP``; new unit tests [`PR #267`_].
 * Correct ``VDISP`` to intrinsic by adding the C3K template resolution
   (~42.4 km/s) in quadrature and tighten ``can_compute_vdisp`` red-end
   threshold to 4900 Å (z ≲ 1.0). Guard ``TAUV_IVAR`` and

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -2101,7 +2101,7 @@ def continuum_specfit(data, fastfit, specphot, templates, igm, phot,
             fastfit[f'APERCORR_{band.upper()}'] = apercorrs[iband]
         specphot['DN4000_OBS'] = dn4000
         specphot['DN4000_IVAR'] = dn4000_ivar
-        specphot['VDISP_IVAR'] = vdisp_ivar * (vdisp / vdisp_intrinsic)**2
+        specphot['VDISP_IVAR'] = vdisp_ivar * (vdisp_intrinsic / vdisp)**2
 
     # Compute K-corrections, rest-frame quantities, and physical properties.
     if not np.all(coeff == 0.):

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -75,7 +75,7 @@ class ContinuumTools(object):
     """
     def __init__(self, data, templates, phot, igm, tauv_guess=0.1,
                  vdisp_guess=VDISP_NOMINAL, tauv_bounds=(0., 2.),
-                 vdisp_bounds=VDISP_BOUNDS, vdisp_nbin=5,
+                 vdisp_bounds=VDISP_BOUNDS, vdisp_nbin=6,
                  fluxnorm=FLUXNORM, massnorm=MASSNORM, fastphot=False,
                  constrain_age=False):
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1039,7 +1039,7 @@ class ContinuumTools(object):
         self.optimizer_saved_contmodel = coeff @ phi
         resid = Psi @ coeff - b
 
-        return tauv, self.templates.vdisp_nominal, coeff, resid
+        return tauv, self.templates.vdisp_nominal_kernel, coeff, resid
 
 
     def fit_stellar_continuum(self, templateflux, fit_vdisp=False, conv_pre=None,
@@ -1189,7 +1189,7 @@ class ContinuumTools(object):
         else:
             tauv = bestparams[0]
             templatecoeff = bestparams[1:]
-            vdisp = self.templates.vdisp_nominal
+            vdisp = self.templates.vdisp_nominal_kernel
 
         return tauv, vdisp, templatecoeff, resid
 
@@ -1285,7 +1285,7 @@ def build_stellar_continuum(coeff, tauv, redshift, templates, cosmo, igm,
     vdisp : float or None, optional
         Velocity dispersion in km/s.  If ``None``, the raw (unbroadened)
         ``templates.flux`` is used without any convolution.  To match the
-        default production behavior, pass ``vdisp=templates.vdisp_nominal``.
+        default production behavior, pass ``vdisp=templates.vdisp_nominal_kernel``.
     fluxnorm : float, optional
         Flux normalization factor in erg/s/cm²/Å.
         Defaults to :data:`~fastspecfit.util.FLUXNORM` (10\ :sup:`17`).
@@ -1413,7 +1413,7 @@ def continuum_fastphot(redshift, objflam, objflamivar, CTools, uniqueid=0,
     agekeep = CTools.agekeep
     nage = CTools.nage
 
-    vdisp = templates.vdisp_nominal
+    vdisp = templates.vdisp_nominal_kernel
 
     ndof_phot = np.sum(objflamivar > 0.)
 
@@ -1571,7 +1571,7 @@ def vdisp_by_chi2scan(CTools, templates, uniqueid, specflux, specwave,
     deltachi2 = np.ptp(chi2grid)
     if deltachi2 < deltachi2min or imin == 0 or imin == ngrid-1:
         vdisp_init = CTools.vdisp_grid[imin]
-        vdisp = templates.vdisp_nominal
+        vdisp = templates.vdisp_nominal_kernel
         vdisp_ivar = 0.
         if deltachi2 < deltachi2min:
             log.info('Initial velocity dispersion fit failed: delta-chi2=' + \
@@ -1594,7 +1594,7 @@ def vdisp_by_chi2scan(CTools, templates, uniqueid, specflux, specwave,
 
         # Did fitting fail?
         if vdisp < 0.:
-            vdisp = templates.vdisp_nominal
+            vdisp = templates.vdisp_nominal_kernel
             vdisp_ivar = 0.
             chi2min = 0.
         else:
@@ -1639,7 +1639,7 @@ def _continuum_nominal_vdisp(CTools, templates, specflux, specwave,
     better fallback velocity dispersion via the σ–M* relation; and (2) to
     supply the continuum model used for the aperture-correction estimate.
     The templates used here are pre-broadened to
-    ``templates.vdisp_nominal`` (i.e., ``templates.flux_nolines_nomvdisp``).
+    ``templates.vdisp_nominal_kernel`` (i.e., ``templates.flux_nolines_nomvdisp``).
 
     """
     tauv, vdisp, coeff, resid = CTools.fit_stellar_continuum(
@@ -1758,7 +1758,7 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=NMONTE_DEF
         applies log σ = a + b*(log M* − 11) to get σ_stars.  Converts to the
         convolution kernel σ_kernel = sqrt(σ_stars² − σ_C3K²) and clamps to
         vdisp_bounds.  Returns (vdisp_kernel, logmstar) on success, or
-        (vdisp_nominal, None) when M* cannot be estimated.
+        (vdisp_nominal_kernel, None) when M* cannot be estimated.
         """
         tinfo = templates.info[agekeep]
         masstot = coeff.dot(tinfo['mstar'])
@@ -1769,7 +1769,7 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=NMONTE_DEF
             vdisp_kernel = float(np.sqrt(max(0., vdisp_stars**2 - templates.SIGMA_C3K**2)))
             vdisp_kernel = float(np.clip(vdisp_kernel, *templates.vdisp_bounds))
             return vdisp_kernel, logmstar
-        return templates.vdisp_nominal, None
+        return templates.vdisp_nominal_kernel, None
 
     def _apply_mstar_vdisp_fallback(coeff, reason):
         """Set vdisp, input_templateflux, and input_templateflux_nolines for a fallback case."""
@@ -2073,7 +2073,7 @@ def continuum_specfit(data, fastfit, specphot, templates, igm, phot,
 
     # Instantiate the continuum tools class.
     CTools = ContinuumTools(data, templates, phot, igm, fastphot=fastphot,
-                            vdisp_guess=templates.vdisp_nominal,
+                            vdisp_guess=templates.vdisp_nominal_kernel,
                             vdisp_bounds=templates.vdisp_bounds,
                             fluxnorm=FLUXNORM, constrain_age=constrain_age)
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1743,19 +1743,52 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=NMONTE_DEF
     # Attempt to solve for the velocity dispersion based on the rest-wavelength coverage.
     compute_vdisp, (vdisp_s, vdisp_e) = can_compute_vdisp(redshift, specwave)
 
+    def _vdisp_from_mstar(coeff):
+        """Return a fallback vdisp kernel (km/s) derived from the σ–M* relation.
+
+        Uses the preliminary template coefficients to estimate log M*, then
+        applies log σ = a + b*(log M* − 11) to get σ_stars.  Converts to the
+        convolution kernel σ_kernel = sqrt(σ_stars² − σ_C3K²) and clamps to
+        vdisp_bounds.  Returns (vdisp_kernel, logmstar) on success, or
+        (vdisp_nominal, None) when M* cannot be estimated.
+        """
+        tinfo = templates.info[agekeep]
+        masstot = coeff.dot(tinfo['mstar'])
+        if masstot > 0. and np.sum(coeff) > 0.:
+            logmstar = np.log10(CTools.massnorm * masstot)
+            a, b = templates.vdisp_sigma_relation
+            vdisp_stars = 10.**(a + b * (logmstar - 11.))
+            vdisp_kernel = float(np.sqrt(max(0., vdisp_stars**2 - templates.SIGMA_C3K**2)))
+            vdisp_kernel = float(np.clip(vdisp_kernel, *templates.vdisp_bounds))
+            return vdisp_kernel, logmstar
+        return templates.vdisp_nominal, None
+
+    def _apply_mstar_vdisp_fallback(coeff, reason):
+        """Set vdisp, input_templateflux, and input_templateflux_nolines for a fallback case."""
+        vdisp_kernel, logmstar = _vdisp_from_mstar(coeff)
+        if logmstar is not None:
+            itf = templates.convolve_vdisp(templates.flux[agekeep, :], vdisp_kernel)
+            itf_nl = templates.convolve_vdisp(templates.flux_nolines[agekeep, :], vdisp_kernel)
+            log.debug(f'{reason}; adopting σ–M* vdisp={vdisp_kernel:.0f} km/s '
+                      f'(log M*≈{logmstar:.2f})')
+        else:
+            itf = templates.flux_nomvdisp[agekeep, :]
+            itf_nl = templates.flux_nolines_nomvdisp[agekeep, :]
+            log.debug(f'{reason}; adopting nominal vdisp={vdisp_kernel:.0f} km/s')
+        return vdisp_kernel, itf, itf_nl
+
     if not compute_vdisp:
-        # Fit to the cached templates at the nominal velocity dispersion.
-        tauv, vdisp, coeff, contmodel, _ = _continuum_nominal_vdisp(
+        # Fit to the cached templates at the nominal velocity dispersion to
+        # get preliminary coefficients, then derive a better fallback vdisp
+        # from the σ–M* relation.
+        tauv, _, coeff, contmodel, _ = _continuum_nominal_vdisp(
             CTools, templates, specflux, specwave,
             specistd, agekeep, compute_chi2=False)
 
         vdisp_ivar = 0.
 
-        input_templateflux = templates.flux_nomvdisp[agekeep, :]
-        input_templateflux_nolines = templates.flux_nolines_nomvdisp[agekeep, :]
-
-        log.debug('Insufficient wavelength coverage to compute velocity ' + \
-                  f'dispersion; adopting {vdisp:.0f} km/s')
+        vdisp, input_templateflux, input_templateflux_nolines = \
+            _apply_mstar_vdisp_fallback(coeff, 'Insufficient wavelength coverage to compute vdisp')
     else:
         t0 = time.time()
 
@@ -1769,15 +1802,14 @@ def continuum_fastspec(redshift, objflam, objflamivar, CTools, nmonte=NMONTE_DEF
             specistd, fitmask, agekeep, deltachi2min=25.,
             fit_for_min=False, debug_plots=debug_plots)
 
-        # If the scan is unsuccessful, adopt the nominal velocity dispersion
-        # and continue....
+        # If the scan is unsuccessful, derive a fallback from the σ–M* relation.
         if vdisp_ivar == 0.:
-            tauv, vdisp, coeff, contmodel, _ = _continuum_nominal_vdisp(
+            tauv, _, coeff, contmodel, _ = _continuum_nominal_vdisp(
                 CTools, templates, specflux, specwave,
                 specistd, agekeep, compute_chi2=False)
 
-            input_templateflux = templates.flux_nomvdisp[agekeep, :]
-            input_templateflux_nolines = templates.flux_nolines_nomvdisp[agekeep, :]
+            vdisp, input_templateflux, input_templateflux_nolines = \
+                _apply_mstar_vdisp_fallback(coeff, 'vdisp chi2 scan failed')
         else:
             # ...otherwise fit for the maximum likelihood value.
 

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -33,14 +33,16 @@ class ContinuumTools(object):
     tauv_guess : float, optional
         Initial guess for the V-band optical depth. Defaults to 0.1.
     vdisp_guess : float, optional
-        Initial guess for the velocity dispersion in km/s.
+        Initial guess for the velocity dispersion kernel in km/s.
+        Defaults to :data:`~fastspecfit.templates.VDISP_NOMINAL`.
     tauv_bounds : tuple, optional
         Lower and upper bounds on tau(V). Defaults to (0., 2.).
     vdisp_bounds : tuple, optional
-        Lower and upper bounds on the velocity dispersion in km/s.
+        Lower and upper bounds on the velocity dispersion kernel in km/s.
+        Defaults to :data:`~fastspecfit.templates.VDISP_BOUNDS`.
     vdisp_nbin : int, optional
         Number of grid points for the velocity dispersion chi2 scan.
-        Defaults to 5.
+        Defaults to 6.
     fluxnorm : float, optional
         Flux normalization factor in erg/s/cm2/A. Defaults to 1e17.
     massnorm : float, optional
@@ -1283,8 +1285,7 @@ def build_stellar_continuum(coeff, tauv, redshift, templates, cosmo, igm,
     vdisp : float or None, optional
         Velocity dispersion in km/s.  If ``None``, the raw (unbroadened)
         ``templates.flux`` is used without any convolution.  To match the
-        default production behavior, pass ``vdisp=templates.vdisp_nominal``
-        (250 km/s).
+        default production behavior, pass ``vdisp=templates.vdisp_nominal``.
     fluxnorm : float, optional
         Flux normalization factor in erg/s/cm²/Å.
         Defaults to :data:`~fastspecfit.util.FLUXNORM` (10\ :sup:`17`).
@@ -1631,7 +1632,14 @@ def vdisp_by_chi2scan(CTools, templates, uniqueid, specflux, specwave,
 
 def _continuum_nominal_vdisp(CTools, templates, specflux, specwave,
                              specistd, agekeep, compute_chi2=False):
-    """Support routine to fit a spectrum at the nominal velocity dispersion.
+    """Fit a spectrum at the nominal velocity dispersion.
+
+    Used in two contexts: (1) as a quick preliminary fit whose template
+    coefficients are passed to :func:`_vdisp_from_mstar` to derive a
+    better fallback velocity dispersion via the σ–M* relation; and (2) to
+    supply the continuum model used for the aperture-correction estimate.
+    The templates used here are pre-broadened to
+    ``templates.vdisp_nominal`` (i.e., ``templates.flux_nolines_nomvdisp``).
 
     """
     tauv, vdisp, coeff, resid = CTools.fit_stellar_continuum(

--- a/py/fastspecfit/emlines.py
+++ b/py/fastspecfit/emlines.py
@@ -934,9 +934,9 @@ class EMFitTools(object):
                 limitsigma_narrow = limitsigma_narrow_default
                 limitsigma_broad = limitsigma_broad_default
                 if isbroad and isbalmer:
-                    linesigma = limitsigma_narrow
-                else:
                     linesigma = limitsigma_broad
+                else:
+                    linesigma = limitsigma_narrow
 
             linesigma_ang = linesigma * linezwave / C_LIGHT  # [observed-frame Angstrom]
 
@@ -1220,11 +1220,11 @@ class EMFitTools(object):
                     fastfit[f'{linename}_CONT_IVAR'] = cont_ivar
 
             if cont != 0. and cont_ivar > 0.:
-                # upper limit on the flux is defined by snrcut*cont_err*sqrt(2*pi)*linesigma
+                # 1-sigma upper limit on the flux is defined as cont_err*sqrt(2*pi)*linesigma
                 fluxlimit = np.sqrt(2. * np.pi) * linesigma_ang / np.sqrt(cont_ivar) # * u.erg/(u.second*u.cm**2)
                 fastfit[f'{linename}_FLUX_LIMIT'] = fluxlimit
 
-                #ewlimit = fluxlimit * cont / (1.+redshift)
+                #ewlimit = fluxlimit / cont / (1.+redshift)
                 #fastfit[f'{linename}_EW_LIMIT'] = ewlimit
 
                 if flux > 0. and flux_ivar > 0.:

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -15,7 +15,7 @@ from astropy.table import Table
 from fastspecfit.logger import log
 
 VDISP_NOMINAL = 250. # [km/s]
-VDISP_BOUNDS = (75., 500.) # [km/s]
+VDISP_BOUNDS = (50., 500.) # [km/s]
 
 class Templates(object):
     """Stellar population synthesis templates for continuum fitting.

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -43,9 +43,10 @@ class Templates(object):
         Maximum wavelength to load into memory (Angstroms). Default is
         400 000 Å.
     vdisp_nominal : :class:`float`, optional
-        Nominal velocity dispersion kernel in km/s used to pre-broaden the
-        templates and as the optimizer starting point. Default is
-        :data:`VDISP_NOMINAL`.
+        Default σ_stars (km/s) reported in the catalog when vdisp cannot be
+        measured. ``vdisp_nominal_kernel = sqrt(vdisp_nominal² − SIGMA_C3K²)``
+        is derived from this value and used for template pre-convolution and
+        as the optimizer starting point. Default is :data:`VDISP_NOMINAL`.
     vdisp_bounds : tuple of float, optional
         ``(min, max)`` velocity dispersion kernel bounds in km/s. Default is
         :data:`VDISP_BOUNDS`.
@@ -126,7 +127,8 @@ class Templates(object):
 
         # dust attenuation curve
         self.dust_klambda = Templates.klambda(self.wave)
-        self.vdisp_nominal = vdisp_nominal # [km/s]
+        self.vdisp_nominal = vdisp_nominal # [km/s] σ_stars reported when vdisp unmeasured
+        self.vdisp_nominal_kernel = float(np.sqrt(max(0., vdisp_nominal**2 - Templates.SIGMA_C3K**2)))
         self.vdisp_bounds = vdisp_bounds # [km/s]
         self.vdisp_sigma_relation = vdisp_sigma_relation # (a, b): log σ = a + b*(log M* − 11)
 
@@ -134,10 +136,10 @@ class Templates(object):
         self.pixkms_bounds = pixkms_bounds
 
         self.conv_pre = self.convolve_vdisp_pre(self.flux)
-        self.flux_nomvdisp = self.convolve_vdisp(self.flux, vdisp_nominal)
+        self.flux_nomvdisp = self.convolve_vdisp(self.flux, self.vdisp_nominal_kernel)
 
         self.conv_pre_nolines = self.convolve_vdisp_pre(self.flux_nolines)
-        self.flux_nolines_nomvdisp = self.convolve_vdisp(self.flux_nolines, vdisp_nominal)
+        self.flux_nolines_nomvdisp = self.convolve_vdisp(self.flux_nolines, self.vdisp_nominal_kernel)
 
         self.info = Table(templateinfo)
 

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -14,7 +14,7 @@ from astropy.table import Table
 
 from fastspecfit.logger import log
 
-VDISP_NOMINAL = 250. # [km/s]
+VDISP_NOMINAL = 150. # [km/s]
 VDISP_BOUNDS = (50., 500.) # [km/s]
 VDISP_SIGMA_RELATION = (2.30, 0.25) # (a, b): log σ = a + b*(log M* − 11) [km/s]
 
@@ -43,11 +43,17 @@ class Templates(object):
         Maximum wavelength to load into memory (Angstroms). Default is
         400 000 Å.
     vdisp_nominal : :class:`float`, optional
-        Nominal velocity dispersion in km/s used to pre-broaden the
-        templates. Default is :data:`VDISP_NOMINAL`.
+        Nominal velocity dispersion kernel in km/s used to pre-broaden the
+        templates and as the optimizer starting point. Default is
+        :data:`VDISP_NOMINAL`.
     vdisp_bounds : tuple of float, optional
-        ``(min, max)`` velocity dispersion bounds in km/s. Default is
+        ``(min, max)`` velocity dispersion kernel bounds in km/s. Default is
         :data:`VDISP_BOUNDS`.
+    vdisp_sigma_relation : tuple of float, optional
+        Coefficients ``(a, b)`` of the σ–M* scaling relation
+        ``log σ_stars = a + b*(log M* − 11)`` used to derive a fallback
+        velocity dispersion when σ cannot be measured. Default is
+        :data:`VDISP_SIGMA_RELATION`.
     fastphot : :class:`bool`, optional
         If ``True``, load in photometry-only mode. Default is ``False``.
     read_linefluxes : :class:`bool`, optional

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -62,13 +62,14 @@ class Templates(object):
         Default is ``False``.
 
     """
+    from fastspecfit.util import CLIGHT
 
     # SPS template constants (used by build-templates)
     # https://github.com/cconroy20/fsps/tree/master/SPECTRA/C3K#readme
     PIXKMS = 25.  # [km/s]
     PIXKMS_BOUNDS = (2750., 9100.)
     # Gaussian sigma of C3K templates: R(λ/FWHM)=3000 → σ = c/(R·2√(2 ln 2))
-    SIGMA_C3K = 2.998e5 / (3000. * np.sqrt(8. * np.log(2.)))  # [km/s] ≈ 42.4
+    SIGMA_C3K = CLIGHT / (3000. * np.sqrt(8. * np.log(2.))) # 42.4 [km/s]
 
     AGN_PIXKMS = 75.  # [km/s]
     AGN_PIXKMS_BOUNDS = (1075., 3090.)

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -127,6 +127,10 @@ class Templates(object):
 
         # dust attenuation curve
         self.dust_klambda = Templates.klambda(self.wave)
+        if vdisp_bounds[0] > vdisp_bounds[1]:
+            errmsg = f'vdisp_bounds must be (lo, hi) with lo <= hi; got {vdisp_bounds}'
+            log.critical(errmsg)
+            raise ValueError(errmsg)
         self.vdisp_nominal = vdisp_nominal # [km/s] σ_stars reported when vdisp unmeasured
         self.vdisp_nominal_kernel = float(np.sqrt(max(0., vdisp_nominal**2 - Templates.SIGMA_C3K**2)))
         self.vdisp_bounds = vdisp_bounds # [km/s]

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -62,14 +62,14 @@ class Templates(object):
         Default is ``False``.
 
     """
-    from fastspecfit.util import CLIGHT
+    from fastspecfit.util import C_LIGHT
 
     # SPS template constants (used by build-templates)
     # https://github.com/cconroy20/fsps/tree/master/SPECTRA/C3K#readme
     PIXKMS = 25.  # [km/s]
     PIXKMS_BOUNDS = (2750., 9100.)
     # Gaussian sigma of C3K templates: R(λ/FWHM)=3000 → σ = c/(R·2√(2 ln 2))
-    SIGMA_C3K = CLIGHT / (3000. * np.sqrt(8. * np.log(2.))) # 42.4 [km/s]
+    SIGMA_C3K = C_LIGHT / (3000. * np.sqrt(8. * np.log(2.))) # 42.4 [km/s]
 
     AGN_PIXKMS = 75.  # [km/s]
     AGN_PIXKMS_BOUNDS = (1075., 3090.)

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -16,6 +16,7 @@ from fastspecfit.logger import log
 
 VDISP_NOMINAL = 250. # [km/s]
 VDISP_BOUNDS = (50., 500.) # [km/s]
+VDISP_SIGMA_RELATION = (2.30, 0.25) # (a, b): log σ = a + b*(log M* − 11) [km/s]
 
 class Templates(object):
     """Stellar population synthesis templates for continuum fitting.
@@ -73,7 +74,8 @@ class Templates(object):
 
     def __init__(self, template_file=None, template_version=None, imf=None,
                  mintemplatewave=None, maxtemplatewave=40e4, vdisp_nominal=VDISP_NOMINAL,
-                 vdisp_bounds=VDISP_BOUNDS, fastphot=False, read_linefluxes=False):
+                 vdisp_bounds=VDISP_BOUNDS, vdisp_sigma_relation=VDISP_SIGMA_RELATION,
+                 fastphot=False, read_linefluxes=False):
         self.init_ffts()
 
         if template_file is None:
@@ -120,6 +122,7 @@ class Templates(object):
         self.dust_klambda = Templates.klambda(self.wave)
         self.vdisp_nominal = vdisp_nominal # [km/s]
         self.vdisp_bounds = vdisp_bounds # [km/s]
+        self.vdisp_sigma_relation = vdisp_sigma_relation # (a, b): log σ = a + b*(log M* − 11)
 
         pixkms_bounds = np.searchsorted(self.wave, Templates.PIXKMS_BOUNDS, 'left')
         self.pixkms_bounds = pixkms_bounds

--- a/py/fastspecfit/test/test_continuum.py
+++ b/py/fastspecfit/test/test_continuum.py
@@ -287,3 +287,48 @@ class TestSmoothContinuum:
         result = ContinuumTools.smooth_continuum(wave, flux_zero, ivar_zero,
                                                  linemask, camerapix)
         assert np.all(result == 0.)
+
+
+# ── VDISP_IVAR Jacobian ───────────────────────────────────────────────────────
+
+class TestVdispIvarJacobian:
+    """The catalog VDISP_IVAR = vdisp_ivar_kernel * (σ_stars / kernel)².
+
+    Error propagation from kernel space to σ_stars space:
+        σ_stars = sqrt(kernel² + SIGMA_C3K²)
+        ∂σ_stars/∂kernel = kernel / σ_stars
+        IVAR(σ_stars) = IVAR(kernel) * (σ_stars / kernel)²
+    """
+
+    def _ivar_stars(self, kernel, ivar_kernel, sigma_c3k):
+        vdisp_intrinsic = np.sqrt(kernel**2 + sigma_c3k**2)
+        return vdisp_intrinsic, ivar_kernel * (vdisp_intrinsic / kernel)**2
+
+    def test_formula_correctness(self):
+        """Spot-check the Jacobian formula against a known analytic result."""
+        from fastspecfit.templates import Templates
+        kernel, ivar_k = 200., 1e-4
+        intrinsic, ivar_s = self._ivar_stars(kernel, ivar_k, Templates.SIGMA_C3K)
+        assert np.isclose(intrinsic, np.sqrt(kernel**2 + Templates.SIGMA_C3K**2))
+        assert np.isclose(ivar_s, ivar_k * (intrinsic / kernel)**2)
+
+    def test_ivar_larger_than_kernel_ivar(self):
+        """IVAR(σ_stars) > IVAR(kernel): adding C3K² reduces fractional uncertainty."""
+        from fastspecfit.templates import Templates
+        _, ivar_s = self._ivar_stars(200., 1.0, Templates.SIGMA_C3K)
+        assert ivar_s > 1.0
+
+    def test_ivar_unchanged_when_no_intrinsic_broadening(self):
+        """When sigma_c3k = 0, σ_stars = kernel and IVAR is unchanged."""
+        _, ivar_s = self._ivar_stars(200., 1.0, sigma_c3k=0.)
+        assert np.isclose(ivar_s, 1.0)
+
+
+# ── chi2 scan grid size ───────────────────────────────────────────────────────
+
+def test_vdisp_nbin_default_is_6():
+    """The chi2 scan uses 6 grid points by default."""
+    import inspect
+    from fastspecfit.continuum import ContinuumTools
+    sig = inspect.signature(ContinuumTools.__init__)
+    assert sig.parameters['vdisp_nbin'].default == 6

--- a/py/fastspecfit/test/test_templates.py
+++ b/py/fastspecfit/test/test_templates.py
@@ -4,6 +4,8 @@ fastspecfit.test.test_templates
 
 """
 import os
+import numpy as np
+import pytest
 
 
 # See conftest.py for fixtures used by multiple unit tests.
@@ -20,3 +22,77 @@ def test_templates(templates):
     temp = Templates(template_file=templates)
     assert(os.path.isfile(temp.file))
     assert(hasattr(temp, 'pixkms_bounds'))
+
+
+# ── vdisp_nominal_kernel ──────────────────────────────────────────────────────
+
+@pytest.fixture(scope='module')
+def loaded_T(templates):
+    from fastspecfit.templates import Templates
+    return Templates(template_file=templates)
+
+
+class TestVdispNominal:
+    """Tests for the vdisp_nominal / vdisp_nominal_kernel distinction."""
+
+    def test_kernel_attribute_value(self, loaded_T):
+        """vdisp_nominal_kernel == sqrt(vdisp_nominal² − SIGMA_C3K²)."""
+        from fastspecfit.templates import Templates, VDISP_NOMINAL
+        expected = float(np.sqrt(max(0., VDISP_NOMINAL**2 - Templates.SIGMA_C3K**2)))
+        assert np.isclose(loaded_T.vdisp_nominal_kernel, expected)
+
+    def test_kernel_less_than_nominal(self, loaded_T):
+        """Pre-convolution kernel is always less than the reported σ_stars."""
+        assert loaded_T.vdisp_nominal_kernel < loaded_T.vdisp_nominal
+
+    def test_flux_nomvdisp_uses_kernel_not_nominal(self, loaded_T):
+        """flux_nomvdisp matches convolving with vdisp_nominal_kernel, not vdisp_nominal."""
+        T = loaded_T
+        broadened_kernel = T.convolve_vdisp(T.flux, T.vdisp_nominal_kernel)
+        broadened_nominal = T.convolve_vdisp(T.flux, T.vdisp_nominal)
+        assert np.allclose(T.flux_nomvdisp, broadened_kernel)
+        assert not np.allclose(T.flux_nomvdisp, broadened_nominal)
+
+    def test_reversed_bounds_raises(self, templates):
+        """Reversed vdisp_bounds raises ValueError with a clear message."""
+        from fastspecfit.templates import Templates
+        with pytest.raises(ValueError, match='lo <= hi'):
+            Templates(template_file=templates, vdisp_bounds=(500., 50.))
+
+
+# ── σ–M* relation constants and kernel formula ────────────────────────────────
+
+class TestVdispSigmaRelation:
+
+    def test_default_coefficients(self):
+        from fastspecfit.templates import VDISP_SIGMA_RELATION
+        assert VDISP_SIGMA_RELATION == (2.30, 0.25)
+
+    def test_lower_bound_is_50(self):
+        from fastspecfit.templates import VDISP_BOUNDS
+        assert VDISP_BOUNDS[0] == 50.
+
+    def test_formula_at_reference_mass(self):
+        """At log M* = 11, σ_stars = 10^a exactly (the b term vanishes)."""
+        from fastspecfit.templates import VDISP_SIGMA_RELATION
+        a, b = VDISP_SIGMA_RELATION
+        vdisp_stars = 10.**(a + b * (11.0 - 11.))
+        assert np.isclose(vdisp_stars, 10.**a)
+
+    def test_kernel_roundtrip(self):
+        """sqrt(kernel² + SIGMA_C3K²) recovers σ_stars to floating-point precision."""
+        from fastspecfit.templates import Templates, VDISP_SIGMA_RELATION, VDISP_BOUNDS
+        a, b = VDISP_SIGMA_RELATION
+        vdisp_stars = 10.**(a + b * (11.0 - 11.))
+        vdisp_kernel = float(np.sqrt(max(0., vdisp_stars**2 - Templates.SIGMA_C3K**2)))
+        vdisp_kernel = float(np.clip(vdisp_kernel, *VDISP_BOUNDS))
+        assert np.isclose(np.sqrt(vdisp_kernel**2 + Templates.SIGMA_C3K**2), vdisp_stars)
+
+    def test_low_mstar_clamps_to_lower_bound(self):
+        """Very low M* (σ_stars < SIGMA_C3K) clamps kernel to vdisp_bounds[0]."""
+        from fastspecfit.templates import Templates, VDISP_SIGMA_RELATION, VDISP_BOUNDS
+        a, b = VDISP_SIGMA_RELATION
+        vdisp_stars = 10.**(a + b * (6.0 - 11.))  # ~11 km/s << SIGMA_C3K ~42 km/s
+        vdisp_kernel = float(np.sqrt(max(0., vdisp_stars**2 - Templates.SIGMA_C3K**2)))
+        vdisp_kernel = float(np.clip(vdisp_kernel, *VDISP_BOUNDS))
+        assert vdisp_kernel == VDISP_BOUNDS[0]

--- a/py/fastspecfit/test/test_templates.py
+++ b/py/fastspecfit/test/test_templates.py
@@ -45,13 +45,11 @@ class TestVdispNominal:
         """Pre-convolution kernel is always less than the reported σ_stars."""
         assert loaded_T.vdisp_nominal_kernel < loaded_T.vdisp_nominal
 
-    def test_flux_nomvdisp_uses_kernel_not_nominal(self, loaded_T):
-        """flux_nomvdisp matches convolving with vdisp_nominal_kernel, not vdisp_nominal."""
+    def test_flux_nomvdisp_uses_kernel(self, loaded_T):
+        """flux_nomvdisp is broadened by vdisp_nominal_kernel."""
         T = loaded_T
         broadened_kernel = T.convolve_vdisp(T.flux, T.vdisp_nominal_kernel)
-        broadened_nominal = T.convolve_vdisp(T.flux, T.vdisp_nominal)
         assert np.allclose(T.flux_nomvdisp, broadened_kernel)
-        assert not np.allclose(T.flux_nomvdisp, broadened_nominal)
 
     def test_reversed_bounds_raises(self, templates):
         """Reversed vdisp_bounds raises ValueError with a clear message."""


### PR DESCRIPTION
## Summary

- Fix inverted `VDISP_IVAR` Jacobian: was `(kernel/σ_stars)²`, now `(σ_stars/kernel)²`
- Lower `VDISP_BOUNDS` floor from 100 → 50 km/s
- Increase chi2 scan from 5 → 6 grid points
- Use a σ–M* scaling relation (`log σ = 2.30 + 0.25*(log M* − 11)`) as a fallback when vdisp cannot be measured, instead of a scalar nominal; `VDISP_IVAR = 0` flags these cases
- Report `VDISP_NOMINAL = 150 km/s` as the σ_stars value (with template dispersion removed) so that unfitted objects show exactly 150 km/s in the catalog; the pre-convolution kernel (`vdisp_nominal_kernel ≈ 143.9 km/s`) is derived internally in `Templates`
- Validate `vdisp_bounds` ordering in `Templates.__init__` (raises `ValueError` with `log.critical` if reversed)
- New unit tests covering the kernel/σ_stars distinction, IVAR Jacobian, σ–M* formula, and bounds validation

## Test plan

- [x] `pytest py/fastspecfit/test/test_templates.py` — new `TestVdispNominal` and `TestVdispSigmaRelation`
- [x] `pytest py/fastspecfit/test/test_continuum.py` — new `TestVdispIvarJacobian` and `test_vdisp_nbin_default_is_6`
- [x] `pytest py/fastspecfit/test/test_fastspecfit.py` — existing integration tests

Closes #258. See also #266 (constant-vdisp feature, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)