### PR TITLE
more flexible template-building and better header information

### DIFF
--- a/bin/build-mini-specprod
+++ b/bin/build-mini-specprod
@@ -201,6 +201,7 @@ def build_photometry(dr9dir, outdir, fibermaps):
     """Gather and write the Tractor photometry matching *fibermaps*."""
     from astropy.table import MaskedColumn
     from desispec.io.photo import gather_tractorphot
+    from fastspecfit.photometry import desitarget_resolve_dec
 
     # Each fibermap carries per-file FITS metadata (CHECKSUM, DATASUM, ...)
     # that vstack otherwise complains about merging; it's meaningless once
@@ -225,6 +226,13 @@ def build_photometry(dr9dir, outdir, fibermaps):
 
     tractor = gather_tractorphot(combined, legacysurveydir=dr9dir)
 
+    # Per-TARGETID PHOTSYS/Dec, needed below to pick the correct region for
+    # boundary-strip bricks that have a Tractor catalog in *both* trees (see
+    # comment further down).
+    photsys_map = dict(zip(combined['TARGETID'], combined['PHOTSYS']))
+    dec_map = dict(zip(combined['TARGETID'], combined['TARGET_DEC']))
+    resolve_dec = desitarget_resolve_dec()
+
     for brick in sorted(set(tractor['BRICKNAME'])):
         B = tractor[tractor['BRICKNAME'] == brick].copy()
 
@@ -237,19 +245,42 @@ def build_photometry(dr9dir, outdir, fibermaps):
                  f"skipping: {list(B['TARGETID'])}")
             continue
 
-        # Determine which region (north/south) actually contains this brick
-        # by checking the filesystem directly, rather than trusting the
-        # targeting-time PHOTSYS: for positionally-matched objects (blank or
-        # zero-valued BRICKID/BRICK_OBJID, e.g. secondary targets) the real
-        # match can land in either region regardless of the nominal PHOTSYS
-        # value, and the two can disagree near the north/south boundary.
-        for oneregion in ('north', 'south'):
-            infile = os.path.join(dr9dir, oneregion, 'tractor', brick[:3], f'tractor-{brick}.fits')
-            if os.path.isfile(infile):
-                break
+        # Determine which region (north/south) this brick's Tractor file
+        # should come from using each target's own PHOTSYS, falling back to
+        # the same Dec cut used for positionally-matched targets (mirrors
+        # fastspecfit.photometry._gather_tractorphot_onebrick) -- not simply
+        # whichever region happens to exist on disk. Boundary-strip bricks
+        # can have a Tractor catalog in *both* trees (overlapping BASS/MzLS
+        # and DECaLS imaging), and fastspec's later PHOTSYS-driven lookup
+        # expects a specific one; copying the wrong one here causes a
+        # spurious "Unable to find Tractor catalog" crash downstream.
+        regions = []
+        for tid in B['TARGETID']:
+            photsys = photsys_map.get(tid, '')
+            if photsys == 'S':
+                regions.append('south')
+            elif photsys == 'N':
+                regions.append('north')
+            else:
+                dec = dec_map.get(tid)
+                regions.append('south' if dec is not None and dec < resolve_dec else 'north')
+        vals, counts = np.unique(regions, return_counts=True)
+        preferred = vals[np.argmax(counts)]
+
+        infile = os.path.join(dr9dir, preferred, 'tractor', brick[:3], f'tractor-{brick}.fits')
+        if os.path.isfile(infile):
+            oneregion = preferred
         else:
-            print(f'WARNING: could not locate a north or south Tractor file for brick {brick}; skipping.')
-            continue
+            # Only one region has the file; use it regardless of preference.
+            fallback = 'north' if preferred == 'south' else 'south'
+            infile = os.path.join(dr9dir, fallback, 'tractor', brick[:3], f'tractor-{brick}.fits')
+            if os.path.isfile(infile):
+                print(f'WARNING: brick {brick} PHOTSYS/Dec indicates {preferred}, but only the '
+                     f'{fallback} Tractor file exists; using it.')
+                oneregion = fallback
+            else:
+                print(f'WARNING: could not locate a north or south Tractor file for brick {brick}; skipping.')
+                continue
 
         B.remove_columns([col for col in ('TARGETID', 'LS_ID') if col in B.colnames])
 

--- a/bin/build-templates
+++ b/bin/build-templates
@@ -608,8 +608,8 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
     :func:`build_fe_templates`, then assembles the results into a single
     multi-extension FITS file. With no ``tag``, this is written to
     ``<templatedir>/<version>/ftemplates-{imf}-{version}.fits``; with a
-    custom ``tag`` it is written to
-    ``<templatedir>/<tag>/ftemplates-{imf}-{tag}-{version}.fits``.
+    custom ``tag`` it is written flat to
+    ``<templatedir>/ftemplates-{imf}-{tag}-{version}.fits``.
 
     Parameters
     ----------
@@ -650,12 +650,13 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
         Provenance string embedded in the FITS header's ``VERSION``
         keyword, e.g. ``'2.1.0'``.
     tag : :class:`str` or None, optional
-        Tag used for the output directory and filename instead of
-        ``version``, e.g. for a custom/one-off template set. Defaults to
-        ``version`` when ``None``.
+        Tag used in place of ``version`` in the output filename, e.g. for
+        a custom/one-off template set. When given, the file is written
+        flat directly into ``templatedir`` (no version subdirectory), so
+        multiple versions of the same tag can coexist there. Defaults to
+        ``version`` when ``None`` (production layout, see above).
     templatedir : :class:`str` or None, optional
-        Root output directory; the FITS file is written under
-        ``<templatedir>/<tag>/`` (see above).
+        Root output directory (see above).
     origdir : :class:`str` or None, optional
         Directory containing the shared raw input files (DL07 dust
         grids, Fe template, Nenkova+08 torus grid). Defaults to
@@ -752,15 +753,16 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
     #agnflux[I] = 0.
 
     # Write out. Production (no --tag) keeps the versioned-subdirectory
-    # layout; a custom --tag is written flat so multiple versions of the
-    # same tag can coexist in one directory.
-    outdir = os.path.join(templatedir, tag)
-    if not os.path.isdir(outdir):
-        os.makedirs(outdir, exist_ok=True)
+    # layout; a custom --tag is written flat directly into templatedir so
+    # multiple versions of the same tag can coexist in one directory.
     if custom_tag:
+        outdir = templatedir
         outfile = os.path.join(outdir, f'ftemplates-{imf}-{tag}-{version}.fits')
     else:
+        outdir = os.path.join(templatedir, tag)
         outfile = os.path.join(outdir, f'ftemplates-{imf}-{tag}.fits')
+    if not os.path.isdir(outdir):
+        os.makedirs(outdir, exist_ok=True)
 
     #isplit = np.argmin(np.abs(wave-PIXKMS_WAVESPLIT)) + 1
 
@@ -852,9 +854,11 @@ if __name__ == '__main__':
                              '$FTEMPLATES_DIR/original.')
     parser.add_argument('--version', required=True, help='Version number (e.g., 3.0.0)')
     parser.add_argument('--tag', type=str, default=None,
-                        help='Output directory/filename tag; defaults to --version. '
-                             'Use for a custom/one-off template set (e.g., paper1) '
-                             'whose --version need not follow the production numbering.')
+                        help='Output filename tag used in place of --version; when given, '
+                             'the file is written flat directly into --templatedir (no '
+                             'version subdirectory). Use for a custom/one-off template set '
+                             '(e.g., paper1) whose --version need not follow the production '
+                             'numbering.')
     parser.add_argument('--no-agn', action='store_true',
                         help='Skip building the AGN torus and Fe emission templates '
                              '(AGNFLUX, AGNWAVE, FEFLUX, FEWAVE), which are only used '

--- a/bin/build-templates
+++ b/bin/build-templates
@@ -19,20 +19,23 @@ Usage
       --templatedir $DESI_ROOT/users/ioannis/fastspecfit/templates \\
       --logmets=-1.,0.,0.3
 
-  time python bin/build-templates --version 1.0.0 --tag paper1 \\
-      --templatedir $DESI_ROOT/users/ioannis/fastspecfit/templates
+  time python bin/build-templates --version 1.0.0 --tag paper1 --no-agn \\
+      --templatedir /path/to/custom/templates
 
 Input Files
 -----------
-The script expects the following raw data files under
-``<templatedir>/original/``:
+The script expects the following raw data files under ``origdir``
+(``--origdir``, default ``$FTEMPLATES_DIR/original`` — the shared
+production input directory, so a custom/side-project ``--templatedir``
+does not need its own copy):
 
 - ``DL07_MW3.1_{00,10,20,30,40,50,60}.dat`` — Draine & Li (2007) dust
   emission grids (Table 3 of https://arxiv.org/pdf/astro-ph/0608003).
+  Always required.
 - ``fetemplates-1.0.fits`` — Vestergaard & Wilkes (2001) UV Fe emission
-  template (``VW01ALT`` extension).
+  template (``VW01ALT`` extension). Not needed with ``--no-agn``.
 - ``Nenkova08_y010_torusg_n10_q2.0.dat`` — Nenkova et al. (2008) clumpy
-  AGN torus model grid.
+  AGN torus model grid. Not needed with ``--no-agn``.
 
 Stellar Population Model
 ------------------------
@@ -52,8 +55,9 @@ Stellar spectra are computed with ``python-fsps`` using:
 
 Output FITS Extensions
 ----------------------
-The output ``ftemplates-{imf}-{version}.fits`` file contains the
-following extensions (in order):
+The output file contains the following extensions (in order). The
+``AGNFLUX``, ``AGNWAVE``, ``FEFLUX``, and ``FEWAVE`` extensions are
+omitted when ``--no-agn`` is passed.
 
 ``FLUX`` (Primary HDU, float64 [nwave x nmodel])
     Stellar continuum plus nebular emission in units of
@@ -236,11 +240,13 @@ def _qa_dustem_templates(dustwave, mduste, qpah, umin, gamma, png):
     fig.savefig(png)
 
 
-def build_dustem_templates(qpah=3.5, umin=1., gamma=0.01, png=None):
+def build_dustem_templates(origdir, qpah=3.5, umin=1., gamma=0.01, png=None):
     """Build the DL07 dust emission templates.
 
     Parameters
     ----------
+    origdir : :class:`str`
+        Directory containing the raw ``DL07_MW3.1_*.dat`` input files.
     qpah : :class:`float`, optional
         PAH fraction. Default is 3.5.
     umin : :class:`float`, optional
@@ -282,7 +288,7 @@ def build_dustem_templates(qpah=3.5, umin=1., gamma=0.01, png=None):
     dustem = np.zeros((nqpah, numin*2, nwave))
 
     for imodel, model in enumerate(models):
-        dustfile = os.path.join(templatedir, 'original', f'DL07_{model}.dat')
+        dustfile = os.path.join(origdir, f'DL07_{model}.dat')
         dustem1 = np.loadtxt(dustfile, skiprows=2)
         if imodel == 0:
             dustwave = dustem1[:, 0]
@@ -312,11 +318,13 @@ def build_dustem_templates(qpah=3.5, umin=1., gamma=0.01, png=None):
     return dustwave, mduste
 
 
-def build_fe_templates(version='1.0', png=None):
+def build_fe_templates(origdir, version='1.0', png=None):
     """Build the Fe emission template.
 
     Parameters
     ----------
+    origdir : :class:`str`
+        Directory containing the raw ``fetemplates-{version}.fits`` input file.
     version : :class:`str`, optional
         Template file version string. Default is ``'1.0'``.
     png : :class:`str` or None, optional
@@ -348,7 +356,7 @@ def build_fe_templates(version='1.0', png=None):
         fig.tight_layout()
         fig.savefig(png)
 
-    templatefile = os.path.join(templatedir, 'original', f'fetemplates-{version}.fits')
+    templatefile = os.path.join(origdir, f'fetemplates-{version}.fits')
     fe = fitsio.read(templatefile, 'VW01ALT')
     fewave = fe['WAVE'].astype('f8')
     feflux = fe['FLUX'].astype('f8')
@@ -373,11 +381,14 @@ def build_fe_templates(version='1.0', png=None):
     return newwave, newflux
 
 
-def build_agn_templates(agntau=10., png=None):
+def build_agn_templates(origdir, agntau=10., png=None):
     """Build the AGN (Nenkova+08 torus) template.
 
     Parameters
     ----------
+    origdir : :class:`str`
+        Directory containing the raw ``Nenkova08_y010_torusg_n10_q2.0.dat``
+        input file.
     agntau : :class:`float`, optional
         AGN optical depth. Default is 10.0.
     png : :class:`str` or None, optional
@@ -412,7 +423,7 @@ def build_agn_templates(agntau=10., png=None):
         fig.tight_layout()
         fig.savefig(png)
 
-    templatefile = os.path.join(templatedir, 'original', 'Nenkova08_y010_torusg_n10_q2.0.dat')
+    templatefile = os.path.join(origdir, 'Nenkova08_y010_torusg_n10_q2.0.dat')
     data = np.loadtxt(templatefile, skiprows=4)
     agnwave = data[:, 0]    # [nwave, Angstrom]
     agngrid = data[:, 1:].T # [nagn, nwave]
@@ -587,14 +598,18 @@ def build_fsps_templates(models, logages, agebins=None, imf='chabrier',
 
 
 def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0.01,
-         agntau=10., test=False, version='1.0.0', tag=None, templatedir=None):
+         agntau=10., include_agn=True, test=False, version='1.0.0', tag=None,
+         templatedir=None, origdir=None):
     """Build all templates and write the output FITS file.
 
     Orchestrates calls to :func:`build_fsps_templates` (twice — with and
-    without nebular emission), :func:`build_dustem_templates`,
-    :func:`build_agn_templates`, and :func:`build_fe_templates`, then
-    assembles the results into a single multi-extension FITS file at
-    ``<templatedir>/<version>/ftemplates-{imf}-{version}.fits``.
+    without nebular emission), :func:`build_dustem_templates`, and
+    (unless ``include_agn`` is ``False``) :func:`build_agn_templates` and
+    :func:`build_fe_templates`, then assembles the results into a single
+    multi-extension FITS file. With no ``tag``, this is written to
+    ``<templatedir>/<version>/ftemplates-{imf}-{version}.fits``; with a
+    custom ``tag`` it is written to
+    ``<templatedir>/<tag>/ftemplates-{imf}-{tag}-{version}.fits``.
 
     Parameters
     ----------
@@ -621,6 +636,13 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
         radiation field component). Default is 0.01.
     agntau : :class:`float`, optional
         Nenkova et al. (2008) AGN torus optical depth. Default is 10.0.
+    include_agn : :class:`bool`, optional
+        If ``False``, skip building the AGN torus and Fe emission
+        templates and omit the ``AGNFLUX``, ``AGNWAVE``, ``FEFLUX``, and
+        ``FEWAVE`` extensions from the output file (and skip reading
+        their raw inputs from ``origdir``). These extensions are only
+        used by the still-in-development ``fastqso`` mode. Default is
+        ``True``.
     test : :class:`bool`, optional
         If ``True``, override ``logmets`` with ``[0.0]`` for a quick
         single-metallicity test run. Default is ``False``.
@@ -632,20 +654,32 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
         ``version``, e.g. for a custom/one-off template set. Defaults to
         ``version`` when ``None``.
     templatedir : :class:`str` or None, optional
-        Root template directory. Raw input files are read from
-        ``<templatedir>/original/`` and the output FITS file is written
-        to ``<templatedir>/<tag>/``.
+        Root output directory; the FITS file is written under
+        ``<templatedir>/<tag>/`` (see above).
+    origdir : :class:`str` or None, optional
+        Directory containing the shared raw input files (DL07 dust
+        grids, Fe template, Nenkova+08 torus grid). Defaults to
+        ``$FTEMPLATES_DIR/original`` when ``None``.
 
     """
+    custom_tag = tag is not None
     if tag is None:
         tag = version
+
+    if origdir is None:
+        ftemplates_dir = os.environ.get('FTEMPLATES_DIR')
+        if not ftemplates_dir:
+            raise IOError('origdir not specified and $FTEMPLATES_DIR is not set.')
+        origdir = os.path.join(os.path.expandvars(ftemplates_dir), 'original')
+
     # AGN + Fe template(s)
-    fewave, feflux = build_fe_templates(version='1.0')#, png=os.path.join(templatedir, 'original', 'qa-fe.png'))
-    agnwave, agnflux = build_agn_templates(agntau=agntau, png=os.path.join(templatedir, 'original', 'qa-agn.png'))
+    if include_agn:
+        fewave, feflux = build_fe_templates(origdir, version='1.0')#, png=os.path.join(origdir, 'qa-fe.png'))
+        agnwave, agnflux = build_agn_templates(origdir, agntau=agntau)#, png=os.path.join(origdir, 'qa-agn.png'))
 
     # dust emission template(s)
-    dustwave, dustflux = build_dustem_templates(qpah=qpah, umin=umin, gamma=gamma)#,
-                                              #png=os.path.join(templatedir, 'original', 'qa-dustem.png'))
+    dustwave, dustflux = build_dustem_templates(origdir, qpah=qpah, umin=umin, gamma=gamma)#,
+                                              #png=os.path.join(origdir, 'qa-dustem.png'))
 
     print(f'<IR Dust>: q_PAH = {qpah}, U_min = {umin}, gamma = {gamma}')
 
@@ -717,11 +751,16 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
     #I = wave <= agnwave[0] # do not extrapolate blueward
     #agnflux[I] = 0.
 
-    # Write out.
+    # Write out. Production (no --tag) keeps the versioned-subdirectory
+    # layout; a custom --tag is written flat so multiple versions of the
+    # same tag can coexist in one directory.
     outdir = os.path.join(templatedir, tag)
     if not os.path.isdir(outdir):
         os.makedirs(outdir, exist_ok=True)
-    outfile = os.path.join(outdir, f'ftemplates-{imf}-{tag}.fits')
+    if custom_tag:
+        outfile = os.path.join(outdir, f'ftemplates-{imf}-{tag}-{version}.fits')
+    else:
+        outfile = os.path.join(outdir, f'ftemplates-{imf}-{tag}.fits')
 
     #isplit = np.argmin(np.abs(wave-PIXKMS_WAVESPLIT)) + 1
 
@@ -742,14 +781,15 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
     hduflux3.header['GAMMA'] = (gamma, 'gamma parameter')
     hduflux3.header['BUNIT'] = 'erg/(s cm2 Angstrom)'
 
-    hduflux4 = fits.ImageHDU(agnflux)
-    hduflux4.header['EXTNAME'] = 'AGNFLUX'
-    hduflux4.header['AGNTAU'] = (agntau, 'AGN optical depth')
-    hduflux4.header['BUNIT'] = 'erg/(s cm2 Angstrom)'
+    if include_agn:
+        hduflux4 = fits.ImageHDU(agnflux)
+        hduflux4.header['EXTNAME'] = 'AGNFLUX'
+        hduflux4.header['AGNTAU'] = (agntau, 'AGN optical depth')
+        hduflux4.header['BUNIT'] = 'erg/(s cm2 Angstrom)'
 
-    hduflux5 = fits.ImageHDU(feflux)
-    hduflux5.header['EXTNAME'] = 'FEFLUX'
-    hduflux5.header['BUNIT'] = 'erg/(s cm2 Angstrom)'
+        hduflux5 = fits.ImageHDU(feflux)
+        hduflux5.header['EXTNAME'] = 'FEFLUX'
+        hduflux5.header['BUNIT'] = 'erg/(s cm2 Angstrom)'
 
 
     hduwave1 = fits.ImageHDU(wave)
@@ -761,16 +801,17 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
     hduwave1.header['PIXKMS'] = (Templates.PIXKMS, 'pixel size within PIXWAVLO-PIXWAVHI [km/s]')
     hduwave1.header['SIGC3K'] = (Templates.SIGMA_C3K, 'C3K native Gaussian sigma [km/s]')
 
-    hduwave2 = fits.ImageHDU(agnwave)
-    hduwave2.header['EXTNAME'] = 'AGNWAVE'
-    hduwave2.header['BUNIT'] = 'Angstrom'
-    hduwave2.header['AIRORVAC'] = ('vac', 'vacuum wavelengths')
+    if include_agn:
+        hduwave2 = fits.ImageHDU(agnwave)
+        hduwave2.header['EXTNAME'] = 'AGNWAVE'
+        hduwave2.header['BUNIT'] = 'Angstrom'
+        hduwave2.header['AIRORVAC'] = ('vac', 'vacuum wavelengths')
 
-    hduwave3 = fits.ImageHDU(fewave)
-    hduwave3.header['EXTNAME'] = 'FEWAVE'
-    hduwave3.header['BUNIT'] = 'Angstrom'
-    hduwave3.header['AIRORVAC'] = ('vac', 'vacuum wavelengths')
-    hduwave3.header['PIXSZ'] = (Templates.AGN_PIXKMS, 'pixel size [km/s]')
+        hduwave3 = fits.ImageHDU(fewave)
+        hduwave3.header['EXTNAME'] = 'FEWAVE'
+        hduwave3.header['BUNIT'] = 'Angstrom'
+        hduwave3.header['AIRORVAC'] = ('vac', 'vacuum wavelengths')
+        hduwave3.header['PIXSZ'] = (Templates.AGN_PIXKMS, 'pixel size [km/s]')
 
 
     hdutable = fits.convenience.table_to_hdu(meta)
@@ -789,10 +830,11 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
     hduwave4.header['AIRORVAC'] = ('vac', 'vacuum wavelengths')
 
     # metadata table
-    hx = fits.HDUList([hduflux1, hduflux2, hduflux3, hduwave1, hdutable,
-                       hduflux4, hduwave2,
-                       hduflux5, hduwave3,
-                       hduflux6, hduwave4])
+    hdus = [hduflux1, hduflux2, hduflux3, hduwave1, hdutable]
+    if include_agn:
+        hdus += [hduflux4, hduwave2, hduflux5, hduwave3]
+    hdus += [hduflux6, hduwave4]
+    hx = fits.HDUList(hdus)
 
     print(f'Writing {len(models)} model spectra to {outfile}')
     hx.writeto(outfile, overwrite=True)
@@ -803,12 +845,20 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--templatedir', required=True, help='Location of original and output templates')
+    parser.add_argument('--templatedir', required=True, help='Location of output templates')
+    parser.add_argument('--origdir', type=str, default=None,
+                        help='Location of shared raw input templates (DL07 dust grids, '
+                             'Fe template, Nenkova+08 torus grid). Defaults to '
+                             '$FTEMPLATES_DIR/original.')
     parser.add_argument('--version', required=True, help='Version number (e.g., 3.0.0)')
     parser.add_argument('--tag', type=str, default=None,
                         help='Output directory/filename tag; defaults to --version. '
                              'Use for a custom/one-off template set (e.g., paper1) '
                              'whose --version need not follow the production numbering.')
+    parser.add_argument('--no-agn', action='store_true',
+                        help='Skip building the AGN torus and Fe emission templates '
+                             '(AGNFLUX, AGNWAVE, FEFLUX, FEWAVE), which are only used '
+                             'by the still-in-development fastqso mode.')
 
     # DL07 parameters
     # https://python-fsps.readthedocs.io/en/latest/stellarpop_api
@@ -830,12 +880,20 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     templatedir = os.path.expandvars(args.templatedir)
-    origdir = os.path.join(templatedir, 'original')
+
+    if args.origdir:
+        origdir = os.path.expandvars(args.origdir)
+    else:
+        ftemplates_dir = os.environ.get('FTEMPLATES_DIR')
+        if not ftemplates_dir:
+            raise IOError('Either --origdir must be specified or $FTEMPLATES_DIR must be set.')
+        origdir = os.path.join(os.path.expandvars(ftemplates_dir), 'original')
     if not os.path.isdir(origdir):
         raise IOError(f'Missing directory containing original templates {origdir}')
 
     logmets = np.array(args.logmets.split(',')).astype(float)
     agelims = np.array(args.agelims.split(',')).astype(float) if args.agelims else None
     main(imf=args.imf, logmets=logmets, agelims=agelims, qpah=args.qpah,
-         umin=args.umin, gamma=args.gamma, agntau=args.agntau, test=args.test,
-         version=args.version, tag=args.tag, templatedir=templatedir)
+         umin=args.umin, gamma=args.gamma, agntau=args.agntau, include_agn=not args.no_agn,
+         test=args.test, version=args.version, tag=args.tag, templatedir=templatedir,
+         origdir=origdir)

--- a/bin/build-templates
+++ b/bin/build-templates
@@ -19,6 +19,9 @@ Usage
       --templatedir $DESI_ROOT/users/ioannis/fastspecfit/templates \\
       --logmets=-1.,0.,0.3
 
+  time python bin/build-templates --version 1.0.0 --tag paper1 \\
+      --templatedir $DESI_ROOT/users/ioannis/fastspecfit/templates
+
 Input Files
 -----------
 The script expects the following raw data files under
@@ -583,7 +586,7 @@ def build_fsps_templates(models, logages, agebins=None, imf='chabrier',
     return meta, newwave, fluxes, linewaves, linefluxes
 
 
-def main(imf='chabrier', logmets=[0.0], qpah=1.0, umin=1., gamma=0.01,
+def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0.01,
          agntau=10., test=False, version='1.0.0', tag=None, templatedir=None):
     """Build all templates and write the output FITS file.
 
@@ -602,6 +605,12 @@ def main(imf='chabrier', logmets=[0.0], qpah=1.0, umin=1., gamma=0.01,
         log10(Z/Zsun) metallicity grid values. Default is ``[0.0]``
         (solar metallicity only). The production templates use
         ``[-1.0, 0.0, 0.3]``.
+    agelims : :class:`list` of :class:`float` or None, optional
+        Lookback time bin edges in Gyr, ascending, of length ``nages+1``.
+        When ``None`` (default), generated with the production 5-bin
+        prescription (``adjust_continuity_agebins``-style: an edge at
+        ~30 Myr, log-spaced edges out to ``0.85*tuniv``, and a final edge
+        at ``tuniv=13.7`` Gyr).
     qpah : :class:`float`, optional
         Draine & Li (2007) PAH mass fraction parameter. Default is 1.0.
     umin : :class:`float`, optional
@@ -640,29 +649,34 @@ def main(imf='chabrier', logmets=[0.0], qpah=1.0, umin=1., gamma=0.01,
 
     print(f'<IR Dust>: q_PAH = {qpah}, U_min = {umin}, gamma = {gamma}')
 
-    # Choose lookback time bins.
-
-    # from prospect.templates.adjust_continuity_agebins
-    nbins = 5
-    tuniv = 13.7
-    tbinmax = (tuniv * 0.85) * 1e9
-    lim1, lim2 = 7.4772, 8.0
-    agelims = np.array([0, lim1] + np.linspace(lim2, np.log10(tbinmax), nbins-2).tolist() + [np.log10(tuniv*1e9)]) # log10(yr)
-    agelims = 10.**agelims / 1e9 # [Gyr]
+    # Choose lookback time bin edges (Gyr). If not supplied explicitly, fall
+    # back to the production default: nbins=5 edges following the
+    # prospect.templates.adjust_continuity_agebins prescription (one edge at
+    # ~30 Myr for young-population resolution, then log-spaced edges out to
+    # 0.85*tuniv, then a final bin out to tuniv).
+    if agelims is None:
+        nbins = 5
+        tuniv = 13.7
+        tbinmax = (tuniv * 0.85) * 1e9
+        lim1, lim2 = 7.4772, 8.0
+        agelims = np.array([0, lim1] + np.linspace(lim2, np.log10(tbinmax), nbins-2).tolist() + [np.log10(tuniv*1e9)]) # log10(yr)
+        agelims = 10.**agelims / 1e9 # [Gyr]
+    else:
+        agelims = np.asarray(agelims, dtype=float) # [Gyr]
 
     agebins = np.array([agelims[:-1], agelims[1:]]).T # [Gyr]
     logages = np.log10(1e9*np.sum(agebins, axis=1) / 2) # mean age [log10(yr)] in each bin
     print('   <Ages>: '+', '.join(['{:.4f}'.format(10.**logage/1e9) for logage in logages]) + ' Gyr')
 
     nages = len(logages)
-    nmets = len(logmets)
-    zsolar = 0.019
-    print(' <Z/Zsun>: '+', '.join(['{:.2f}'.format(10.**logmet) for logmet in logmets]))
 
     # for testing
     if test:
         logmets = [0.]
-        nmets = 1
+
+    nmets = len(logmets)
+    zsolar = 0.019
+    print(' <Z/Zsun>: '+', '.join(['{:.2f}'.format(10.**logmet) for logmet in logmets]))
 
     dims = (nages, nmets)
 
@@ -807,6 +821,10 @@ if __name__ == '__main__':
     parser.add_argument('--imf', type=str, default='chabrier', choices=['chabrier', 'salpeter', 'kroupa'],
                         help='Initial mass function')
     parser.add_argument('--logmets', type=str, default='0.', help='Stellar metallicity values')
+    parser.add_argument('--agelims', type=str, default=None,
+                        help='Comma-separated lookback time bin edges in Gyr, ascending, '
+                             'of length nages+1 (e.g., 0,0.03,0.1,1.08,11.6,13.7). '
+                             'Defaults to the production 5-bin grid.')
     parser.add_argument('--test', action='store_true', help='Generate a test set of SPS models.')
     args = parser.parse_args()
 
@@ -816,6 +834,7 @@ if __name__ == '__main__':
         raise IOError(f'Missing directory containing original templates {origdir}')
 
     logmets = np.array(args.logmets.split(',')).astype(float)
-    main(imf=args.imf, logmets=logmets, qpah=args.qpah,
+    agelims = np.array(args.agelims.split(',')).astype(float) if args.agelims else None
+    main(imf=args.imf, logmets=logmets, agelims=agelims, qpah=args.qpah,
          umin=args.umin, gamma=args.gamma, agntau=args.agntau, test=args.test,
          version=args.version, tag=args.tag, templatedir=templatedir)

--- a/bin/build-templates
+++ b/bin/build-templates
@@ -675,7 +675,7 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
         logmets = [0.]
 
     nmets = len(logmets)
-    zsolar = 0.019
+    zsolar = 0.0134 # Asplund et al. (2009); matches the C3K library abundance mixture
     print(' <Z/Zsun>: '+', '.join(['{:.2f}'.format(10.**logmet) for logmet in logmets]))
 
     dims = (nages, nmets)
@@ -775,7 +775,8 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
 
     hdutable = fits.convenience.table_to_hdu(meta)
     hdutable.header['EXTNAME'] = 'METADATA'
-    hdutable.header['imf'] = imf
+    hdutable.header['IMF'] = imf
+    hdutable.header['ZSUN'] = (zsolar, 'adopted solar metallicity (Asplund+09)')
 
     # emission lines
     hduflux6 = fits.ImageHDU(linefluxes)

--- a/bin/build-templates
+++ b/bin/build-templates
@@ -584,7 +584,7 @@ def build_fsps_templates(models, logages, agebins=None, imf='chabrier',
 
 
 def main(imf='chabrier', logmets=[0.0], qpah=1.0, umin=1., gamma=0.01,
-         agntau=10., test=False, version='1.0.0', templatedir=None):
+         agntau=10., test=False, version='1.0.0', tag=None, templatedir=None):
     """Build all templates and write the output FITS file.
 
     Orchestrates calls to :func:`build_fsps_templates` (twice — with and
@@ -616,14 +616,20 @@ def main(imf='chabrier', logmets=[0.0], qpah=1.0, umin=1., gamma=0.01,
         If ``True``, override ``logmets`` with ``[0.0]`` for a quick
         single-metallicity test run. Default is ``False``.
     version : :class:`str`, optional
-        Version string embedded in the output filename and FITS header,
-        e.g. ``'2.1.0'``.
+        Provenance string embedded in the FITS header's ``VERSION``
+        keyword, e.g. ``'2.1.0'``.
+    tag : :class:`str` or None, optional
+        Tag used for the output directory and filename instead of
+        ``version``, e.g. for a custom/one-off template set. Defaults to
+        ``version`` when ``None``.
     templatedir : :class:`str` or None, optional
         Root template directory. Raw input files are read from
         ``<templatedir>/original/`` and the output FITS file is written
-        to ``<templatedir>/<version>/``.
+        to ``<templatedir>/<tag>/``.
 
     """
+    if tag is None:
+        tag = version
     # AGN + Fe template(s)
     fewave, feflux = build_fe_templates(version='1.0')#, png=os.path.join(templatedir, 'original', 'qa-fe.png'))
     agnwave, agnflux = build_agn_templates(agntau=agntau, png=os.path.join(templatedir, 'original', 'qa-agn.png'))
@@ -698,10 +704,10 @@ def main(imf='chabrier', logmets=[0.0], qpah=1.0, umin=1., gamma=0.01,
     #agnflux[I] = 0.
 
     # Write out.
-    outdir = os.path.join(templatedir, version)
+    outdir = os.path.join(templatedir, tag)
     if not os.path.isdir(outdir):
         os.makedirs(outdir, exist_ok=True)
-    outfile = os.path.join(outdir, f'ftemplates-{imf}-{version}.fits')
+    outfile = os.path.join(outdir, f'ftemplates-{imf}-{tag}.fits')
 
     #isplit = np.argmin(np.abs(wave-PIXKMS_WAVESPLIT)) + 1
 
@@ -739,6 +745,7 @@ def main(imf='chabrier', logmets=[0.0], qpah=1.0, umin=1., gamma=0.01,
     hduwave1.header['PIXWAVLO'] = (Templates.PIXKMS_BOUNDS[0], 'min(wave) where pixel size is PIXKMS [Angstrom]')
     hduwave1.header['PIXWAVHI'] = (Templates.PIXKMS_BOUNDS[1], 'max(wave) where pixel size is PIXKMS [Angstrom]')
     hduwave1.header['PIXKMS'] = (Templates.PIXKMS, 'pixel size within PIXWAVLO-PIXWAVHI [km/s]')
+    hduwave1.header['SIGC3K'] = (Templates.SIGMA_C3K, 'C3K native Gaussian sigma [km/s]')
 
     hduwave2 = fits.ImageHDU(agnwave)
     hduwave2.header['EXTNAME'] = 'AGNWAVE'
@@ -783,6 +790,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--templatedir', required=True, help='Location of original and output templates')
     parser.add_argument('--version', required=True, help='Version number (e.g., 3.0.0)')
+    parser.add_argument('--tag', type=str, default=None,
+                        help='Output directory/filename tag; defaults to --version. '
+                             'Use for a custom/one-off template set (e.g., paper1) '
+                             'whose --version need not follow the production numbering.')
 
     # DL07 parameters
     # https://python-fsps.readthedocs.io/en/latest/stellarpop_api
@@ -807,4 +818,4 @@ if __name__ == '__main__':
     logmets = np.array(args.logmets.split(',')).astype(float)
     main(imf=args.imf, logmets=logmets, qpah=args.qpah,
          umin=args.umin, gamma=args.gamma, agntau=args.agntau, test=args.test,
-         version=args.version, templatedir=templatedir)
+         version=args.version, tag=args.tag, templatedir=templatedir)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,11 @@ Change Log
 3.6.1 (not released yet)
 ------------------------
 
+* More flexible ``build-templates`` script and improved header
+  metadata [`PR #277`_].
+
+.. _`PR #277`: https://github.com/desihub/fastspecfit/pull/277
+
 3.6.0 (2026-07-25)
 ------------------
 

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -112,14 +112,27 @@ class Templates(object):
         templateflux     = np.transpose(templateflux).copy()
         templatelineflux = np.transpose(templatelineflux).copy()
 
-        self.version = T[0].read_header()['VERSION']
+        primhdr = T[0].read_header()
+        if 'VERSION' in primhdr:
+            self.version = primhdr['VERSION']
+        else:
+            self.version = Templates.DEFAULT_TEMPLATEVERSION
+            log.warning(f'Templates file {template_file} is missing the VERSION header '
+                        f'keyword; assuming {self.version}.')
 
-        # Templates <3.0.0 were built on the C3K_a (R~3000) grid with a
-        # different segment/pixel-size convention; use the values that
-        # actually match how those files were resampled (bin/build-templates
-        # was technically wrong to resample to 25 km/s pixels for that R,
-        # but this matches what's actually baked into those files).
-        if int(self.version.split('.')[0]) < 3:
+        # Templates built with a SIGC3K keyword in the WAVE header record
+        # their own grid parameters directly, so no inference is needed.
+        # Older files lack this keyword; <3.0.0 of those were built on the
+        # C3K_a (R~3000) grid with a different segment/pixel-size convention,
+        # so fall back to the values that actually match how those files
+        # were resampled (bin/build-templates was technically wrong to
+        # resample to 25 km/s pixels for that R, but this matches what's
+        # actually baked into those files).
+        if 'SIGC3K' in wavehdr:
+            self.PIXKMS = wavehdr['PIXKMS']
+            self.PIXKMS_BOUNDS = (wavehdr['PIXWAVLO'], wavehdr['PIXWAVHI'])
+            self.SIGMA_C3K = wavehdr['SIGC3K']
+        elif int(self.version.split('.')[0]) < 3:
             self.PIXKMS = 25.  # [km/s]
             self.PIXKMS_BOUNDS = (2750., 9100.)
             self.SIGMA_C3K = Templates.C_LIGHT / (3000. * np.sqrt(8. * np.log(2.))) # 42.4 [km/s]

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -175,19 +175,25 @@ class Templates(object):
         if 'dt' not in self.info.colnames:
             log.warning('Template file lacks dt column; SFR will be averaged over ~30 Myr instead of 100 Myr.')
 
-        if 'DUSTFLUX' in T and 'AGNFLUX' in T:
-            from fastspecfit.util import trapz
+        if 'DUSTFLUX' not in T:
+            errmsg = f'Templates file {template_file} missing mandatory extension DUSTFLUX.'
+            log.critical(errmsg)
+            raise IOError(errmsg)
 
-            # make sure fluxes are normalized to unity
-            dustflux = T['DUSTFLUX'].read()
-            #dustflux /= trapz(dustflux, x=templatewave) # should already be 1.0
-            self.dustflux = dustflux[keeplo:keephi]
+        # make sure fluxes are normalized to unity
+        dustflux = T['DUSTFLUX'].read()
+        #dustflux /= trapz(dustflux, x=templatewave) # should already be 1.0
+        self.dustflux = dustflux[keeplo:keephi]
 
-            #dusthdr = T['DUSTFLUX'].read_header()
-            #self.qpah     = dusthdr['QPAH']
-            #self.umin     = dusthdr['UMIN']
-            #self.gamma    = dusthdr['GAMMA']
+        #dusthdr = T['DUSTFLUX'].read_header()
+        #self.qpah     = dusthdr['QPAH']
+        #self.umin     = dusthdr['UMIN']
+        #self.gamma    = dusthdr['GAMMA']
 
+        # AGNFLUX/AGNWAVE/FEFLUX/FEWAVE are only used by the
+        # still-in-development fastqso mode, and are absent from template
+        # files built with --no-agn.
+        if 'AGNFLUX' in T and 'FEFLUX' in T:
             # construct the AGN wavelength vector
             iragnflux = T['AGNFLUX'].read()
             iragnwave = T['AGNWAVE'].read()
@@ -210,10 +216,6 @@ class Templates(object):
 
             #agnhdr = T['AGNFLUX'].read_header()
             #self.agntau   = agnhdr['AGNTAU']
-        else:
-            errmsg = f'Templates file {template_file} missing mandatory extensions DUSTFLUX and AGNFLUX.'
-            log.critical(errmsg)
-            raise IOError(errmsg)
 
         # Read the model emission-line fluxes; only present for
         # template_version>=1.1.1 and generally only useful to a power-user.


### PR DESCRIPTION
This PR is mostly in support of the `desimetals` project, allowing for generating custom templates much more flexibly, including
* arbitrary age boundaries (`agelims`);
* optionally do not write out AGN templates (via `--no-agn`);
* new `--tag` option which allows `--version` to reset independently of the production version;

In addition, a small bug was also identified which affects the 3.0.0 (production) templates that recently shipped, so we will need 3.0.1 models when NERSC is back.

And a bug in the new `build-mini-specprod` script also comes along for the ride.