### PR TITLE
speed up continuum fitting, cache the dust map, and fix a fastphot nmonte=0 crash

### DIFF
--- a/bin/profile-fastspec
+++ b/bin/profile-fastspec
@@ -207,6 +207,7 @@ def build_init_args(paths, templates, mode):
         'template_version':  TEMPLATE_VERSION,
         'template_imf':      'chabrier',
         'log_verbose':       False,
+        'mapdir':            paths['mapdir'],
     }
 
 
@@ -258,7 +259,6 @@ def phase_io(paths, mode, args, timer):
         phot=sc_data.photometry,
         cosmo=sc_data.cosmology,
         fphotodir=paths['fphotodir'],
-        mapdir=paths['mapdir'],
         redux_dir=paths['redux_dir'],
     )
 

--- a/bin/profile-fastspec
+++ b/bin/profile-fastspec
@@ -10,12 +10,17 @@ Phases timed independently:
   3. fastspec_one cold run(s)     -- first pass; JIT compilation may fire here
   4. fastspec_one warm run(s)     -- subsequent passes; steady-state throughput
 
+The I/O phase (2) is cProfile'd by default, writing <mode>-io.prof (pass
+--no-cprofile-io to skip). The fitting loop (3-4) is only cProfile'd (into
+<mode>.prof) when --cprofile is passed explicitly.
+
 Usage examples
 --------------
-# Basic timing breakdown (fastspec mode, bundled test spectrum):
+# Basic timing breakdown (fastspec mode, bundled test spectrum); I/O cProfile
+# is written automatically:
   profile-fastspecfit
 
-# fastphot mode with 3 warm repeats, save cProfile output:
+# fastphot mode with 3 warm repeats, also cProfile the fitting loop:
   profile-fastspecfit --mode fastphot --nwarm 3 --cprofile
 
 # Use a pre-downloaded template file:
@@ -80,6 +85,9 @@ def parse_args(argv=None):
                    help='Monte Carlo realizations per object (default: 10).')
     p.add_argument('--cprofile', action='store_true',
                    help='Run cProfile on the warm fitting loop and write <mode>.prof.')
+    p.add_argument('--no-cprofile-io', dest='cprofile_io', default=True, action='store_false',
+                   help='Do not run cProfile on the DESISpectra I/O phase '
+                        '(on by default; writes <mode>-io.prof).')
     p.add_argument('--cprofile-top', type=int, default=30,
                    help='Number of top cProfile entries to print (default: 30).')
     p.add_argument('--outdir', default=None,
@@ -320,6 +328,27 @@ def build_fitargs(Spec, data, meta, mode, nmonte):
     ]
 
 
+def run_cprofile(callable_, prof_path, cprofile_top, label):
+    """Run cProfile around callable_() (no args), dump stats to prof_path,
+    print the top-N cumulative-time entries, and return callable_()'s result."""
+    pr = cProfile.Profile()
+    pr.enable()
+    result = callable_()
+    pr.disable()
+
+    pr.dump_stats(str(prof_path))
+
+    buf = io.StringIO()
+    ps  = pstats.Stats(pr, stream=buf).sort_stats('cumulative')
+    ps.print_stats(cprofile_top)
+    print(buf.getvalue())
+    print(f'Full {label} profile saved to: {prof_path}')
+    print(f'  View with:  python -m snakeviz {prof_path}')
+    print(f'  Or:         python -m pstats {prof_path}')
+
+    return result
+
+
 def run_fitting_loop(fitargs):
     """Run fastspec_one for every object; return wall-clock seconds.
 
@@ -359,7 +388,14 @@ def main(argv=None):
     phase_init(sc_data, init_args, timer)
 
     # Phase 2: I/O
-    Spec, data, meta = phase_io(paths, mode, args, timer)
+    if args.cprofile_io:
+        io_prof_path = outdir / f'{mode}-io.prof'
+        print(f'Running cProfile on I/O -> {io_prof_path} ...', flush=True)
+        Spec, data, meta = run_cprofile(
+            lambda: phase_io(paths, mode, args, timer),
+            io_prof_path, args.cprofile_top, 'I/O')
+    else:
+        Spec, data, meta = phase_io(paths, mode, args, timer)
     fitargs = build_fitargs(Spec, data, meta, mode, args.nmonte)
     nobj    = len(fitargs)
 
@@ -385,26 +421,16 @@ def main(argv=None):
 
     timer.report()
 
+    if args.cprofile_io:
+        print('Note: "DESISpectra I/O" above includes cProfile instrumentation '
+              'overhead (mostly one-time lazy imports, e.g. desitarget/healpy); '
+              'pass --no-cprofile-io for an uninstrumented wall-clock number.\n')
+
     # Optional: cProfile on one warm pass
     if args.cprofile:
         prof_path = outdir / f'{mode}.prof'
         print(f'Running cProfile (1 warm pass) -> {prof_path} ...', flush=True)
-
-        pr = cProfile.Profile()
-        pr.enable()
-        run_fitting_loop(fitargs)
-        pr.disable()
-
-        pr.dump_stats(str(prof_path))
-
-        # Print top-N to stdout
-        buf = io.StringIO()
-        ps  = pstats.Stats(pr, stream=buf).sort_stats('cumulative')
-        ps.print_stats(args.cprofile_top)
-        print(buf.getvalue())
-        print(f'Full profile saved to: {prof_path}')
-        print(f'  View with:  python -m snakeviz {prof_path}')
-        print(f'  Or:         python -m pstats {prof_path}')
+        run_cprofile(lambda: run_fitting_loop(fitargs), prof_path, args.cprofile_top, 'fit-loop')
 
     return 0
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ Change Log
 3.6.0 (not released yet)
 ------------------------
 
+* Faster continuum fitting and I/O by caching the SFD dust map [`PR
+  #275`_].
 * Support analysis of mini-specprod datasets [`PR #274`_].
 * Dynamically split ``FASTSPEC`` HDU into an additional ``MORELINES``
   HDU [`PR #273`_].
@@ -14,6 +16,7 @@ Change Log
 * New unit test and documentation of external photometric catalog
   "mode" [`PR #269`_].
 
+.. _`PR #275`: https://github.com/desihub/fastspecfit/pull/275
 .. _`PR #274`: https://github.com/desihub/fastspecfit/pull/274
 .. _`PR #273`: https://github.com/desihub/fastspecfit/pull/273
 .. _`PR #271`: https://github.com/desihub/fastspecfit/pull/271

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1001,23 +1001,37 @@ class ContinuumTools(object):
             log.critical(errmsg)
             raise ValueError(errmsg)
 
+        # Scratch buffers reused across every _fill(tauv) call (Brent's method
+        # evaluates this ~10-15 times per fit) so the outer-product-sized
+        # arrays aren't reallocated on every trial tauv.
+        npix   = templateflux.shape[1]
+        A_buf  = np.empty(npix)
+        Az_buf = np.empty(npix)
+        if dust_emission:
+            dterm_buf  = np.empty((ntemplates, npix - 1))
+            dterm_buf2 = np.empty((ntemplates, npix - 1))
+            outer_buf  = np.empty((ntemplates, npix))
+
         def _fill(tauv):
-            A           = np.exp(-tauv * dust_kl)     # (npix,)
-            Az          = A * zfactors                 # (npix,)
-            phi[:]      = templateflux * Az            # (ntemplates, npix)
+            np.multiply(dust_kl, -tauv, out=A_buf)
+            np.exp(A_buf, out=A_buf)                       # A_buf: A = exp(-tauv*dust_kl)
+            np.multiply(A_buf, zfactors, out=Az_buf)       # Az_buf: Az
+            np.multiply(templateflux, Az_buf, out=phi)     # phi = templateflux * Az
             if dust_emission:
-                one_minus_A = 1. - A
-                d = 0.5 * (
-                    templateflux[:, :-1] * one_minus_A[:-1] +
-                    templateflux[:, 1:]  * one_minus_A[1:]
-                ) @ wave_diff                          # (ntemplates,)
-                phi[:] += d[:, None] * dustflux_zf
+                np.subtract(1., A_buf, out=A_buf)          # A_buf: one_minus_A
+                np.multiply(templateflux[:, :-1], A_buf[:-1], out=dterm_buf)
+                np.multiply(templateflux[:, 1:],  A_buf[1:],  out=dterm_buf2)
+                dterm_buf[:] += dterm_buf2
+                dterm_buf[:] *= 0.5
+                d = dterm_buf @ wave_diff                  # (ntemplates,)
+                np.multiply(d[:, None], dustflux_zf, out=outer_buf)
+                phi[:] += outer_buf
             if synthspec:
                 spec_batch = self.continuum_to_spectroscopy_batch(phi)  # (ntemplates, nspec)
-                Psi[:nspec, :] = spec_batch.T * specistd[:, None]
+                np.multiply(spec_batch.T, specistd[:, None], out=Psi[:nspec, :])
             if synthphot:
                 phot_batch = self.continuum_to_photometry_batch(phi)    # (ntemplates, nphot)
-                Psi[nspec:, :] = phot_batch.T * objflamistd[:, None]
+                np.multiply(phot_batch.T, objflamistd[:, None], out=Psi[nspec:, :])
 
         def objective(tauv):
             _fill(tauv)

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -982,6 +982,19 @@ class ContinuumTools(object):
         # Precompute quantities that are independent of tauv.
         wave_diff    = np.diff(wave)
         dustflux_zf  = dustflux * zfactors
+        if dust_emission:
+            # Trapezoidal-quadrature weights on the (fixed) template
+            # wavelength grid, so that trapz(f, wave) == f @ trapz_weights
+            # for any f. The energy-balance term is
+            #   d = trapz(templateflux * (1 - A), wave)
+            #     = trapz(templateflux, wave) - trapz(templateflux * A, wave)
+            #     = template_wave_integral - templateflux @ (A * trapz_weights)
+            # and since templateflux doesn't depend on tauv, the first term
+            # can be computed once here instead of on every _fill(tauv) call.
+            trapz_weights = np.zeros_like(wave)
+            trapz_weights[:-1] += 0.5 * wave_diff
+            trapz_weights[1:]  += 0.5 * wave_diff
+            template_wave_integral = templateflux @ trapz_weights   # (ntemplates,)
 
         b   = np.empty(nrows)
         Psi = np.empty((nrows, ntemplates))
@@ -1008,9 +1021,8 @@ class ContinuumTools(object):
         A_buf  = np.empty(npix)
         Az_buf = np.empty(npix)
         if dust_emission:
-            dterm_buf  = np.empty((ntemplates, npix - 1))
-            dterm_buf2 = np.empty((ntemplates, npix - 1))
-            outer_buf  = np.empty((ntemplates, npix))
+            Aw_buf    = np.empty(npix)
+            outer_buf = np.empty((ntemplates, npix))
 
         def _fill(tauv):
             np.multiply(dust_kl, -tauv, out=A_buf)
@@ -1018,12 +1030,8 @@ class ContinuumTools(object):
             np.multiply(A_buf, zfactors, out=Az_buf)       # Az_buf: Az
             np.multiply(templateflux, Az_buf, out=phi)     # phi = templateflux * Az
             if dust_emission:
-                np.subtract(1., A_buf, out=A_buf)          # A_buf: one_minus_A
-                np.multiply(templateflux[:, :-1], A_buf[:-1], out=dterm_buf)
-                np.multiply(templateflux[:, 1:],  A_buf[1:],  out=dterm_buf2)
-                dterm_buf[:] += dterm_buf2
-                dterm_buf[:] *= 0.5
-                d = dterm_buf @ wave_diff                  # (ntemplates,)
+                np.multiply(A_buf, trapz_weights, out=Aw_buf)
+                d = template_wave_integral - templateflux @ Aw_buf  # (ntemplates,)
                 np.multiply(d[:, None], dustflux_zf, out=outer_buf)
                 phi[:] += outer_buf
             if synthspec:

--- a/py/fastspecfit/continuum.py
+++ b/py/fastspecfit/continuum.py
@@ -1533,6 +1533,13 @@ def continuum_fastphot(redshift, objflam, objflamivar, CTools, uniqueid=0,
                 msg.append(f'{label}={val:.3f}{var_msg}{units}')
             msg.append(f'vdisp={vdisp:.0f} km/s')
             log.info(' '.join(msg))
+        else:
+            coeff_monte = None
+            tauv_monte = None
+            sedmodel_monte = None
+            sedmodel_nolines_monte = None
+            tauv_ivar = 0.
+            dn4000_model_ivar = 0.
 
     return (coeff, coeff_monte, rchi2_phot, tauv, tauv_monte, tauv_ivar, vdisp,
             dn4000_model, dn4000_model_ivar, sedmodel, sedmodel_monte,

--- a/py/fastspecfit/fastspecfit.py
+++ b/py/fastspecfit/fastspecfit.py
@@ -47,6 +47,7 @@ def make_init_sc_args(args, fastphot=False, fitstack=False):
         'log_verbose':       getattr(args, 'verbose', False),
         'vdisp_nominal':     getattr(args, 'vdisp_nominal', VDISP_NOMINAL),
         'vdisp_bounds':      getattr(args, 'vdisp_bounds', VDISP_BOUNDS),
+        'mapdir':            getattr(args, 'mapdir', None),
     }
 
 
@@ -347,8 +348,7 @@ def fastspec(fastphot=False, fitstack=False, args=None, comm=None, verbose=False
 
         # Read the data.
         Spec = DESISpectra(phot=sc_data.photometry, cosmo=sc_data.cosmology,
-                           fphotodir=args.fphotodir, mapdir=args.mapdir,
-                           redux_dir=args.redux_dir)
+                           fphotodir=args.fphotodir, redux_dir=args.redux_dir)
 
         if fitstack:
             data, meta = Spec.read_stacked(args.redrockfiles, firsttarget=args.firsttarget,

--- a/py/fastspecfit/io.py
+++ b/py/fastspecfit/io.py
@@ -471,13 +471,10 @@ class DESISpectra(object):
     fphotodir : str or None, optional
         Top-level directory of the source photometry (Legacy Survey). Defaults
         to ``$FPHOTO_DIR``.
-    mapdir : str or None, optional
-        Directory containing the Milky Way dust maps. Defaults to
-        ``$DUST_DIR/maps``.
 
     """
 
-    def __init__(self, phot, cosmo, redux_dir=None, fphotodir=None, mapdir=None):
+    def __init__(self, phot, cosmo, redux_dir=None, fphotodir=None):
         if redux_dir is None:
             redux_env = os.environ.get('DESI_SPECTRO_REDUX')
             self.redux_dir = os.path.expandvars(redux_env) if redux_env else None
@@ -503,12 +500,6 @@ class DESISpectra(object):
                     pass
             self.fphotoext = fphotoext
             self.fphotodir = fphotodir
-
-        if mapdir is None:
-            dust_env = os.environ.get('DUST_DIR')
-            self.mapdir = os.path.join(os.path.expandvars(dust_env), 'maps') if dust_env else None
-        else:
-            self.mapdir = mapdir
 
         self.phot = phot
         self.cosmo = cosmo
@@ -1080,13 +1071,10 @@ class DESISpectra(object):
         from desitarget.geomask import match_to
         from desispec.coaddition import coadd_cameras
         from desispec.io import read_spectra
-        from desiutil.dust import SFDMap
         from fastspecfit.resolution import Resolution
         from fastspecfit.util import mwdust_transmission
 
         t0 = time.time()
-
-        SFD = SFDMap(scaling=1.0, mapdir=self.mapdir)
 
         uniqueid_col = self.phot.uniqueid_col
 
@@ -1115,7 +1103,7 @@ class DESISpectra(object):
                 tuniv = np.full_like(redshift, 100.)
 
             # Populate 'meta' with dust and filter-related quantities.
-            ebv = SFD.ebv(meta['RA'], meta['DEC'])
+            ebv = sc_data.sfdmap.ebv(meta['RA'], meta['DEC'])
             meta['EBV'] = ebv
 
             if 'PHOTSYS' in meta.colnames:

--- a/py/fastspecfit/qa.py
+++ b/py/fastspecfit/qa.py
@@ -1929,6 +1929,7 @@ def fastqa(args=None, comm=None):
         'template_version':  args.templateversion,
         'template_imf':      args.imf,
         'log_verbose':       False,
+        'mapdir':            args.mapdir,
     }
 
     sc_data.initialize(**init_sc_args)
@@ -1958,8 +1959,7 @@ def fastqa(args=None, comm=None):
 
     # Initialize the I/O class.
     Spec = DESISpectra(phot=sc_data.photometry, cosmo=sc_data.cosmology,
-                       redux_dir=args.redux_dir, fphotodir=args.fphotodir,
-                       mapdir=args.mapdir)
+                       redux_dir=args.redux_dir, fphotodir=args.fphotodir)
 
     def _wrap_qa(redrockfile, indx=None, fitstack=False):
         if indx is None:

--- a/py/fastspecfit/singlecopy.py
+++ b/py/fastspecfit/singlecopy.py
@@ -22,7 +22,8 @@ class Singletons(object):
 
     """
     def __init__(self):
-        pass
+        self._mapdir = None
+        self._sfdmap = None
 
     def initialize(self,
                    emlines_file=None,
@@ -37,6 +38,7 @@ class Singletons(object):
                    template_version=None,
                    template_imf=None,
                    log_verbose=False,
+                   mapdir=None,
     ):
         """Load all singleton data structures from disk.
 
@@ -75,6 +77,12 @@ class Singletons(object):
         log_verbose : :class:`bool`, optional
             If ``True``, set the logger level to ``DEBUG``. Default is
             ``False``.
+        mapdir : :class:`str` or None, optional
+            Directory containing the Milky Way dust maps; defaults to
+            ``$DUST_DIR/maps``. Only consulted if something actually
+            accesses :attr:`sfdmap` (the map itself is loaded lazily, on
+            first access, not here); stacked-spectra fits and other callers
+            that never touch dust corrections never require it.
 
         """
         if log_verbose:
@@ -82,10 +90,13 @@ class Singletons(object):
 
         key = (emlines_file, constraints_file, fphotofile, fastphot, fitstack,
                ignore_photometry, template_file, template_version, template_imf,
-               vdisp_nominal, tuple(vdisp_bounds) if vdisp_bounds is not None else None)
+               vdisp_nominal, tuple(vdisp_bounds) if vdisp_bounds is not None else None,
+               mapdir)
         if getattr(self, '_init_key', None) == key:
             return
         self._init_key = key
+        self._mapdir = mapdir
+        self._sfdmap = None
 
         # templates for continuum fitting
         self.templates = Templates(template_file=template_file,
@@ -119,6 +130,22 @@ class Singletons(object):
         # IGM model
         self.igm = Inoue14()
         log.debug(f'Cached {self.igm.reference} IGM attenuation parameters.')
+
+    @property
+    def sfdmap(self):
+        """Milky Way dust map (:class:`desiutil.dust.SFDMap`), shared across
+        every :meth:`~fastspecfit.io.DESISpectra.read` call in this process.
+
+        Built lazily on first access rather than in :meth:`initialize`, so
+        that stacked-spectra fits and any other caller that never touches
+        dust corrections neither pay the load cost nor require ``$DUST_DIR``
+        to be set.
+        """
+        if self._sfdmap is None:
+            from desiutil.dust import SFDMap
+            self._sfdmap = SFDMap(scaling=1.0, mapdir=self._mapdir)
+            log.debug(f'Cached Milky Way dust map {self._sfdmap.mapdir}')
+        return self._sfdmap
 
 
 # global structure with single-copy data, initially empty


### PR DESCRIPTION
## Summary

Optimizes the inner tau_V search loop of the stellar continuum fit (buffer reuse plus hoisting a tau_V-independent term out of the per-iteration work), giving a meaningful speed-up in the hottest part of continuum.py without changing the fitted results. Also stops rebuilding the Milky Way dust map on every spectrum read, sharing one copy per process instead, and fixes a crash in fastphot when Monte Carlo realizations are disabled (--nmonte 0).

Along the way, the standalone profiling harness (bin/profile-fastspec) was generalized to run against real DESI spectra instead of only the bundled test file, and now profiles the I/O phase in addition to the fitting loop; that is what surfaced the dust-map opportunity in the first place.

Verified against the full test suite plus targeted before/after profiling for each change.