### PR TITLE
support analysis of (local) mini-specprod datasets

### DIFF
--- a/bin/build-mini-specprod
+++ b/bin/build-mini-specprod
@@ -19,15 +19,16 @@ and point ``DESI_SPECTRO_REDUX`` at ``$outdir/spectro/redux`` and
 ``FPHOTO_DIR`` at ``$outdir/external/legacysurvey/dr9`` there.
 
 Note on ``--output-specprod``: only the top-level *directory* name is
-changed. The Redrock file headers keep the real, input ``--specprod`` name
-(e.g. ``iron``, ``loa``) as their ``SPECPROD`` dependency, because
-fastspecfit uses that string to pick the correct QuasarNet-afterburner column
-schema (see ``update_qso_redshifts`` in ``fastspecfit/io.py``); renaming it
-would silently break that logic for older productions. One consequence: for
-cumulative-tile samples, ``tiles-{specprod}.csv`` keeps the *input* specprod
-name in its filename, and downstream ``fastspec``/``fastqa`` runs against the
-mini tree should pass ``--specproddir $outdir/spectro/redux/{output-specprod}``
-explicitly so that file is found.
+changed. The Redrock and coadd file headers keep the real, input
+``--specprod`` name (e.g. ``iron``, ``loa``) as their ``SPECPROD``
+dependency, because fastspecfit uses that string to pick the correct
+QuasarNet-afterburner column schema (see ``update_qso_redshifts`` in
+``fastspecfit/io.py``); renaming it would silently break that logic for
+older productions. One consequence: for cumulative-tile samples,
+``tiles-{specprod}.csv`` keeps the *input* specprod name in its filename, and
+downstream ``fastspec``/``fastqa`` runs against the mini tree should pass
+``--specprod {output-specprod}`` explicitly so that file is found under the
+renamed directory.
 
 Examples
 --------
@@ -105,8 +106,22 @@ def subset_spectro_files(in_dir, out_dir, stem, targetids):
 
     if not _skip(out_coaddfile):
         print(f'Writing {out_coaddfile}')
+        orig_hdr = fitsio.read_header(coaddfile, ext=0)
         spec = read_spectra(coaddfile).select(targets=targetids)
         write_spectra(out_coaddfile, spec)
+        # write_spectra() builds a fresh primary header (via
+        # desiutil.depend.add_dependencies), which stamps DEPVER(SPECPROD)
+        # from the *current* $SPECPROD environment variable rather than
+        # preserving the original file's provenance. Restore the original
+        # header verbatim, as is done for the redrock file above: drop
+        # whatever write_spectra() added that wasn't in the original header,
+        # then write the original keys back.
+        with fitsio.FITS(out_coaddfile, 'rw') as ff:
+            keep = {r['name'] for r in orig_hdr.records() if r['name']}
+            new_hdr = ff[0].read_header()
+            stale = [r['name'] for r in new_hdr.records() if r['name'] and r['name'] not in keep]
+            ff[0].delete_keys(stale)
+            ff[0].write_keys(orig_hdr, clean=True)
 
     for prefix, extname in (('qso_qn', 'QN_RR'), ('qso_mgii', 'MGII')):
         infile = os.path.join(in_dir, f'{prefix}-{stem}.fits')

--- a/bin/profile-fastspec
+++ b/bin/profile-fastspec
@@ -12,7 +12,7 @@ Phases timed independently:
 
 Usage examples
 --------------
-# Basic timing breakdown (fastspec mode):
+# Basic timing breakdown (fastspec mode, bundled test spectrum):
   profile-fastspecfit
 
 # fastphot mode with 3 warm repeats, save cProfile output:
@@ -24,10 +24,22 @@ Usage examples
 # Point py-spy at this script (no --cprofile needed):
   py-spy record -o profile.svg -- profile-fastspecfit --mode fastspec --nwarm 5
 
+# Profile real spectra on disk (uses $DESI_SPECTRO_REDUX, $FPHOTO_DIR,
+# $DUST_DIR unless overridden below):
+  profile-fastspecfit --redrockfiles $DESI_SPECTRO_REDUX/iron/healpix/.../redrock-....fits \
+      --ntargets 5
+
+# Same, restricted to specific targets and a non-default production tree:
+  profile-fastspecfit --redrockfiles /path/to/redrock-....fits \
+      --targetids 39633345008634465,39633345008634466 --specprod iron
+
 Environment variables
 ---------------------
-FTEMPLATES_CACHE_DIR  Directory where template files are cached between runs.
-                      If set, the template is not deleted after the run.
+FTEMPLATES_DIR        Local template checkout, checked before any network
+                      download (e.g. $FTEMPLATES_DIR/3.0.0/ftemplates-chabrier-3.0.0.fits).
+FTEMPLATES_CACHE_DIR  Directory where downloaded template files are cached
+                      between runs. If set, the template is not deleted
+                      after the run.
 """
 import argparse
 import cProfile
@@ -42,7 +54,7 @@ from importlib import resources
 from urllib.request import urlretrieve
 
 
-TEMPLATE_VERSION = '2.0.0'
+TEMPLATE_VERSION = '3.0.0'
 TEMPLATE_FILENAME = f'ftemplates-chabrier-{TEMPLATE_VERSION}.fits'
 TEMPLATE_URL = (
     f'https://data.desi.lbl.gov/public/external/templates/fastspecfit/'
@@ -72,6 +84,35 @@ def parse_args(argv=None):
                    help='Number of top cProfile entries to print (default: 30).')
     p.add_argument('--outdir', default=None,
                    help='Directory for output FITS and .prof files.  Defaults to a temp dir.')
+    p.add_argument('--redrockfiles', nargs='+', default=None,
+                   help='Full path to one or more real Redrock file(s), for --mode fastspec/fastphot. '
+                        'If not given, use the bundled test spectrum.')
+    p.add_argument('--stackfiles', nargs='+', default=None,
+                   help='Full path to one or more real stacked-spectra file(s), for --mode stackfit. '
+                        'If not given, use the bundled test stack file.')
+    p.add_argument('--redux_dir', type=str, default=None,
+                   help='Optional full path $DESI_SPECTRO_REDUX; only used with --redrockfiles/--stackfiles.')
+    p.add_argument('--fphotodir', type=str, default=None,
+                   help='Top-level location of the source photometry; only used with --redrockfiles/--stackfiles.')
+    p.add_argument('--mapdir', type=str, default=None,
+                   help='Optional directory name for the dust maps; only used with --redrockfiles/--stackfiles.')
+    p.add_argument('--specprod', type=str, default=None,
+                   help='Optional override of the on-disk specprod directory name (see fastspec --specprod).')
+    p.add_argument('--targetids', type=str, default=None,
+                   help='Comma-separated list of TARGETIDs to process.')
+    p.add_argument('-n', '--ntargets', type=int, default=None,
+                   help='Number of targets to process in each file (default: all).')
+    p.add_argument('--firsttarget', type=int, default=0,
+                   help='Index of first object to process in each file, zero-indexed.')
+    p.add_argument('--redrockfile-prefix', type=str, default='redrock-',
+                   help='Prefix of the input Redrock file name(s).')
+    p.add_argument('--specfile-prefix', type=str, default='coadd-',
+                   help='Prefix of the spectral file(s).')
+    p.add_argument('--qnfile-prefix', type=str, default='qso_qn-',
+                   help='Prefix of the QuasarNet afterburner file(s).')
+    p.add_argument('--use-quasarnet', action='store_true',
+                   help='Use QuasarNet to improve QSO redshifts (default: off, since the '
+                        'bundled test spectrum has no QuasarNet afterburner file).')
     args = p.parse_args(argv)
     if args.fastphot:
         args.mode = 'fastphot'
@@ -86,6 +127,13 @@ def get_template_path(args):
     """Return a path to the template file, downloading if necessary."""
     if args.templates:
         return args.templates
+
+    ftemplates_dir = os.environ.get('FTEMPLATES_DIR')
+    if ftemplates_dir:
+        local = pathlib.Path(ftemplates_dir) / TEMPLATE_VERSION / TEMPLATE_FILENAME
+        if local.is_file():
+            print(f'Using local $FTEMPLATES_DIR templates: {local}', flush=True)
+            return str(local)
 
     cache_dir = os.environ.get('FTEMPLATES_CACHE_DIR')
     if cache_dir:
@@ -111,16 +159,33 @@ def get_template_path(args):
 # Setup helpers (mirror conftest.py)
 # ---------------------------------------------------------------------------
 
-def get_test_paths():
+def get_paths(args, mode):
+    """Return the input paths/files to use, either the bundled test data or
+    real spectra pointed to by --redrockfiles/--stackfiles."""
     base = resources.files('fastspecfit').joinpath('test/data')
-    return {
-        'redux_dir':   base,
-        'specproddir': base,
-        'mapdir':      base,
-        'fphotodir':   base,
-        'redrockfile': base.joinpath('redrock-4-80613-thru20210324.fits'),
-        'stackfile':   base.joinpath('stack-LRG.fits'),
+    fitstack = (mode == 'stackfit')
+
+    using_real_data = bool(args.stackfiles) if fitstack else bool(args.redrockfiles)
+
+    if fitstack:
+        files = list(args.stackfiles) if args.stackfiles else [str(base.joinpath('stack-LRG.fits'))]
+    else:
+        files = list(args.redrockfiles) if args.redrockfiles else [str(base.joinpath('redrock-4-80613-thru20210324.fits'))]
+
+    paths = {
+        'redux_dir': args.redux_dir or (None if using_real_data else str(base)),
+        'mapdir':    args.mapdir or (None if using_real_data else str(base)),
+        'fphotodir': args.fphotodir or (None if using_real_data else str(base)),
+        # bundled test data recorded a bogus SPECPROD in its file headers;
+        # passing the test-data directory itself as an absolute override
+        # makes gather_metadata() look for tiles-*.csv there (see conftest.py).
+        'specprod':  args.specprod or (None if using_real_data else str(base)),
     }
+    if fitstack:
+        paths['stackfile'] = files
+    else:
+        paths['redrockfile'] = files
+    return paths
 
 
 def build_init_args(paths, templates, mode):
@@ -174,7 +239,7 @@ def phase_init(sc_data, init_args, timer):
     timer.mark('sc_data.initialize (templates + JIT warmup)')
 
 
-def phase_io(paths, mode, timer):
+def phase_io(paths, mode, args, timer):
     from fastspecfit.io import DESISpectra, get_output_dtype
     from fastspecfit.singlecopy import sc_data
 
@@ -184,25 +249,31 @@ def phase_io(paths, mode, timer):
     Spec = DESISpectra(
         phot=sc_data.photometry,
         cosmo=sc_data.cosmology,
-        fphotodir=str(paths['fphotodir']),
-        mapdir=str(paths['mapdir']),
-        redux_dir=str(paths['redux_dir']),
+        fphotodir=paths['fphotodir'],
+        mapdir=paths['mapdir'],
+        redux_dir=paths['redux_dir'],
     )
+
+    targetids = None
+    if args.targetids:
+        targetids = [int(t) for t in args.targetids.split(',')]
 
     if fitstack:
         data, meta = Spec.read_stacked(
-            [str(paths['stackfile'])],
-            firsttarget=0, ntargets=None,
+            paths['stackfile'],
+            firsttarget=args.firsttarget, ntargets=args.ntargets,
+            stackids=targetids,
         )
     else:
         Spec.gather_metadata(
-            [str(paths['redrockfile'])],
-            firsttarget=0,
-            redrockfile_prefix='redrock-',
-            specfile_prefix='coadd-',
-            qnfile_prefix='qso_qn-',
-            use_quasarnet=False,
-            specprod_dir=str(paths['specproddir']),
+            paths['redrockfile'],
+            firsttarget=args.firsttarget, ntargets=args.ntargets,
+            targetids=targetids,
+            redrockfile_prefix=args.redrockfile_prefix,
+            specfile_prefix=args.specfile_prefix,
+            qnfile_prefix=args.qnfile_prefix,
+            use_quasarnet=args.use_quasarnet,
+            specprod=paths['specprod'],
         )
         data, meta = Spec.read(sc_data.photometry, fastphot=fastphot)
 
@@ -274,8 +345,8 @@ def main(argv=None):
     outdir.mkdir(parents=True, exist_ok=True)
 
     templates = get_template_path(args)
-    paths     = get_test_paths()
     mode      = args.mode
+    paths     = get_paths(args, mode)
 
     print(f'\n--- FastSpecFit profiling harness  (mode={mode}) ---\n')
 
@@ -288,7 +359,7 @@ def main(argv=None):
     phase_init(sc_data, init_args, timer)
 
     # Phase 2: I/O
-    Spec, data, meta = phase_io(paths, mode, timer)
+    Spec, data, meta = phase_io(paths, mode, args, timer)
     fitargs = build_fitargs(Spec, data, meta, mode, args.nmonte)
     nobj    = len(fitargs)
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ Change Log
 3.6.0 (not released yet)
 ------------------------
 
+* Support analysis of mini-specprod datasets [`PR #274`_].
 * Dynamically split ``FASTSPEC`` HDU into an additional ``MORELINES``
   HDU [`PR #273`_].
 * Switch to new default templates (version 3.0.0) built from a
@@ -13,6 +14,7 @@ Change Log
 * New unit test and documentation of external photometric catalog
   "mode" [`PR #269`_].
 
+.. _`PR #274`: https://github.com/desihub/fastspecfit/pull/274
 .. _`PR #273`: https://github.com/desihub/fastspecfit/pull/273
 .. _`PR #271`: https://github.com/desihub/fastspecfit/pull/271
 .. _`PR #270`: https://github.com/desihub/fastspecfit/pull/270

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -156,8 +156,8 @@ Set these variables and download the required external files::
 
   wget -r -np -nH --cut-dirs 5 -A fits -P $DUST_DIR \
     https://portal.nersc.gov/project/cosmo/data/dust/v0_1/maps
-  wget -O $FTEMPLATES_DIR/ftemplates-chabrier-2.0.0.fits \
-    https://data.desi.lbl.gov/public/external/templates/fastspecfit/2.0.0/ftemplates-chabrier-2.0.0.fits
+  wget -O $FTEMPLATES_DIR/ftemplates-chabrier-3.0.0.fits \
+    https://data.desi.lbl.gov/public/external/templates/fastspecfit/3.0.0/ftemplates-chabrier-3.0.0.fits
 
 Building the Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -103,7 +103,9 @@ def parse(options=None, rank=0):
     parser.add_argument('--emlinesfile', type=str, default=None, help='Emission line parameter file.')
     parser.add_argument('--constraintsfile', type=str, default=None, help='Emission-line kinematic constraint YAML file.')
     parser.add_argument('--redux_dir', type=str, default=None, help='Optional full path $DESI_SPECTRO_REDUX.')
-    parser.add_argument('--specproddir', type=str, default=None, help='Optional directory name for the spectroscopic production.')
+    parser.add_argument('--specprod', type=str, default=None, help="""Optional override of the on-disk spectroscopic
+        production directory name under --redux_dir, when it differs from the SPECPROD dependency recorded in the
+        Redrock/coadd file headers (e.g., a relocated or "mini" production tree).""")
     parser.add_argument('--uncertainty-floor', type=float, default=0.01, help='Minimum fractional uncertainty to add in quadrature to the formal inverse variance spectrum.')
     parser.add_argument('--minsnr-balmer-broad', type=float, default=2.5, help='Minimum broad Balmer S/N to force broad+narrow-line model.')
     parser.add_argument('--debug-plots', action='store_true', help='Generate a variety of debugging plots (written to $PWD).')
@@ -358,7 +360,7 @@ def fastspec(fastphot=False, fitstack=False, args=None, comm=None, verbose=False
                                  ntargets=args.ntargets, zmin=args.zmin,
                                  redrockfile_prefix=args.redrockfile_prefix,
                                  specfile_prefix=args.specfile_prefix, qnfile_prefix=args.qnfile_prefix,
-                                 use_quasarnet=args.use_quasarnet, specprod_dir=args.specproddir)
+                                 use_quasarnet=args.use_quasarnet, specprod=args.specprod)
             if len(Spec.specfiles) == 0:
                 return 0
 

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -599,7 +599,7 @@ class DESISpectra(object):
 
     def gather_metadata(self, redrockfiles, zmin=None, zmax=None, zwarnmax=None,
                         targetids=None, firsttarget=0, ntargets=None,
-                        input_redshifts=None, specprod_dir=None, use_quasarnet=True,
+                        input_redshifts=None, specprod=None, use_quasarnet=True,
                         redrockfile_prefix='redrock-', specfile_prefix='coadd-',
                         qnfile_prefix='qso_qn-', mgiifile_prefix='qso_mgii-'):
         """Select targets for fitting and gather spectroscopic metadata.
@@ -627,8 +627,15 @@ class DESISpectra(object):
         input_redshifts : float or array-like or None, optional
             Override redshifts for each entry in ``targetids``. If ``None``,
             use Redrock (or QuasarNet) redshifts.
-        specprod_dir : str or None, optional
-            Override the spectroscopic production directory.
+        specprod : str or None, optional
+            Override the on-disk spectroscopic production *directory name*
+            under ``redux_dir``, for cases where it differs from the
+            ``SPECPROD`` dependency recorded in the Redrock/coadd file
+            headers (e.g., a relocated or "mini" production tree). This is
+            independent of the instance attribute ``self.specprod``, which
+            is always read from the file headers and used to pick the
+            correct QuasarNet-afterburner column schema; this parameter only
+            affects where the ``tiles-{specprod}.csv`` file is looked up.
         use_quasarnet : bool, optional
             Use QuasarNet afterburner redshifts for QSOs when available.
             Defaults to ``True``.
@@ -718,14 +725,14 @@ class DESISpectra(object):
             # only compatible with Fuji & Guadalupe headers and later.
             hdr = fitsio.read_header(specfile, ext=0)
 
-            specprod = getdep(hdr, 'SPECPROD')
+            file_specprod = getdep(hdr, 'SPECPROD')
             if hasattr(self, 'specprod'):
-                if self.specprod != specprod:
-                    errmsg = f'specprod must be the same for all input redrock files! {specprod}!={self.specprod}'
+                if self.specprod != file_specprod:
+                    errmsg = f'specprod must be the same for all input redrock files! {file_specprod}!={self.specprod}'
                     log.critical(errmsg)
                     raise ValueError(errmsg)
 
-            self.specprod = specprod
+            self.specprod = file_specprod
 
             if 'SPGRP' in hdr:
                 self.coadd_type = hdr['SPGRP']
@@ -775,8 +782,12 @@ class DESISpectra(object):
                 # cache the tiles file so we can grab the survey and program name
                 # appropriate for this tile; silently skip if redux_dir is unavailable
                 if not hasattr(self, 'tileinfo') and self.redux_dir is not None:
-                    if specprod_dir is None:
-                        specprod_dir = os.path.join(self.redux_dir, self.specprod)
+                    # NB: the on-disk directory name (specprod, an optional
+                    # override) can differ from self.specprod, the "real"
+                    # production name recorded in the file headers (e.g., a
+                    # relocated or "mini" production tree); the CSV filename
+                    # always uses the latter.
+                    specprod_dir = os.path.join(self.redux_dir, specprod if specprod else self.specprod)
                     infofile = os.path.join(specprod_dir, f'tiles-{self.specprod}.csv')
                     if os.path.isfile(infofile):
                         self.tileinfo = Table.read(infofile)

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -13,7 +13,7 @@ from astropy.table import Table
 
 from fastspecfit.logger import log
 from fastspecfit.singlecopy import sc_data
-from fastspecfit.photometry import Photometry
+from fastspecfit.photometry import Photometry, release_to_photsys, desitarget_resolve_dec, releasedict
 from fastspecfit.util import FLUXNORM, ZWarningMask, fsftime, _uid
 from fastspecfit.templates import VDISP_NOMINAL, VDISP_BOUNDS
 
@@ -551,7 +551,6 @@ class DESISpectra(object):
             return northern
 
         # ADM retrieve the photometric system from the RELEASE.
-        from desitarget.io import release_to_photsys, desitarget_resolve_dec
         if 'PHOTSYS' in targets.dtype.names:
             photsys = targets["PHOTSYS"]
         else:
@@ -660,7 +659,7 @@ class DESISpectra(object):
         """
         from astropy.table import vstack, hstack
         from desiutil.depend import getdep
-        from desitarget import geomask
+        from desitarget.geomask import match_to
 
         if zmin is None:
             zmin = 1e-3
@@ -911,7 +910,7 @@ class DESISpectra(object):
 
             # make sure we're sorted
             if targetids is not None:
-                srt = geomask.match_to(meta['TARGETID'], targetids)
+                srt = match_to(meta['TARGETID'], targetids)
                 meta = meta[srt]
                 assert(np.all(meta['TARGETID'] == targetids))
 
@@ -961,7 +960,7 @@ class DESISpectra(object):
                 if 'FIBER' in expmeta.colnames:
                     meta['FIBER'] = np.zeros(len(meta), dtype=expmeta['FIBER'].dtype)
                     _, uindx = np.unique(expmeta['TARGETID'], return_index=True)
-                    I = geomask.match_to(expmeta[uindx]['TARGETID'], meta['TARGETID'])
+                    I = match_to(expmeta[uindx]['TARGETID'], meta['TARGETID'])
                     assert(np.all(expmeta[uindx][I]['TARGETID'] == meta['TARGETID']))
                     meta['FIBER'] = expmeta[uindx[I]]['FIBER']
 
@@ -1078,7 +1077,7 @@ class DESISpectra(object):
 
         """
         from astropy.table import vstack
-        from desitarget import geomask
+        from desitarget.geomask import match_to
         from desispec.coaddition import coadd_cameras
         from desispec.io import read_spectra
         from desiutil.dust import SFDMap
@@ -1163,7 +1162,7 @@ class DESISpectra(object):
                 os.environ['DESI_LOGLEVEL'] = 'warning'
                 spec = read_spectra(specfile)#.select(targets=meta[uniqueid])
 
-                srt = geomask.match_to(spec.fibermap[uniqueid_col], meta['TARGETID'])
+                srt = match_to(spec.fibermap[uniqueid_col], meta['TARGETID'])
                 spec = spec[srt]
                 assert(np.all(spec.fibermap[uniqueid_col] == meta[uniqueid_col]))
 
@@ -1400,7 +1399,7 @@ class DESISpectra(object):
     def _gather_photometry(self, specprod=None, alltiles=None):
         """Gather Tractor photometry from disk and merge into the metadata tables."""
         from astropy.table import vstack
-        from desitarget import geomask
+        from desitarget.geomask import match_to
         from fastspecfit.photometry import gather_tractorphot
 
         input_meta = vstack(self.meta).copy()
@@ -1410,8 +1409,6 @@ class DESISpectra(object):
 
         # Legacy Surveys
         if hasattr(self.phot, 'legacysurveydr'):
-            from desitarget.io import releasedict
-
             legacysurveydr = self.phot.legacysurveydr
 
             # targeting and Tractor columns to read from disk but need
@@ -1430,7 +1427,7 @@ class DESISpectra(object):
             if legacysurveydr.lower() in ['dr9', 'dr10', 'dr11']:
                 metas = []
                 for meta in self.meta:
-                    srt = geomask.match_to(tractor[uniqueid_col], meta[uniqueid_col])
+                    srt = match_to(tractor[uniqueid_col], meta[uniqueid_col])
                     assert(np.all(meta[uniqueid_col] == tractor[uniqueid_col][srt]))
 
                     # The fibermaps in fuji and guadalupe (plus earlier productions) had a
@@ -1456,7 +1453,7 @@ class DESISpectra(object):
                                     log.warning('Updating column {} in metadata table: {}-->{}.'.format(
                                         col, meta[col][0], targets[col][0]))
                                     meta[col][diffcol] = targets[col][diffcol]
-                    srt = geomask.match_to(tractor[uniqueid_col], meta[uniqueid_col])
+                    srt = match_to(tractor[uniqueid_col], meta[uniqueid_col])
                     assert(np.all(meta[uniqueid_col] == tractor[uniqueid_col][srt]))
 
                     # Add the tractor catalog quantities (overwriting columns if necessary).
@@ -1502,7 +1499,7 @@ class DESISpectra(object):
                     meta = meta[inmask]
                 if len(meta) == 0:
                     continue
-                srt = geomask.match_to(phot_tbl[uniqueid_col], meta[uniqueid_col])
+                srt = match_to(phot_tbl[uniqueid_col], meta[uniqueid_col])
                 assert(np.all(meta[uniqueid_col] == phot_tbl[uniqueid_col][srt]))
                 if hasattr(self.phot, 'dropcols'):
                     meta.remove_columns(self.phot.dropcols)

--- a/py/fastspecfit/photometry.py
+++ b/py/fastspecfit/photometry.py
@@ -13,6 +13,35 @@ from astropy.table import Table
 from fastspecfit.logger import log
 from fastspecfit.util import trapz, C_LIGHT, FLUXNORM
 
+# Ported from desitarget.io (see https://github.com/desihub/desitarget/issues/893)
+# to avoid desitarget.io's module-level desimodel import.
+releasedict = {3000: 'S', 4000: 'N', 5000: 'S', 6000: 'N', 7000: 'S', 7999: 'S',
+               8000: 'S', 8001: 'N', 9000: 'S', 9001: 'N', 9002: 'S', 9003: 'N',
+               9004: 'S', 9005: 'N', 9006: 'S', 9007: 'N', 9008: 'S', 9009: 'N',
+               9010: 'S', 9011: 'N', 9012: 'S', 9013: 'N', 10000: 'S'}
+
+
+def desitarget_resolve_dec():
+    """Default Dec cut to separate targets in BASS/MzLS from DECaLS."""
+    return 32.375
+
+
+def release_to_photsys(release):
+    """Convert RELEASE to PHOTSYS using the releasedict lookup table."""
+    releasenums = np.array(list(releasedict.keys()))
+    photstrings = np.array(list(releasedict.values()))
+
+    unknown = set(release) - set(releasenums)
+    if bool(unknown):
+        errmsg = 'Unknown release number {}'.format(unknown)
+        log.critical(errmsg)
+        raise ValueError(errmsg)
+
+    r2p = np.empty(np.max(releasenums)+1, dtype='|S1')
+    r2p[releasenums] = photstrings
+
+    return r2p[release]
+
 
 class Photometry(object):
     """Load filter curves and provide photometric synthesis methods.
@@ -1155,8 +1184,7 @@ def _gather_tractorphot_onebrick(input_cat, legacysurveydir, radius_match, racol
     """Retrieve Tractor photometry for targets sharing a single brick."""
     import astropy.units as u
     from astropy.coordinates import SkyCoord
-    from desitarget import geomask
-    from desitarget.io import desitarget_resolve_dec
+    from desitarget.geomask import match_to
 
     assert(np.all(input_cat['BRICKNAME'] == input_cat['BRICKNAME'][0]))
     brick = input_cat['BRICKNAME'][0]
@@ -1213,7 +1241,7 @@ def _gather_tractorphot_onebrick(input_cat, legacysurveydir, radius_match, racol
         tractor_dr9 = Table(fitsio.read(tractorfile, rows=I, upper=True))
 
         # sort explicitly in order to ensure order
-        srt = geomask.match_to(tractor_dr9['OBJID'], input_cat['BRICK_OBJID'][idr9])
+        srt = match_to(tractor_dr9['OBJID'], input_cat['BRICK_OBJID'][idr9])
         tractor_dr9 = tractor_dr9[srt]
         assert(np.all((tractor_dr9['BRICKID'] == input_cat['BRICKID'][idr9])*(tractor_dr9['OBJID'] == input_cat['BRICK_OBJID'][idr9])))
 

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -13,8 +13,42 @@ from fastspecfit.util import MPPool
 
 # Sticky per-process flag: once the Legacy Survey viewer is found
 # unreachable, stop retrying it for every subsequent object in this process
-# (see _fetch_cutout).
+# (see _fetch_cutout). Seeded once per fastqa() call by _probe_cutout_host()
+# and propagated to multiprocessing workers via their pool initializer, so
+# a single probe covers the whole call regardless of --mp.
 _cutout_unreachable = False
+
+
+def _probe_cutout_host(timeout=5):
+    """One-shot reachability check for the Legacy Survey viewer host.
+
+    Cheap up-front alternative to letting every worker separately discover
+    an outage via _fetch_cutout()'s multi-attempt retry/backoff loop. Unlike
+    socket.create_connection(), which tries *every* address getaddrinfo
+    returns (this host round-robins across several backend IPs, so that can
+    multiply the effective timeout severalfold), this only ever attempts the
+    first resolved address, so the wall-clock cost is bounded by `timeout`.
+    """
+    import socket
+    host, port = 'www.legacysurvey.org', 443
+    try:
+        family, socktype, proto, _, sockaddr = socket.getaddrinfo(
+            host, port, socket.AF_UNSPEC, socket.SOCK_STREAM)[0]
+        with socket.socket(family, socktype, proto) as sock:
+            sock.settimeout(timeout)
+            sock.connect(sockaddr)
+        return True
+    except OSError as e:
+        log.warning(f'Legacy Survey viewer unreachable ({e}); skipping image cutouts for this run.')
+        return False
+
+
+def _qa_worker_init(cutout_unreachable=False, **init_sc_args):
+    """Pool initializer: seed this worker's cutout-reachability state, then
+    initialize the single-copy objects as usual."""
+    global _cutout_unreachable
+    _cutout_unreachable = cutout_unreachable
+    sc_data.initialize(**init_sc_args)
 
 
 def _corner_plot(plotdata, bins, ranges, labels, titles, truths, sigmas,
@@ -1899,6 +1933,13 @@ def fastqa(args=None, comm=None):
 
     sc_data.initialize(**init_sc_args)
 
+    # Probe the Legacy Survey viewer once for this call and seed the
+    # (per-process) cutout-reachability flag, both here in the main process
+    # (covers the args.mp<=1 case) and via the pool initializer below (covers
+    # each multiprocessing worker).
+    global _cutout_unreachable
+    _cutout_unreachable = not _probe_cutout_host()
+
     # if multiprocessing, create a pool of worker processes
     # and initialize single-copy objects in each worker
     if args.mp > 1 and not 'NERSC_HOST' in os.environ:
@@ -1906,8 +1947,8 @@ def fastqa(args=None, comm=None):
         multiprocessing.set_start_method('fork')
 
     mp_pool = MPPool(args.mp,
-                     initializer=sc_data.initialize,
-                     init_argdict=init_sc_args)
+                     initializer=_qa_worker_init,
+                     init_argdict=dict(cutout_unreachable=_cutout_unreachable, **init_sc_args))
 
     log.info(f'Cached stellar templates {sc_data.templates.file}')
     log.info(f'Cached emission-line table {sc_data.emlines.file}')

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -11,6 +11,11 @@ from fastspecfit.templates import Templates
 from fastspecfit.singlecopy import sc_data
 from fastspecfit.util import MPPool
 
+# Sticky per-process flag: once the Legacy Survey viewer is found
+# unreachable, stop retrying it for every subsequent object in this process
+# (see _fetch_cutout).
+_cutout_unreachable = False
+
 
 def _corner_plot(plotdata, bins, ranges, labels, titles, truths, sigmas,
                  suptitle, pngfile, subplots_adjust=None):
@@ -723,8 +728,10 @@ def _fetch_cutout(metadata, outdir, pngfile, layer, pixscale):
     hdr['CD2_2'] = +pixscale/3600
     wcs = WCS(hdr)
 
+    global _cutout_unreachable
+
     cutoutjpeg = os.path.join(outdir, 'tmp.'+os.path.basename(pngfile.replace('.png', '.jpeg')))
-    if not os.path.isfile(cutoutjpeg):
+    if not os.path.isfile(cutoutjpeg) and not _cutout_unreachable:
         import random
         import time
         import urllib.request
@@ -756,7 +763,9 @@ def _fetch_cutout(metadata, outdir, pngfile, layer, pixscale):
                                 f'Retrying in {backoff:.1f}s.')
                     time.sleep(backoff)
                 else:
-                    log.warning(f'No viewer cutout retrieved after {max_retries} attempts: {e}.')
+                    log.warning(f'No viewer cutout retrieved after {max_retries} attempts: {e}. '
+                                f'Skipping further cutout fetches for the remainder of this run.')
+                    _cutout_unreachable = True
     try:
         img = mpimg.imread(cutoutjpeg)
     except:

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -1721,6 +1721,9 @@ def parse(options=None):
     parser.add_argument('--night', default=None, type=str, nargs='*', help="""Generate QA for all objects observed on this
         night (only defined for coadd-type 'pernight' and 'perexp').""")
     parser.add_argument('--redux_dir', type=str, default=None, help='Optional full path $DESI_SPECTRO_REDUX.')
+    parser.add_argument('--specprod', type=str, default=None, help="""Optional override of the on-disk spectroscopic
+        production directory name under --redux_dir, when it differs from the SPECPROD recorded in the fastspecfit
+        output file (e.g., a relocated or "mini" production tree).""")
     parser.add_argument('--redrockfiles', nargs='*', help='Optional full path to redrock file(s).')
     parser.add_argument('--redrockfile-prefix', type=str, default='redrock-', help='Prefix of the input Redrock file name(s).')
     parser.add_argument('--specfile-prefix', type=str, default='coadd-', help='Prefix of the spectral file(s).')
@@ -2000,7 +2003,7 @@ def fastqa(args=None, comm=None):
                                             (program == allprograms) * (pixel == allpixels))[0]
                             if len(indx) == 0:
                                 continue
-                            redrockfile = os.path.join(args.redux_dir, specprod, 'healpix', str(survey), str(program), str(pixel // 100),
+                            redrockfile = os.path.join(args.redux_dir, args.specprod or specprod, 'healpix', str(survey), str(program), str(pixel // 100),
                                                        str(pixel), 'redrock-{}-{}-{}.fits'.format(survey, program, pixel))
                             _wrap_qa(redrockfile, indx)
     elif coadd_type == 'uniqpix':
@@ -2020,7 +2023,7 @@ def fastqa(args=None, comm=None):
                                             (program == allprograms) * (pixel == allpixels))[0]
                             if len(indx) == 0:
                                 continue
-                            redrockfile = os.path.join(args.redux_dir, specprod, 'spectra', str(survey), str(program), str(pixel // 100),
+                            redrockfile = os.path.join(args.redux_dir, args.specprod or specprod, 'spectra', str(survey), str(program), str(pixel // 100),
                                                        str(pixel), 'redrock-{}-{}-{}.fits'.format(survey, program, pixel))
                             _wrap_qa(redrockfile, indx)
     elif coadd_type == 'custom':
@@ -2047,7 +2050,7 @@ def fastqa(args=None, comm=None):
                                 #log.warning('No object found with tileid={} and petal={}!'.format(
                                 #    tile, petal))
                                 continue
-                            redrockfile = os.path.join(args.redux_dir, specprod, 'tiles', 'cumulative', str(tile), allnights[indx[0]],
+                            redrockfile = os.path.join(args.redux_dir, args.specprod or specprod, 'tiles', 'cumulative', str(tile), allnights[indx[0]],
                                                        'redrock-{}-{}-thru{}.fits'.format(petal, tile, allnights[indx[0]]))
                             _wrap_qa(redrockfile, indx)
             elif coadd_type == 'pernight':
@@ -2059,7 +2062,7 @@ def fastqa(args=None, comm=None):
                                                 (tile == alltiles) * (petal == allpetals))[0]
                                 if len(indx) == 0:
                                     continue
-                                redrockfile = os.path.join(args.redux_dir, specprod, 'tiles', 'pernight', str(tile), str(night),
+                                redrockfile = os.path.join(args.redux_dir, args.specprod or specprod, 'tiles', 'pernight', str(tile), str(night),
                                                            'redrock-{}-{}-{}.fits'.format(petal, tile, night))
                                 _wrap_qa(redrockfile, indx)
             elif coadd_type == 'perexp':
@@ -2074,7 +2077,7 @@ def fastqa(args=None, comm=None):
                                                     (petal == allpetals))[0]
                                     if len(indx) == 0:
                                         continue
-                                    redrockfile = os.path.join(args.redux_dir, specprod, 'tiles', 'perexp', str(tile), '{:08d}'.format(expid),
+                                    redrockfile = os.path.join(args.redux_dir, args.specprod or specprod, 'tiles', 'perexp', str(tile), '{:08d}'.format(expid),
                                                                'redrock-{}-{}-exp{:08d}.fits'.format(petal, tile, expid))
                                     _wrap_qa(redrockfile, indx)
 

--- a/py/fastspecfit/test/conftest.py
+++ b/py/fastspecfit/test/conftest.py
@@ -73,14 +73,14 @@ def templates(templatedir, template_version):
 def filenames(outdir):
     from importlib import resources
     redux_dir    = resources.files('fastspecfit').joinpath('test/data')
-    specproddir  = resources.files('fastspecfit').joinpath('test/data')
+    specprod     = resources.files('fastspecfit').joinpath('test/data')
     mapdir       = resources.files('fastspecfit').joinpath('test/data')
     fphotodir    = resources.files('fastspecfit').joinpath('test/data')
     redrockfile  = resources.files('fastspecfit').joinpath('test/data/redrock-4-80613-thru20210324.fits')
     stackfile    = resources.files('fastspecfit').joinpath('test/data/stack-LRG.fits')
     yield {
         'redux_dir':        redux_dir,
-        'specproddir':      specproddir,
+        'specprod':         specprod,
         'mapdir':           mapdir,
         'fphotodir':        fphotodir,
         'redrockfile':      redrockfile,
@@ -98,7 +98,7 @@ def fastphot_output(filenames, templates):
     cmd = (f'fastphot {filenames["redrockfile"]} -o {outfile} '
            f'--mapdir {filenames["mapdir"]} --fphotodir {filenames["fphotodir"]} '
            f'--redux_dir {filenames["redux_dir"]} '
-           f'--specproddir {filenames["specproddir"]} --templates {templates}')
+           f'--specprod {filenames["specprod"]} --templates {templates}')
     fastphot(args=parse(options=cmd.split()[1:]))
     yield outfile
 
@@ -110,7 +110,7 @@ def fastspec_output(filenames, templates):
     cmd = (f'fastspec {filenames["redrockfile"]} -o {outfile} '
            f'--redux_dir {filenames["redux_dir"]} '
            f'--mapdir {filenames["mapdir"]} --fphotodir {filenames["fphotodir"]} '
-           f'--specproddir {filenames["specproddir"]} --templates {templates}')
+           f'--specprod {filenames["specprod"]} --templates {templates}')
     fastspec(args=parse(options=cmd.split()[1:]))
     yield outfile
 
@@ -128,7 +128,7 @@ def fastspec_hii_output(filenames, templates, outdir):
     cmd = (f'fastspec {filenames["redrockfile"]} -o {outfile} '
            f'--redux_dir {filenames["redux_dir"]} '
            f'--mapdir {filenames["mapdir"]} --fphotodir {filenames["fphotodir"]} '
-           f'--specproddir {filenames["specproddir"]} --templates {templates} '
+           f'--specprod {filenames["specprod"]} --templates {templates} '
            f'--emlinesfile {emlinesfile} --constraintsfile {constraintsfile}')
     fastspec(args=parse(options=cmd.split()[1:]))
     yield outfile
@@ -143,7 +143,7 @@ def fastspec_fixedvdisp_output(filenames, templates, outdir):
     cmd = (f'fastspec {filenames["redrockfile"]} -o {outfile} '
            f'--redux_dir {filenames["redux_dir"]} '
            f'--mapdir {filenames["mapdir"]} --fphotodir {filenames["fphotodir"]} '
-           f'--specproddir {filenames["specproddir"]} --templates {templates} '
+           f'--specprod {filenames["specprod"]} --templates {templates} '
            f'--vdisp-bounds 0 0')
     fastspec(args=parse(options=cmd.split()[1:]))
     yield outfile


### PR DESCRIPTION
With NERSC down, https://github.com/desihub/fastspecfit/commit/90dd8a4091add5b99f722637db9f5ab9afb17fbe added a new `bin/buid-mini-specprod` script (based on the discussion in https://github.com/desihub/desispec/issues/2421) which generates a "mini" specprod of a well-defined sample of galaxies which can be pulled to a laptop for offline analysis.

This PR adds some additional functionality along these lines, including being smarter about detecting when the viewer is down when generating the QA cutout.