### PR TITLE
dynamically split `FASTSPEC` HDU into an additional `MORELINES` HDU

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,12 +5,15 @@ Change Log
 3.6.0 (not released yet)
 ------------------------
 
+* Dynamically split ``FASTSPEC`` HDU into an additional ``MORELINES``
+  HDU [`PR #273`_].
 * Switch to new default templates (version 3.0.0) built from a
   higher-resolution (``R=10000``) C3K library [`PR #271`_].
 * Pass ``constraintsfile`` argument to ``fastqa`` [`PR #270`_].
 * New unit test and documentation of external photometric catalog
   "mode" [`PR #269`_].
 
+.. _`PR #273`: https://github.com/desihub/fastspecfit/pull/273
 .. _`PR #271`: https://github.com/desihub/fastspecfit/pull/271
 .. _`PR #270`: https://github.com/desihub/fastspecfit/pull/270
 .. _`PR #269`: https://github.com/desihub/fastspecfit/pull/269

--- a/py/fastspecfit/data/emline-constraints-hii.yaml
+++ b/py/fastspecfit/data/emline-constraints-hii.yaml
@@ -1,0 +1,387 @@
+# FastSpecFit emission-line kinematic constraints
+# ================================================
+# Companion file to emlines.ecsv. Every line defined in emlines.ecsv
+# must appear exactly once in each profile, placed in one of:
+#   - a kinematic_group (as anchor or member)
+#   - free_lines  (independently fitted kinematics)
+#   - fixed_lines (amplitude fixed to zero, not fitted)
+# Lines in the global section are shared across all profiles and do not
+# need to be repeated in each profile. A startup consistency check
+# verifies that the union of placements equals the emlines.ecsv line list.
+#
+# Units:  sigma  [km/s],  vshift [km/s],  amplitude [10^-17 erg/s/cm^2/A]
+#
+# Schema rules (enforced at startup):
+#   - Every key under kinematic_groups.members, free_lines, and fixed_lines
+#     must be a name that exists in emlines.ecsv (or line_components below).
+#   - Every anchor must also exist in emlines.ecsv.
+#   - amplitude_constraints.fixed[].line and .ref must exist in emlines.ecsv.
+#   - amplitude_constraints.doublet_ratios[].line and .ref must exist in emlines.ecsv.
+#   - line_components[].base_line must exist in emlines.ecsv.
+#   - Within a profile, no line name may appear more than once across all placements.
+#   - bounds.sigma.min >= 0; bounds.sigma.min < bounds.sigma.max.
+#   - bounds.vshift.min < bounds.vshift.max.
+#   - Every kinematic group (global and profile-level) must contain a final_pass block.
+#   - profiles.<name>.final_pass.adopt_if in {always, chi2_improves}.
+#   - Every profile must contain a final_pass block with all required keys.
+
+
+# =============================================================================
+# SECTION 1: Line component extensions
+# =============================================================================
+# Additional kinematic components beyond those in emlines.ecsv.
+# Add entries here when introducing outflow components, narrow sub-components
+# of broad lines, etc. Each entry must supply base_line (the existing
+# emlines.ecsv line at the same rest wavelength), and it must then appear
+# in a kinematic_group or free_lines in every profile.
+
+line_components: []
+
+
+# =============================================================================
+# SECTION 2: Amplitude constraints  (profile-independent)
+# =============================================================================
+# These apply regardless of which kinematic profile is active.
+
+amplitude_constraints:
+
+  # Fixed ratios: constrained amplitude = factor * reference amplitude.
+  # Factors encode the theoretical flux ratio corrected to velocity-space
+  # amplitudes (flux_ratio * lambda_constrained / lambda_reference).
+  # See comments in emlines.py for references.
+  fixed:
+    - line: nii_6548
+      ref:  nii_6584
+      factor: 0.32975    # 1/3.0326  ([NII] flux ratio 3.049, lambda-corrected)
+      param_name: NII_DOUBLET_RATIO
+    - line: oiii_4959
+      ref:  oiii_5007
+      factor: 0.33735    # 1/2.9643  ([OIII] flux ratio 2.993, lambda-corrected)
+      param_name: OIII_DOUBLET_RATIO
+    - line: oii_7330
+      ref:  oii_7320
+      factor: 0.81633    # 1/1.225
+      param_name: OIIRED_DOUBLET_RATIO
+
+  # Doublet ratios: amplitude ratio is a free fitted parameter.
+  # The ratio is defined as line / ref, bounded as below.
+  # param_name is what appears in the output catalog.
+  doublet_ratios:
+    - line:       oii_3726
+      ref:        oii_3729
+      param_name: oii_doublet_ratio
+      bounds:     {min: 0.0, max: 2.0}
+      initial:    1.0
+    - line:       sii_6731
+      ref:        sii_6716
+      param_name: sii_doublet_ratio
+      bounds:     {min: 0.0, max: 2.0}
+      initial:    1.0
+    - line:       mgii_2796
+      ref:        mgii_2803
+      param_name: mgii_doublet_ratio
+      bounds:     {min: 0.0, max: 10.0}
+      initial:    1.0
+
+
+# =============================================================================
+# SECTION 3: Global placements  (apply to every profile)
+# =============================================================================
+# Lines here do not need to be listed again in any profile.
+
+global:
+
+  # Default bounds and initial guesses for all lines in global.free_lines.
+  # Individual lines can override these by using the long-form entry below.
+  default_bounds:
+    sigma:  {min: 1.0, max: 10000.0}
+    vshift: {min: -2500.0, max: 2500.0}
+  default_initial:
+    sigma:  3000.0    # km/s; data-derived estimates override this at runtime
+    vshift: 0.0
+
+  # Lines with fully independent kinematics in every profile.
+  # These are UV and optical AGN/QSO-type lines (all isbroad=True,
+  # isbalmer=False in emlines.ecsv).
+  free_lines:
+    - heii_4686
+
+  # Small kinematic pairs that are tied to each other but free from
+  # all profile-level groups. Bounds use the global UV/QSO defaults above.
+  kinematic_groups:
+
+    - name: mgii_pair
+      # MgII 2796 kinematics follow MgII 2803; amplitude ratio is a free
+      # doublet parameter defined in amplitude_constraints.doublet_ratios.
+      anchor: mgii_2803
+      bounds:
+        sigma:  {min: 1.0,     max: 10000.0}
+        vshift: {min: -2500.0, max: 2500.0}
+      initial:
+        sigma:  3000.0
+        vshift: 0.0
+      members:
+        - mgii_2796
+      final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: 500.0, delta_sigma_max: 1000.0}
+
+
+# =============================================================================
+# SECTION 4: Named kinematic profiles
+# =============================================================================
+# At runtime one profile pair (narrow_only + narrow_broad) is loaded.
+# Add new profiles here to experiment with different constraint schemes.
+#
+# Per-group fields:
+#   anchor          [string]  : line name; its vshift and sigma are the free parameters
+#   bounds          [mapping] : hard optimizer bounds applied to the anchor's vshift/sigma
+#   initial         [mapping] : default starting point (overridden by data-derived estimates)
+#   members         [list]    : lines tied to anchor with factor 1.0 for vshift and sigma
+#   final_pass      [mapping] : per-group relaxation policy (see below)
+#
+# Per-group final_pass fields:
+#   free_vshift     [bool]    : release vshift ties for all members in the final pass
+#   free_sigma      [bool]    : release sigma ties for all members in the final pass
+#   delta_vshift_max [float|null] : reserved; max vshift deviation from warm-start (not yet used)
+#   delta_sigma_max  [float|null] : reserved; max sigma deviation from warm-start (not yet used)
+#
+# Amplitude bounds (min: 0, max: data-derived) are set in _initial_guesses_and_bounds
+# and are not specified here.
+
+profiles:
+
+  # ---------------------------------------------------------------------------
+  narrow_only:
+  # ---------------------------------------------------------------------------
+  # Preferred when no significant broad Balmer component is detected.
+  # Two kinematic groups: all forbidden lines share [OIII] 5007; all narrow
+  # Balmer + HeI share Halpha. Broad Balmer amplitudes are fixed to zero.
+
+    kinematic_groups:
+
+      - name: forbidden
+        anchor: oiii_5007
+        bounds:
+          sigma:  {min: 1.0,    max: 750.0}
+          vshift: {min: -500.0, max: 500.0}
+        initial:
+          sigma:  150.0
+          vshift: 0.0
+        members:
+          - nev_3346
+          - nev_3426
+          - oii_3726      # amplitude also constrained via doublet_ratios
+          - oii_3729
+          - neiii_3869
+          - neiii_3968
+          - sii_4069
+          - sii_4076
+          - feii_4288
+          - feii_4360
+          - oiii_4363
+          - ariv_4711
+          - ariv_4740
+          - oiii_4959     # amplitude also constrained via amplitude_constraints.fixed
+          - nii_5755
+          - oi_6300
+          - siii_6312
+          - nii_6548      # amplitude also constrained via amplitude_constraints.fixed
+          - nii_6584
+          - sii_6716
+          - sii_6731      # amplitude also constrained via doublet_ratios
+          - ariii_7135
+          - oii_7320
+          - oii_7330      # amplitude also constrained via amplitude_constraints.fixed
+          - siii_9069
+          - siii_9532
+        final_pass: {free_vshift: true, free_sigma: false, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
+
+      - name: narrow_balmer
+        anchor: halpha
+        bounds:
+          sigma:  {min: 1.0,    max: 750.0}
+          vshift: {min: -500.0, max: 500.0}
+        initial:
+          sigma:  150.0
+          vshift: 0.0
+        members:
+          - h12
+          - h11
+          - h10
+          - h9
+          - h8
+          - hepsilon
+          - hdelta
+          - hgamma
+          - hbeta
+          - pa15
+          - pa14
+          - pa13
+          - pa12
+          - pa11
+          - pa10
+          - pa9
+          - pa8
+          - hei_4026
+          - hei_4388
+          - hei_4471
+          - hei_4713
+          - hei_4922
+          - hei_5016
+          - hei_5876
+          - hei_6678
+          - hei_7065
+          - hei_7281
+        final_pass: {free_vshift: true, free_sigma: false, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
+
+    free_lines: []
+
+    # Broad Balmer components are not fitted in this model.
+    fixed_lines:
+      - halpha_broad
+      - hbeta_broad
+      - hgamma_broad
+      - hdelta_broad
+      - hepsilon_broad
+
+    # Fitting strategy for this profile: what to relax is specified per group above.
+    final_pass:
+      enabled:       true
+      warm_start:    true        # initialize from the primary best-fit values
+      adopt_if:      chi2_improves   # "always" | "chi2_improves"
+      inherit_in_mc: true        # MC realizations mirror the final-pass decision
+
+  # ---------------------------------------------------------------------------
+  narrow_broad:
+  # ---------------------------------------------------------------------------
+  # Preferred when a significant broad Balmer component is detected.
+  # Three kinematic groups: all narrow lines (Balmer + forbidden) share
+  # [NII] 6584; [OIII] 4959,5007 have separate kinematics; broad Balmer + HeI
+  # share Halpha_broad. The [OIII] doublet is kept separate because it
+  # frequently shows an outflow component distinct from the other forbidden lines.
+
+    kinematic_groups:
+
+      - name: narrow_all
+        # All narrow lines — Balmer, HeI, and forbidden — share one kinematic
+        # anchor. [OIII] 4959,5007 are excluded (handled in oiii_doublet below).
+        anchor: halpha
+        bounds:
+          sigma:  {min: 1.0,    max: 750.0}
+          vshift: {min: -500.0, max: 500.0}
+        initial:
+          sigma:  150.0
+          vshift: 0.0
+        members:
+          - nev_3346
+          - nev_3426
+          - oii_3726      # amplitude also constrained via doublet_ratios
+          - oii_3729
+          - neiii_3869
+          - neiii_3968
+          - sii_4069
+          - sii_4076
+          - feii_4288
+          - feii_4360
+          - oiii_4363
+          - ariv_4711
+          - ariv_4740
+          - nii_5755
+          - oi_6300
+          - siii_6312
+          - nii_6548      # amplitude also constrained via amplitude_constraints.fixed
+          - nii_6584
+          - sii_6716
+          - sii_6731      # amplitude also constrained via doublet_ratios
+          - ariii_7135
+          - oii_7320
+          - oii_7330      # amplitude also constrained via amplitude_constraints.fixed
+          - siii_9069
+          - siii_9532
+          - h12
+          - h11
+          - h10
+          - h9
+          - h8
+          - hepsilon
+          - hdelta
+          - hgamma
+          - hbeta
+          - pa15
+          - pa14
+          - pa13
+          - pa12
+          - pa11
+          - pa10
+          - pa9
+          - pa8
+          - hei_4026
+          - hei_4388
+          - hei_4471
+          - hei_4713
+          - hei_4922
+          - hei_5016
+          - hei_5876
+          - hei_6678
+          - hei_7065
+          - hei_7281
+          # Free individual vshifts to absorb wavelength calibration offsets;
+        # keep sigma tied so the line-width constraint stabilises the blend.
+        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
+
+      - name: oiii_doublet
+        anchor: oiii_5007
+        bounds:
+          sigma:  {min: 1.0,    max: 750.0}
+          vshift: {min: -500.0, max: 500.0}
+        initial:
+          sigma:  150.0
+          vshift: 0.0
+        members:
+          - oiii_4959   # amplitude also constrained via amplitude_constraints.fixed
+        # Keep the doublet fully tied at all times.
+        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: 100.0, delta_sigma_max: 100.0}
+
+      - name: broad_balmer
+        anchor: halpha_broad
+        bounds:
+          sigma:  {min: 1.0,     max: 10000.0}
+          vshift: {min: -2500.0, max: 2500.0}
+        initial:
+          sigma:  1000.0
+          vshift: 0.0
+        members:
+          - hbeta_broad
+          - hgamma_broad
+          - hdelta_broad
+          - hepsilon_broad
+        # Keep broad Balmer lines fully tied: faint higher-order members need
+        # the constraint provided by the bright halpha_broad anchor.
+        final_pass: {free_vshift: false, free_sigma: false, delta_vshift_max: 500.0, delta_sigma_max: 1000.0}
+
+    free_lines:  []
+    fixed_lines: []
+
+    # Fitting strategy for this profile: what to relax is specified per group above.
+    final_pass:
+      enabled:       true
+      warm_start:    true
+      adopt_if:      chi2_improves
+      inherit_in_mc: true
+
+
+# =============================================================================
+# SECTION 5: Non-parametric spectral moments
+# =============================================================================
+# Lines (or line groups) for which non-parametric flux moments are measured
+# in addition to the fitted Gaussian parameters.  Each entry maps an output
+# column prefix (label) to one or more line names from emlines.ecsv.
+# Multiple lines with the same label are aggregated before moment computation
+# (e.g. a doublet treated as a single feature).
+
+moments:
+  - label: MGII_2800
+    lines: [mgii_2796, mgii_2803]
+  - label: HBETA
+    lines: [hbeta]
+  - label: OIII_5007
+    lines: [oiii_5007]

--- a/py/fastspecfit/data/emlines-hii.ecsv
+++ b/py/fastspecfit/data/emlines-hii.ecsv
@@ -1,0 +1,85 @@
+# %ECSV 1.0
+# ---
+# datatype:
+# - {name: name, datatype: string}
+# - {name: restwave, datatype: float64}
+# - {name: patch, datatype: string}
+# - {name: isbalmer, datatype: bool}
+# - {name: ishelium, datatype: bool}
+# - {name: isbroad, datatype: bool}
+# - {name: isstrong, datatype: bool}
+# - {name: nicename, datatype: string}
+# - {name: plotgroup, datatype: string}
+# meta: !!omap
+# - {description: 'Emission lines to be fit by fastspec. Wavelengths are in the vacuum, rest-frame Angstroms. Wavelength references: *
+#     NIST - https://physics.nist.gov/PhysRefData/ASD/lines_form.html (observed, not Ritz, except as noted) * All the Balmer & Lyman lines
+#     * All the HeI lines * MgII 2796,2803 * [NeV] 3346,3426; [NeIII] 3869; [OII] 3726,29; [SII] 6716,31; [ArIII] 7135; and [OII] 7320,30
+#     * (Ritz) - [OI] 6300; [SIII] 6312; and [SIII] 9069,9532 * vanden Berk et al. 2001 - https://iopscience.iop.org/article/10.1086/321167/pdf,
+#     Table 2 * [NV] 1240; OI 1304; Si IV 1396; CIV 1549; AlIII 1857; Si III] 1892; CIII] 1908; HeII 1640; and HeII 4686 * Chianti Database
+#     - https://db.chiantidatabase.org; https://aas.aanda.org/articles/aas/pdf/1997/13/ds1260.pdf * [NII] 5755; [NII] 6548,84; [OIII]
+#     4363; and [OIII] 4959,5007 * Note that the Chianti [SIII] 9069,9532 wavelengths are quite wrong.'}
+# schema: astropy-2.0
+name restwave patch isbalmer ishelium isbroad isstrong nicename plotgroup
+     mgii_2796 2796.352  g False False True  True  MgII-$\lambda\lambda$2796,2803                            mgii_2796_2803
+     mgii_2803 2803.53   g False False True  True  MgII-$\lambda\lambda$2796,2803                            mgii_2796_2803
+      nev_3346 3346.79   h False False False False [NeV]-$\lambda$3346                                       nev_3346
+      nev_3426 3426.85   h False False False False [NeV]-$\lambda$3426                                       nev_3426
+      oii_3726 3727.1    i False False False True  [OII]-$\lambda\lambda$3726,29                             oii_3726_29
+      oii_3729 3729.86   i False False False True  [OII]-$\lambda\lambda$3726,29                             oii_3726_29
+           h12 3751.216  j True  False False False [NeIII]-$\lambda$3869+H8-12                               neiii_3869_h6
+           h11 3771.701  j True  False False False [NeIII]-$\lambda$3869+H8-12                               neiii_3869_h6
+           h10 3798.978  j True  False False False [NeIII]-$\lambda$3869+H8-12                               neiii_3869_h6
+            h9 3836.478  j True  False False False [NeIII]-$\lambda$3869+H8-12                               neiii_3869_h6
+    neiii_3869 3869.86   j False False False False [NeIII]-$\lambda$3869+H8-12                               neiii_3869_h6
+            h8 3890.166  j True  False False False [NeIII]-$\lambda$3869+H8-12                               neiii_3869_h6
+    neiii_3968 3968.593  k False False False False H$\epsilon$+[NeIII]-$\lambda$3968+HeI-$\lambda$4026       hepsilon
+      hepsilon 3971.198  k True  False False False H$\epsilon$+[NeIII]-$\lambda$3968+HeI-$\lambda$4026       hepsilon
+hepsilon_broad 3971.198  k True  False True  False H$\epsilon$+[NeIII]-$\lambda$3968+HeI-$\lambda$4026       hepsilon
+      hei_4026 4027.329  k True  True  False False H$\epsilon$+[NeIII]-$\lambda$3968+HeI-$\lambda$4026       hepsilon
+      sii_4069 4069.75   l False False False False [SII]-$\lambda\lambda$4069,76+H$\delta$                   hdelta
+      sii_4076 4077.5    l False False False False [SII]-$\lambda\lambda$4069,76+H$\delta$                   hdelta
+        hdelta 4102.892  l True  False False False [SII]-$\lambda\lambda$4069,76+H$\delta$                   hdelta
+  hdelta_broad 4102.892  l True  False True  False [SII]-$\lambda\lambda$4069,76+H$\delta$                   hdelta
+     feii_4288 4288.599  m False False False False H$\gamma$+[FeII]+[OIII]-$\lambda$4363                     hgamma_oiii_4363
+        hgamma 4341.692  m True  False False True  H$\gamma$+[FeII]+[OIII]-$\lambda$4363                     hgamma_oiii_4363
+  hgamma_broad 4341.692  m True  False True  True  H$\gamma$+[FeII]+[OIII]-$\lambda$4363                     hgamma_oiii_4363
+     feii_4360 4359.387  m False False False False H$\gamma$+[FeII]+[OIII]-$\lambda$4363                     hgamma_oiii_4363
+     oiii_4363 4364.436  m False False False False H$\gamma$+[FeII]+[OIII]-$\lambda$4363                     hgamma_oiii_4363
+      hei_4388 4389.162  n True  True  False False HeI-$\lambda\lambda$4388,4471                             hei_4471
+      hei_4471 4472.735  n True  True  False False HeI-$\lambda\lambda$4388,4471                             hei_4471
+     heii_4686 4687.02   o False True  True  False HeII-$\lambda$4686+[ArIV]-$\lambda\lambda$4711,40         heii_4686
+     ariv_4711 4712.67   o False False False False HeII-$\lambda$4686+[ArIV]-$\lambda\lambda$4711,40         heii_4686
+      hei_4713 4714.4644 o False True  False False HeII-$\lambda$4686+[ArIV]-$\lambda\lambda$4711,40         heii_4686
+     ariv_4740 4741.495  o False False False False HeII-$\lambda$4686+[ArIV]-$\lambda\lambda$4711,40         heii_4686
+         hbeta 4862.71   p True  False False True  H$\beta$-$\lambda$4861                                    hbeta
+   hbeta_broad 4862.71   p True  False True  True  H$\beta$-$\lambda$4861                                    hbeta
+      hei_4922 4923.304  p False True  False False HeI+[OIII]-$\lambda\lambda$4959,5007                      oiii_doublet
+     oiii_4959 4960.295  p False False False True  HeI+[OIII]-$\lambda\lambda$4959,5007                      oiii_doublet
+     oiii_5007 5008.24   p False False False True  HeI+[OIII]-$\lambda\lambda$4959,5007                      oiii_doublet
+      hei_5016 5017.42   r True  True  False False HeI+[OIII]-$\lambda\lambda$4959,5007                      oiii_doublet
+      nii_5755 5756.191  q False False False False [NII]-$\lambda$5755                                       nii_5755
+      hei_5876 5877.249  r True  True  False False HeI-$\lambda$5876                                         hei_5876
+       oi_6300 6302.046  s False False False False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                   oi_6300_siii_6312
+     siii_6312 6313.81   s False False False False [OI]-$\lambda$6300+[SIII]-$\lambda$6312                   oi_6300_siii_6312
+      nii_6548 6549.861  t False False False True  H$\alpha$+[NII]-$\lambda\lambda$6548,84+HeI-$\lambda$6678 halpha_nii_6548_48
+        halpha 6564.6    t True  False False True  H$\alpha$+[NII]-$\lambda\lambda$6548,84+HeI-$\lambda$6678 halpha_nii_6548_48
+  halpha_broad 6564.6    t True  False True  True  H$\alpha$+[NII]-$\lambda\lambda$6548,84+HeI-$\lambda$6678 halpha_nii_6548_48
+      nii_6584 6585.273  t False False False True  H$\alpha$+[NII]-$\lambda\lambda$6548,84+HeI-$\lambda$6678 halpha_nii_6548_48
+      hei_6678 6679.995  t False True  False False H$\alpha$+[NII]-$\lambda\lambda$6548,84+HeI-$\lambda$6678 halpha_nii_6548_48
+      sii_6716 6718.294  u False False False True  [SII]-$\lambda\lambda$6716,31                             sii_6716_31
+      sii_6731 6732.674  u False False False True  [SII]-$\lambda\lambda$6716,31                             sii_6716_31
+      hei_7065 7067.138  v False True  False False [ArIII]-$\lambda$7135+[OII]-$\lambda\lambda$7320,30       ariii_7135_oii_7320_30
+    ariii_7135 7137.77   v False False False False [ArIII]-$\lambda$7135+[OII]-$\lambda\lambda$7320,30       ariii_7135_oii_7320_30
+      hei_7281 7283.356  v False True  False False [ArIII]-$\lambda$7135+[OII]-$\lambda\lambda$7320,30       ariii_7135_oii_7320_30
+      oii_7320 7321.94   v False False False False [ArIII]-$\lambda$7135+[OII]-$\lambda\lambda$7320,30       ariii_7135_oii_7320_30
+      oii_7330 7332.21   v False False False False [ArIII]-$\lambda$7135+[OII]-$\lambda\lambda$7320,30       ariii_7135_oii_7320_30
+          pa15 8547.727  w True  False False False P8-15                                                     paschen_series
+          pa14 8600.752  w True  False False False P8-15                                                     paschen_series
+          pa13 8667.4    w True  False False False P8-15                                                     paschen_series
+          pa12 8752.863  w True  False False False P8-15                                                     paschen_series
+          pa11 8865.323  w True  False False False P8-15                                                     paschen_series
+          pa10 9017.774  w True  False False False P8-15                                                     paschen_series
+     siii_9069 9071.1    w False False False False [SIII]-$\lambda$9069                                      siii_9069
+           pa9 9232.232  w True  False False False P8-15                                                     paschen_series
+     siii_9532 9533.2    w False False False False [SIII]-$\lambda$9532                                      siii_9532
+           pa8 9548.818  w True  False False False P8-15                                                     paschen_series

--- a/py/fastspecfit/data/emlines-hii.ecsv
+++ b/py/fastspecfit/data/emlines-hii.ecsv
@@ -73,13 +73,13 @@ hepsilon_broad 3971.198  k True  False True  False H$\epsilon$+[NeIII]-$\lambda$
       hei_7281 7283.356  v False True  False False [ArIII]-$\lambda$7135+[OII]-$\lambda\lambda$7320,30       ariii_7135_oii_7320_30
       oii_7320 7321.94   v False False False False [ArIII]-$\lambda$7135+[OII]-$\lambda\lambda$7320,30       ariii_7135_oii_7320_30
       oii_7330 7332.21   v False False False False [ArIII]-$\lambda$7135+[OII]-$\lambda\lambda$7320,30       ariii_7135_oii_7320_30
-          pa15 8547.727  w True  False False False P8-15                                                     paschen_series
-          pa14 8600.752  w True  False False False P8-15                                                     paschen_series
-          pa13 8667.4    w True  False False False P8-15                                                     paschen_series
-          pa12 8752.863  w True  False False False P8-15                                                     paschen_series
-          pa11 8865.323  w True  False False False P8-15                                                     paschen_series
-          pa10 9017.774  w True  False False False P8-15                                                     paschen_series
+          pa15 8547.727  w True  False False False P8--P15                                                   paschen_series
+          pa14 8600.752  w True  False False False P8--P15                                                   paschen_series
+          pa13 8667.4    w True  False False False P8--P15                                                   paschen_series
+          pa12 8752.863  w True  False False False P8--P15                                                   paschen_series
+          pa11 8865.323  w True  False False False P8--P15                                                   paschen_series
+          pa10 9017.774  w True  False False False P8--P15                                                   paschen_series
      siii_9069 9071.1    w False False False False [SIII]-$\lambda$9069                                      siii_9069
-           pa9 9232.232  w True  False False False P8-15                                                     paschen_series
+           pa9 9232.232  w True  False False False P8--P15                                                   paschen_series
      siii_9532 9533.2    w False False False False [SIII]-$\lambda$9532                                      siii_9532
-           pa8 9548.818  w True  False False False P8-15                                                     paschen_series
+           pa8 9548.818  w True  False False False P8--P15                                                   paschen_series

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -56,6 +56,21 @@ TSNR2COLS = ('TSNR2_BGS', 'TSNR2_LRG', 'TSNR2_ELG', 'TSNR2_QSO', 'TSNR2_LYA')
 QNLINES = ['C_LYA', 'C_CIV', 'C_CIII', 'C_MgII', 'C_Hbeta', 'C_Halpha', ]
 MGIICOLS = ['TARGETID', 'IS_QSO_MGII']
 
+# FITS binary tables cap out at 999 columns (TFIELDS). Past that, per-line
+# columns for isstrong=False lines move from FASTSPEC into a MORELINES HDU
+# (see write_fastspecfit/read_fastspecfit). Must match the per-line fields
+# added in get_output_dtype's line loop.
+MAX_FASTSPEC_COLUMNS = 999
+LINE_COLUMN_SUFFIXES = ('_MODELAMP', '_AMP', '_AMP_IVAR', '_FLUX', '_FLUX_IVAR',
+                        '_BOXFLUX', '_BOXFLUX_IVAR', '_VSHIFT', '_VSHIFT_IVAR',
+                        '_SIGMA', '_SIGMA_IVAR', '_CONT', '_CONT_IVAR', '_EW',
+                        '_EW_IVAR', '_FLUX_LIMIT', '_CHI2', '_NPIX')
+
+# identifying columns copied into MORELINES so it can be read/verified
+# independently of FASTSPEC/METADATA row order
+MORELINES_IDCOLS = ('TARGETID', 'STACKID', 'SURVEY', 'PROGRAM', 'TILEID',
+                    'NIGHT', 'FIBER', 'EXPID')
+
 def one_spectrum(specdata, meta, uncertainty_floor=0.01, RV=3.1,
                  init_sigma_uv=None, init_sigma_narrow=None,
                  init_sigma_balmer=None, init_vshift_uv=None,
@@ -1491,6 +1506,50 @@ class DESISpectra(object):
         return metas
 
 
+def read_fastspec_table(F, rows=None, columns=None):
+    """Read the FASTSPEC extension, transparently merging in MORELINES (the
+    isstrong=False emission-line columns, split out at write time when
+    FASTSPEC would otherwise exceed the FITS 999-column limit) if present.
+
+    Parameters
+    ----------
+    F : :class:`fitsio.FITS`
+        Open fastspecfit output file.
+    rows : array-like or None, optional
+        Row indices to read. If ``None``, read all rows.
+    columns : list of str or None, optional
+        Column names to read (from either FASTSPEC or MORELINES). If
+        ``None``, read all columns from both.
+
+    Returns
+    -------
+    fastfit : :class:`astropy.table.Table`
+        FASTSPEC and MORELINES columns merged into a single table.
+
+    """
+    if 'MORELINES' in F:
+        fastspec_avail = F['FASTSPEC'].get_colnames()
+        morelines_avail = F['MORELINES'].get_colnames()
+        if columns is not None:
+            fastspec_columns = [col for col in columns if col in fastspec_avail]
+            morelines_columns = [col for col in columns if col in morelines_avail
+                                 and col not in fastspec_avail]
+        else:
+            fastspec_columns = None
+            morelines_columns = None
+
+        fastfit = Table(F['FASTSPEC'].read(rows=rows, columns=fastspec_columns))
+        morelines = Table(F['MORELINES'].read(rows=rows, columns=morelines_columns))
+        keep = [col for col in morelines.colnames if col not in MORELINES_IDCOLS]
+        if keep:
+            from astropy.table import hstack
+            fastfit = hstack([fastfit, morelines[keep]], join_type='exact')
+    else:
+        fastfit = Table(F['FASTSPEC'].read(rows=rows, columns=columns))
+
+    return fastfit
+
+
 def read_fastspecfit(fastfitfile, rows=None, metadata_columns=None, specphot_columns=None,
                      fastspec_columns=None, read_models=False):
     """Read fastspecfit fitting results from a FITS file.
@@ -1534,7 +1593,7 @@ def read_fastspecfit(fastfitfile, rows=None, metadata_columns=None, specphot_col
 
         if 'FASTSPEC' in F:
             fastphot = False
-            fastfit = Table(F['FASTSPEC'].read(rows=rows, columns=fastspec_columns))
+            fastfit = read_fastspec_table(F, rows=rows, columns=fastspec_columns)
             if read_models:
                 models = F['MODELS'].read()
                 if rows is not None:
@@ -1643,8 +1702,40 @@ def write_fastspecfit(meta, specphot, fastfit, modelspectra=None, outfile=None,
 
     meta.meta['EXTNAME'] = 'METADATA'
     specphot.meta['EXTNAME'] = 'SPECPHOT'
+
+    morelines = None
     if fastfit is not None:
         fastfit.meta['EXTNAME'] = 'FASTSPEC'
+
+        if len(fastfit.colnames) > MAX_FASTSPEC_COLUMNS:
+            from fastspecfit.linetable import LineTable
+            linetable = LineTable(emlines_file=emlinesfile).table
+
+            weaklines = set(name.upper() for name, isstrong in
+                            zip(linetable['name'], linetable['isstrong']) if not isstrong)
+
+            morelines_cols = [f'{line}{suffix}' for line in weaklines
+                              for suffix in LINE_COLUMN_SUFFIXES
+                              if f'{line}{suffix}' in fastfit.colnames]
+
+            if morelines_cols:
+                idcols = [col for col in MORELINES_IDCOLS if col in meta.colnames]
+                morelines = Table()
+                for col in idcols:
+                    morelines[col] = meta[col]
+                for col in morelines_cols:
+                    morelines[col] = fastfit[col]
+                morelines.meta['EXTNAME'] = 'MORELINES'
+
+                # select (not remove_columns), so the caller's fastfit Table
+                # is not mutated in place
+                keepcols = [col for col in fastfit.colnames if col not in morelines_cols]
+                fastfit = fastfit[keepcols]
+                fastfit.meta['EXTNAME'] = 'FASTSPEC'
+
+                log.info(f'FASTSPEC would have {len(fastfit.colnames)+len(morelines_cols):,d} columns '
+                        f'(>{MAX_FASTSPEC_COLUMNS}); moved {len(morelines_cols):,d} columns for '
+                        f'{len(weaklines):,d} weak lines to a MORELINES HDU.')
 
     hdu_primary = fits.PrimaryHDU(None, primhdr)
 
@@ -1654,6 +1745,8 @@ def write_fastspecfit(meta, specphot, fastfit, modelspectra=None, outfile=None,
         hdu_specphot = fits.convenience.table_to_hdu(specphot)
         if fastfit is not None:
             hdu_fastfit = fits.convenience.table_to_hdu(fastfit)
+        if morelines is not None:
+            hdu_morelines = fits.convenience.table_to_hdu(morelines)
 
         if modelspectra is not None:
             hdu_data = fits.ImageHDU(name='MODELS')
@@ -1701,6 +1794,9 @@ def write_fastspecfit(meta, specphot, fastfit, modelspectra=None, outfile=None,
             if fastfit is not None:
                 hdu_fastfit = fits.convenience.table_to_hdu(fastfit[I])
                 hdus.append(hdu_fastfit)
+            if morelines is not None:
+                hdu_morelines = fits.convenience.table_to_hdu(morelines[I])
+                hdus.append(hdu_morelines)
             if outfile.endswith('.gz'):
                 outfile_pixel = outfile.replace('.fits.gz', f'-nside{nside}-hp{upixel:02}.fits.gz')
             else:
@@ -1713,6 +1809,9 @@ def write_fastspecfit(meta, specphot, fastfit, modelspectra=None, outfile=None,
         if fastfit is not None:
             hdu_list.append(hdu_fastfit)
             suffix_list.append('fastspec')
+        if morelines is not None:
+            hdu_list.append(hdu_morelines)
+            suffix_list.append('morelines')
         if modelspectra is not None:
             hdu_list.append(hdu_data)
             suffix_list.append('models')
@@ -1734,6 +1833,8 @@ def write_fastspecfit(meta, specphot, fastfit, modelspectra=None, outfile=None,
         hdus.append(hdu_specphot)
         if fastfit is not None:
             hdus.append(hdu_fastfit)
+        if morelines is not None:
+            hdus.append(hdu_morelines)
         if modelspectra is not None:
             hdus.append(hdu_data)
         write(hdus, tmpfile, outfile)

--- a/py/fastspecfit/mpi.py
+++ b/py/fastspecfit/mpi.py
@@ -455,13 +455,15 @@ def _read_to_merge_one(args):
 
 def read_to_merge_one(filename, fastphot):
     """Read metadata, specphot, and fastfit tables from one output file."""
+    from fastspecfit.io import read_fastspec_table
+
     info = fitsio.FITS(filename)
     meta = Table(info['METADATA'].read())
     specphot = Table(info['SPECPHOT'].read())
     if fastphot:
         fastfit = None
     else:
-        fastfit = Table(info['FASTSPEC'].read())
+        fastfit = read_fastspec_table(info)
     return meta, specphot, fastfit
 
 

--- a/py/fastspecfit/photometry.py
+++ b/py/fastspecfit/photometry.py
@@ -1349,7 +1349,8 @@ def gather_tractorphot(input_cat, racolumn='TARGET_RA', deccolumn='TARGET_DEC',
         legacysurveydir = os.path.join(desi_root, 'external', 'legacysurvey', 'dr9')
 
     if not os.path.isdir(legacysurveydir):
-        errmsg = f'Legacy Surveys directory {legacysurveydir} not found.'
+        errmsg = (f'Legacy Surveys directory {legacysurveydir} not found; set the correct '
+                  f'path via --fphotodir or the $FPHOTO_DIR environment variable.')
         log.critical(errmsg)
         raise IOError(errmsg)
 

--- a/py/fastspecfit/test/conftest.py
+++ b/py/fastspecfit/test/conftest.py
@@ -98,6 +98,25 @@ def fastspec_output(filenames, templates):
 
 
 @pytest.fixture(scope='session')
+def fastspec_hii_output(filenames, templates, outdir):
+    """fastspec with the HII-region maximal line list (--emlinesfile/
+    --constraintsfile): 63 lines, enough to exceed the FITS 999-column limit
+    and trigger the FASTSPEC/MORELINES HDU split (see issue #236)."""
+    from importlib import resources
+    from fastspecfit.fastspecfit import fastspec, parse
+    emlinesfile = str(resources.files('fastspecfit').joinpath('data/emlines-hii.ecsv'))
+    constraintsfile = str(resources.files('fastspecfit').joinpath('data/emline-constraints-hii.yaml'))
+    outfile = os.path.join(outdir, 'fastspec-hii.fits')
+    cmd = (f'fastspec {filenames["redrockfile"]} -o {outfile} '
+           f'--redux_dir {filenames["redux_dir"]} '
+           f'--mapdir {filenames["mapdir"]} --fphotodir {filenames["fphotodir"]} '
+           f'--specproddir {filenames["specproddir"]} --templates {templates} '
+           f'--emlinesfile {emlinesfile} --constraintsfile {constraintsfile}')
+    fastspec(args=parse(options=cmd.split()[1:]))
+    yield outfile
+
+
+@pytest.fixture(scope='session')
 def stackfit_output(filenames, templates):
     from fastspecfit.fastspecfit import stackfit, parse
     outfile = filenames['stackfit_outfile']

--- a/py/fastspecfit/test/conftest.py
+++ b/py/fastspecfit/test/conftest.py
@@ -116,7 +116,6 @@ def fastspec_output(filenames, templates):
 
 
 @pytest.fixture(scope='session')
-<<<<<<< HEAD
 def fastspec_hii_output(filenames, templates, outdir):
     """fastspec with the HII-region maximal line list (--emlinesfile/
     --constraintsfile): 63 lines, enough to exceed the FITS 999-column limit
@@ -126,22 +125,26 @@ def fastspec_hii_output(filenames, templates, outdir):
     emlinesfile = str(resources.files('fastspecfit').joinpath('data/emlines-hii.ecsv'))
     constraintsfile = str(resources.files('fastspecfit').joinpath('data/emline-constraints-hii.yaml'))
     outfile = os.path.join(outdir, 'fastspec-hii.fits')
-=======
+    cmd = (f'fastspec {filenames["redrockfile"]} -o {outfile} '
+           f'--redux_dir {filenames["redux_dir"]} '
+           f'--mapdir {filenames["mapdir"]} --fphotodir {filenames["fphotodir"]} '
+           f'--specproddir {filenames["specproddir"]} --templates {templates} '
+           f'--emlinesfile {emlinesfile} --constraintsfile {constraintsfile}')
+    fastspec(args=parse(options=cmd.split()[1:]))
+    yield outfile
+
+
+@pytest.fixture(scope='session')
 def fastspec_fixedvdisp_output(filenames, templates, outdir):
     """fastspec with equal --vdisp-bounds: fixed convolution kernel, no
     chi2 scan/optimizer (see issue #266)."""
     from fastspecfit.fastspecfit import fastspec, parse
     outfile = os.path.join(outdir, 'fastspec-fixedvdisp.fits')
->>>>>>> main
     cmd = (f'fastspec {filenames["redrockfile"]} -o {outfile} '
            f'--redux_dir {filenames["redux_dir"]} '
            f'--mapdir {filenames["mapdir"]} --fphotodir {filenames["fphotodir"]} '
            f'--specproddir {filenames["specproddir"]} --templates {templates} '
-<<<<<<< HEAD
-           f'--emlinesfile {emlinesfile} --constraintsfile {constraintsfile}')
-=======
            f'--vdisp-bounds 0 0')
->>>>>>> main
     fastspec(args=parse(options=cmd.split()[1:]))
     yield outfile
 

--- a/py/fastspecfit/test/test_emline_constraints.py
+++ b/py/fastspecfit/test/test_emline_constraints.py
@@ -180,6 +180,32 @@ class TestConsistencyCheck:
             EmlineConstraints(constraints_file=str(bad_yaml), line_table=line_table)
 
 
+class TestHIIConsistencyCheck:
+    """The HII-region maximal line list (data/emlines-hii.ecsv) and its
+    constraints file (data/emline-constraints-hii.yaml) must be consistent
+    with one another, same as the default files above."""
+
+    @pytest.fixture(scope='class')
+    def hii_line_table(self):
+        from importlib import resources
+        from fastspecfit.linetable import LineTable
+        emlines_file = str(resources.files('fastspecfit').joinpath('data/emlines-hii.ecsv'))
+        return LineTable(emlines_file=emlines_file).table
+
+    @pytest.fixture(scope='class')
+    def hii_constraints_file(self):
+        from importlib import resources
+        return str(resources.files('fastspecfit').joinpath('data/emline-constraints-hii.yaml'))
+
+    def test_hii_files_exist(self, hii_constraints_file):
+        assert os.path.isfile(hii_constraints_file)
+
+    def test_hii_bundled_files_pass(self, hii_line_table, hii_constraints_file):
+        from fastspecfit.emlines import EmlineConstraints
+        EmlineConstraints(constraints_file=hii_constraints_file,
+                           line_table=hii_line_table)   # must not raise
+
+
 # ── Group 3: line_bounds ──────────────────────────────────────────────────────
 
 class TestLineBounds:

--- a/py/fastspecfit/test/test_fastspecfit.py
+++ b/py/fastspecfit/test/test_fastspecfit.py
@@ -59,6 +59,38 @@ def test_fastspec(fastspec_output):
 
 
 @pytest.mark.filterwarnings("ignore::astropy.units.UnitsWarning")
+def test_fastspec_hii_morelines(fastspec_hii_output):
+    """The HII-region maximal line list (63 lines) exceeds the FITS 999-column
+    limit, triggering the FASTSPEC/MORELINES HDU split (see issue #236)."""
+    import fitsio
+    from fastspecfit.io import read_fastspecfit, MAX_FASTSPEC_COLUMNS, MORELINES_IDCOLS
+
+    fits = fitsio.FITS(fastspec_hii_output)
+    extnames = [fits[i].get_extname() for i in range(1, len(fits))]
+    assert 'MORELINES' in extnames
+
+    fastspec_cols = fits['FASTSPEC'].get_colnames()
+    morelines_cols = fits['MORELINES'].get_colnames()
+    assert len(fastspec_cols) <= MAX_FASTSPEC_COLUMNS
+    assert 'TARGETID' in morelines_cols
+
+    # a known strong line stays in FASTSPEC; a known weak/auroral line moves
+    # to MORELINES
+    assert 'OIII_5007_AMP' in fastspec_cols
+    assert 'HEI_4471_AMP' in morelines_cols
+    assert 'HEI_4471_AMP' not in fastspec_cols
+
+    # reading transparently merges FASTSPEC+MORELINES back into one table
+    _, _, fastfit, _, _ = read_fastspecfit(fastspec_hii_output)
+    idcols_in_morelines = [c for c in morelines_cols if c in MORELINES_IDCOLS]
+    expected_ncols = len(fastspec_cols) + len(morelines_cols) - len(idcols_in_morelines)
+    assert len(fastfit.colnames) == expected_ncols
+    assert 'HEI_4471_AMP' in fastfit.colnames
+    assert 'OIII_5007_AMP' in fastfit.colnames
+    assert np.all(np.isfinite(fastfit['HEI_4471_AMP']))
+
+
+@pytest.mark.filterwarnings("ignore::astropy.units.UnitsWarning")
 def test_sfr_values(fastspec_output, fastphot_output):
     """SFR in SPECPHOT must be finite and non-negative for all objects."""
     import fitsio


### PR DESCRIPTION
When using a custom line-list, the number of columns in the `FASTSPEC` HDU can exceed 999, which is a hard limit for binary tables with the FITS standard (reported in #236).

Future versions of `FastSpecFit` will likely switch to HDF5 files by default (with an option for maintaining FITS); see #272.

This PR implements a temporary (but reasonable) fix by dynamically moving some emission lines (there are 18 columns per emission line) into an additional `MORELINES` HDU. In addition, I've added a new "maximal" line-list (`emlines-hii.ecsv`, provided by @dirkscholte) into the package, which contains a fairly comprehensive set of lines found in HII-region like spectra.

New unit tests have been added as well.

Can test at NERSC with:
```
fastspec desi/spectro/redux/loa/healpix/main/bright/203/20338/redrock-main-bright-20338.fits --targetids=39628499064980252 \
  --emlinesfile=/global/common/software/desi/users/ioannis/fastspecfit/py/fastspecfit/data/emlines-hii.ecsv \
  --constraintsfile=/global/common/software/desi/users/ioannis/fastspecfit/py/fastspecfit/data/emline-constraints-hii.yaml 
  -o f.fits

[snip]
INFO:fastspecfit.py:478:fastspec: fsftime 3.62 sec for fit_all [nobj=1,3.62s/obj/core] at 2026-07-21T06:08:08.344
INFO:io.py:1736:write_fastspecfit: FASTSPEC would have 1,195 columns (>999); moved 846 columns for 47 weak lines to a MORELINES HDU.
INFO:io.py:1764:write: Writing 1 object to f.fits
[snip]

python -c "import fitsio ; print(fitsio.FITS('f.fits'))"
  file: f.fits
  mode: READONLY
  extnum hdutype         hduname[v]
  0      IMAGE_HDU       PRIMARY
  1      BINARY_TBL      METADATA
  2      BINARY_TBL      SPECPHOT
  3      BINARY_TBL      FASTSPEC
  4      BINARY_TBL      MORELINES
  5      IMAGE_HDU       MODELS
```

Two final notes: 
1. The split is based on the `isstrong` column in the `emlines.ecsv` (or emlines-hii.ecsv`) file, which is used to guide line-masking, so the split is not totally arbitrary.
2. This change is transparent to anyone who uses `io.read_fastspecfit`, which identifies the extra HDU and dynamically v-stacks it with the rest of the lines in the `FASTSPEC` HDU, but it will break downstream pipelines, including VAC codes, which read and open the `FastSpecFit` output files themselves.