### PR TITLE
3k templates

### DIFF
--- a/bin/build-templates
+++ b/bin/build-templates
@@ -146,7 +146,7 @@ Notes
   parameters affect the resulting SED.
 
 """
-import os, time
+import os, time, hashlib
 import numpy as np
 import numpy.ma as ma
 import fitsio
@@ -865,6 +865,22 @@ def main(imf='chabrier', logmets=[0.0], agelims=None, qpah=1.0, umin=1., gamma=0
 
     print(f'Writing {len(models)} model spectra to {outfile}')
     hx.writeto(outfile, overwrite=True)
+
+    # Write a sha256sum checksum file alongside the FITS file, matching the
+    # naming convention of the other external template checksum files, e.g.
+    # external_templates_fastspecfit_2.1.0.sha256sum.
+    outbase = os.path.basename(outfile)
+    suffix = outbase[len(f'ftemplates-{imf}-'):-len('.fits')]
+    sha256file = os.path.join(outdir, f'external_templates_fastspecfit_{suffix}.sha256sum')
+
+    digest = hashlib.sha256()
+    with open(outfile, 'rb') as F:
+        for chunk in iter(lambda: F.read(1024 * 1024), b''):
+            digest.update(chunk)
+
+    with open(sha256file, 'w') as F:
+        F.write(f'{digest.hexdigest()}  {outbase}\n')
+    print(f'Wrote {sha256file}')
 
 
 if __name__ == '__main__':

--- a/bin/build-templates
+++ b/bin/build-templates
@@ -12,10 +12,10 @@ Usage
 -----
 ::
 
-  time python bin/build-templates --version 3.0.1 \\
+  time python bin/build-templates --version 2.2.0 \\
       --templatedir $DESI_ROOT/users/ioannis/fastspecfit/templates
 
-  time python bin/build-templates --version 3.0.1 \\
+  time python bin/build-templates --version 2.2.0 \\
       --templatedir $DESI_ROOT/users/ioannis/fastspecfit/templates \\
       --logmets=-1.,0.,0.3
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,14 @@ Change Log
 3.6.1 (not released yet)
 ------------------------
 
+* Abandoned ``3.0.x`` templates with ``R=10000`` in favor of ``2.2.0``
+  templates with ``R=3000`` [`PR #279`_].
 * New LCDM cosmology class and CLI; re-organized ``argparse`` help
   messages [`PR #278`_].
 * More flexible ``build-templates`` script and improved header
   metadata [`PR #277`_].
 
+.. _`PR #279`: https://github.com/desihub/fastspecfit/pull/279
 .. _`PR #278`: https://github.com/desihub/fastspecfit/pull/278
 .. _`PR #277`: https://github.com/desihub/fastspecfit/pull/277
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -156,8 +156,8 @@ Set these variables and download the required external files::
 
   wget -r -np -nH --cut-dirs 5 -A fits -P $DUST_DIR \
     https://portal.nersc.gov/project/cosmo/data/dust/v0_1/maps
-  wget -O $FTEMPLATES_DIR/ftemplates-chabrier-3.0.1.fits \
-    https://data.desi.lbl.gov/public/external/templates/fastspecfit/3.0.1/ftemplates-chabrier-3.0.1.fits
+  wget -O $FTEMPLATES_DIR/ftemplates-chabrier-2.2.0.fits \
+    https://data.desi.lbl.gov/public/external/templates/fastspecfit/2.2.0/ftemplates-chabrier-2.2.0.fits
 
 Building the Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/py/fastspecfit/linemasker.py
+++ b/py/fastspecfit/linemasker.py
@@ -318,7 +318,8 @@ class LineMasker(object):
                        initsigma_broad=None, initsigma_narrow=None,
                        initsigma_balmer_broad=None, initvshift_broad=None,
                        initvshift_narrow=None, initvshift_balmer_broad=None,
-                       niter=2, nsigma_mask=5., debug_plots=False):
+                       niter=2, nsigma_mask=5., debug_plots=False,
+                       return_patchfit=False):
         """Generate a mask which identifies pixels impacted by emission lines.
 
         Parameters
@@ -361,6 +362,14 @@ class LineMasker(object):
         debug_plots : :class:`bool`, optional
             If ``True``, write per-patch and per-line diagnostic PNG files.
             Default is ``False``.
+        return_patchfit : :class:`bool`, optional
+            If ``True``, include a ``patchfit`` entry in the returned
+            dictionary with the per-patch model arrays (``parameters``,
+            ``bestfit``, ``contfit``, ``patchMap``, ``linetable``,
+            ``noises``, ``linesnrs``, ``camerapix``) for the adopted
+            (broad or narrow-only) fit-in-patches solution, i.e., the same
+            arrays used to build the ``qa-patches-*.png`` debug figure.
+            Default is ``False``.
 
         Returns
         -------
@@ -368,7 +377,8 @@ class LineMasker(object):
             Dictionary with fitted line-width and velocity-shift scalars for
             broad, narrow, and broad-Balmer populations, a ``balmerbroad``
             boolean flag, and ``coadd_linepix`` mapping each line name to its
-            pixel indices in the coadded spectrum.
+            pixel indices in the coadded spectrum. If ``return_patchfit=True``,
+            also contains ``patchfit`` (see above).
 
         """
         from astropy.table import vstack
@@ -393,7 +403,8 @@ class LineMasker(object):
 
         def fit_patches(continuum_patches, patchMap, linemodel,
                         testBalmerBroad=False, minsnr=1.5, modelname='',
-                        suffix='nobroad', debug_plots=False):
+                        suffix='nobroad', debug_plots=False,
+                        return_patchfit=False):
             """Iteratively fit all the lines in patches."""
 
             linesigmas = np.zeros(nline)
@@ -692,7 +703,20 @@ class LineMasker(object):
                 plt.close()
                 log.info(f'Wrote {pngfile}')
 
-            return linefit, contfit, residuals, final_linesigmas, final_linevshifts, maxsnrs
+            patchfit = None
+            if return_patchfit:
+                patchfit = {
+                    'parameters': parameters,
+                    'bestfit': bestfit,
+                    'contfit': contfit,
+                    'patchMap': patchMap,
+                    'linetable': linetable,
+                    'noises': noises,
+                    'linesnrs': linesnrs,
+                    'camerapix': camerapix,
+                }
+
+            return linefit, contfit, residuals, final_linesigmas, final_linevshifts, maxsnrs, patchfit
 
 
         # main function begins here
@@ -749,21 +773,23 @@ class LineMasker(object):
 
         # Need to pass copies of continuum_patches and patchMap because they can
         # get modified dynamically by fit_patches.
-        linefit_nobroad, contfit_nobroad, residuals_nobroad, linesigmas_nobroad, linevshifts_nobroad, maxsnrs_nobroad = \
+        linefit_nobroad, contfit_nobroad, residuals_nobroad, linesigmas_nobroad, linevshifts_nobroad, maxsnrs_nobroad, patchfit_nobroad = \
             fit_patches(continuum_patches.copy(), patchMap.copy(),
                         linemodel_nobroad, testBalmerBroad=False,
                         debug_plots=debug_plots, suffix='nobroad',
-                        modelname='narrow lines only')
+                        modelname='narrow lines only',
+                        return_patchfit=return_patchfit)
 
         # Only fit with broad Balmer lines if at least one patch contains a
         # broad line.
         B = contfit_nobroad['balmerbroad']
         if np.any(B):
-            linefit_broad, contfit_broad, residuals_broad, linesigmas_broad, linevshifts_broad, maxsnrs_broad = \
+            linefit_broad, contfit_broad, residuals_broad, linesigmas_broad, linevshifts_broad, maxsnrs_broad, patchfit_broad = \
                 fit_patches(continuum_patches.copy(), patchMap.copy(),
                             linemodel_broad, testBalmerBroad=True,
                             debug_plots=debug_plots, suffix='broad',
-                            modelname='narrow+broad lines')
+                            modelname='narrow+broad lines',
+                            return_patchfit=return_patchfit)
 
             # if a broad Balmer line is well-detected, take its linewidth
             if maxsnrs_broad[2] > minsnr_balmer_broad:
@@ -773,6 +799,7 @@ class LineMasker(object):
                 finalsigma_broad, finalsigma_narrow, finalsigma_balmer_broad = linesigmas_broad
                 finalvshift_broad, finalvshift_narrow, finalvshift_balmer_broad = linevshifts_broad
                 maxsnr_broad, maxsnr_narrow, maxsnr_balmer_broad = maxsnrs_broad
+                patchfit = patchfit_broad
             else:
                 log.debug(f'Adopting narrow Balmer-line masking: S/N(broad Balmer) ' + \
                           f'{maxsnrs_broad[2]:.1f} < {minsnr_balmer_broad:.1f}')
@@ -780,12 +807,14 @@ class LineMasker(object):
                 finalsigma_broad, finalsigma_narrow, finalsigma_balmer_broad = linesigmas_nobroad
                 finalvshift_broad, finalvshift_narrow, finalvshift_balmer_broad = linevshifts_nobroad
                 maxsnr_broad, maxsnr_narrow, maxsnr_balmer_broad = maxsnrs_nobroad
+                patchfit = patchfit_nobroad
         else:
             log.debug(f'Adopting narrow Balmer-line masking: no Balmer lines in wavelength range.')
             residuals = residuals_nobroad
             finalsigma_broad, finalsigma_narrow, finalsigma_balmer_broad = linesigmas_nobroad
             finalvshift_broad, finalvshift_narrow, finalvshift_balmer_broad = linevshifts_nobroad
             maxsnr_broad, maxsnr_narrow, maxsnr_balmer_broad = maxsnrs_nobroad
+            patchfit = patchfit_nobroad
 
         log.debug(f'Masking line-widths: broad {finalsigma_broad:.0f} km/s; narrow {finalsigma_narrow:.0f} km/s; ' + \
                   f'broad Balmer {finalsigma_balmer_broad:.0f} km/s.')
@@ -948,5 +977,8 @@ class LineMasker(object):
             'balmerbroad': np.any(contfit_nobroad['balmerbroad']), # True = one or more broad Balmer line in range
             'coadd_linepix': linepix,
         }
+
+        if return_patchfit:
+            out['patchfit'] = patchfit
 
         return out

--- a/py/fastspecfit/templates.py
+++ b/py/fastspecfit/templates.py
@@ -66,16 +66,16 @@ class Templates(object):
 
     # SPS template constants (used by build-templates)
     # https://github.com/moustakas/fsps/tree/master/SPECTRA/C3K_R10K#readme
-    R_C3K = 10000.  # [lambda/FWHM]; C3K_R10K resolution in the rest-frame optical
+    R_C3K = 3000.  # [lambda/FWHM]; C3K_R10K resolution in the rest-frame optical
     PIXKMS = C_LIGHT / (R_C3K * 2.)  # [km/s]; native pixel spacing (oversample=2)
     PIXKMS_BOUNDS = (3500., 9800.)
     # Gaussian sigma of C3K templates: σ = c/(R·2√(2 ln 2))
-    SIGMA_C3K = C_LIGHT / (R_C3K * np.sqrt(8. * np.log(2.))) # 12.7 [km/s]
+    SIGMA_C3K = C_LIGHT / (R_C3K * np.sqrt(8. * np.log(2.))) # 42.3 [km/s]
 
     AGN_PIXKMS = 75.  # [km/s]
     AGN_PIXKMS_BOUNDS = (1075., 3090.)
 
-    DEFAULT_TEMPLATEVERSION = '3.0.1'
+    DEFAULT_TEMPLATEVERSION = '2.2.0'
     DEFAULT_IMF = 'chabrier'
 
     # highest vdisp for which we attempt to use cached FFTs


### PR DESCRIPTION
The `3.0.x` templates with R=10000 did not work out in terms of resolving the velocity dispersion systematic found comparing against the FP/DR1 results, while also slowing down the Loa/sv3/{dark,bright} runs by 30%-70%.

This PR reverts the templates to `2.x.x` (`2.2.0` is the new default) with better control of the wavelength range over which the resolution is R=3000 (specifically, 3500-9800 A). New pixel size is c/(2*R)=50 km/s (critically sampled) with only 11566 pixels in each SED (vs 18318 in the `2.1.0` templates), so we should see a measurable *speed-up*.